### PR TITLE
Smooth ETA and FPS calculation

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -51,9 +51,13 @@ def Manager():
 
 class Counter(object):
     def __init__(self, total, initial):
-        self.bar = tqdm(total=total, initial=initial, dynamic_ncols=True, unit="fr", leave=True)
+        self.first_update = True
+        self.bar = tqdm(total=total, initial=initial, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.01)
 
     def update(self, value):
+        if self.first_update:
+            self.bar.reset()
+            self.first_update = False
         self.bar.update(value)
 
 


### PR DESCRIPTION
Smooths the time remaining and fps calculation in the progress bar. Fixes #68.

Since the average is smoothed so much, we need to reset the progress bar on the first update, otherwise it takes about 1000 frames for the fps to reach its correct value after no updates during the first pass. 