### PR TITLE
Fix manually specifying scenedetect threshold

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -105,7 +105,7 @@ class Av1an:
         parser.add_argument('--encoder', '-enc', type=str, default=self.encoder, help='Choosing encoder')
         parser.add_argument('--workers', '-t', type=int, default=0, help='Number of workers')
         parser.add_argument('--audio_params', '-a', type=str, default=self.audio, help='FFmpeg audio settings')
-        parser.add_argument('--threshold', '-tr', type=str, default=self.threshold, help='PySceneDetect Threshold')
+        parser.add_argument('--threshold', '-tr', type=float, default=self.threshold, help='PySceneDetect Threshold')
         parser.add_argument('--logging', '-log', type=str, default=self.logging, help='Enable logging')
         parser.add_argument('--encode_pass', '-p', type=int, default=self.encode_pass, help='Specify encoding passes')
         parser.add_argument('--output_file', '-o', type=str, default='', help='Specify output file')


### PR DESCRIPTION
The threshold being passed to scenedetect needs be a float, but is set as a string in the option parser. This leads the scene detection failing with `Error in PySceneDetect` when setting `-tr 40`. This PR sets the type of the threshold option to be a float.