### PR TITLE
Preserve ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With your own parameters:
     -i   --file_path         Input file (relative or absolute path)
 
     -o   --output_file       Name/Path for output file (Default: (input file name)_av1.mkv)
-                            Output file ending is always `.mkv`
+                            Output file ending is always `.mkv` unless otherwise specified
 
     -enc --encoder          Encoder to use (aom or rav1e or svt_av1. Default: aom)
                             Example: -enc rav1e

--- a/av1an.py
+++ b/av1an.py
@@ -120,10 +120,10 @@ class Av1an:
 
         # Set output file
         if self.d.get('mode') != 2:
-            if self.d.get('output_file'):
-                self.d['output_file'] = self.d.get('output_file').with_suffix('.mkv')
-            else:
+            if not self.d.get('output_file'):
                 self.d['output_file'] = Path(f'{self.d.get("input_file").stem}_av1.mkv')
+            elif not self.d.get('output_file').suffix:
+                self.d['output_file'] = self.d.get('output_file').with_suffix('.mkv')
 
         # Changing pixel format, bit format
         self.d['pix_format'] = f' -strict -1 -pix_fmt {self.d.get("pix_format")}'


### PR DESCRIPTION
Allows the user to specify the output file extension. Default behavior is the same if there is no extension or no output file specified.