### PR TITLE
Fix get_vmaf ffmpeg model not being used

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -181,7 +181,7 @@ class Av1an:
             self.call_cmd(cmd)
 
     def get_vmaf(self, source: Path, encoded: Path):
-        if not self.d.get("vmaf_path"):
+        if self.d.get("vmaf_path"):
             model = f'=model_path={self.d.get("vmaf_path")}'
         else:
             model = ''


### PR DESCRIPTION
Due to the not it looks like the vmaf_path path was never actually being used correctly. If it was not provided it would set the path for the model to None but if it was provided the model was never being populated.

- Original
  - ```bash av1an.py -i short.mkv --vmaf --vmaf_path /usr/local/share/model/vmaf_v0.6.1.pkl ```
    - ```bash ffmpeg -y -hide_banner -loglevel error -i .temp/split/0021.mkv -i .temp/encode/0021.ivf  -filter_complex "[0:v][1:v]libvmaf" -max_muxing_queue_size 1024 -f null - ```
  - ```bash av1an.py -i short.mkv --vmaf ```
    - ```bash ffmpeg -y -hide_banner -loglevel error -i .temp/split/0021.mkv -i .temp/encode/0021.ivf  -filter_complex "[0:v][1:v]libvmaf=model_path=None" -max_muxing_queue_size 1024 -f null - ```
- New
  - ```bash av1an.py -i short.mkv --vmaf --vmaf_path /usr/local/share/model/vmaf_v0.6.1.pkl ```
    - ```bash ffmpeg -y -hide_banner -loglevel error -i .temp/split/0021.mkv -i .temp/encode/0021.ivf  -filter_complex "[0:v][1:v]libvmaf=model_path=/usr/local/share/model/vmaf_v0.6.1.pkl" -max_muxing_queue_size 1024 -f null -  ```
  - ```bash av1an.py -i short.mkv --vmaf ```
    - ```bash ffmpeg -y -hide_banner -loglevel error -i .temp/split/0021.mkv -i .temp/encode/0021.ivf  -filter_complex "[0:v][1:v]libvmaf" -max_muxing_queue_size 1024 -f null - ```

