### PR TITLE
AppVeyor: Deploy on tag/release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,24 @@
-version: 1.0.{build}
 image: Visual Studio 2019
 environment:
   PYTHON: C:\Python38-x64
+
 install:
 - cmd: '"%PYTHON%\python.exe" -m pip install numpy opencv-python tqdm scenedetect[opencv,progress_bar] psutil pypiwin32 '
 - cmd: '"%PYTHON%\python.exe" -m pip install pyinstaller scipy matplotlib'
+
 build_script:
 - cmd: '"%PYTHON%\Scripts\pyinstaller" --onefile av1an.py'
+
 test: off
+
 artifacts:
 - path: dist/av1an.exe
+
+deploy:
+  - provider: GitHub
+    artifact: dist/av1an.exe
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true


### PR DESCRIPTION
This PR modifies the AppVeyor configuration to attach the `av1an.exe` binary to the GitHub release page on a tag or release. You can see [this test release](https://github.com/EwoutH/Av1an/releases/tag/1.11-test0) as an example.

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 21 (after `secure:`) in the `appveyor.yml` file. 

<img width="640" alt="Screenshot_143" src="https://user-images.githubusercontent.com/15776622/82387876-729d9f00-9a38-11ea-95f8-de684b6b7983.png">