### PR TITLE
Change shebang to use python3

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
The command `/usr/bin/env python` uses the Python 2 interpreter (at least on my machine).

By changing the shebang to explicitly use the Python3 interpreter, the problem should not happen anymore.