### PR TITLE
Log encoding command

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -896,6 +896,7 @@ class Av1an:
                 try:
                     frame = 0
 
+                    self.log(f'Encode command: {" ".join(f)} | {" ".join(e)}\n')
                     ffmpeg_pipe = subprocess.Popen(f, stdout=PIPE, stderr=STDOUT)
                     pipe = subprocess.Popen(e, stdin=ffmpeg_pipe.stdout, stdout=PIPE,
                                             stderr=STDOUT,


### PR DESCRIPTION
This puts the encoding command in the log. When the encode fails it is hard to know what went wrong since the exact command is not know. This allows the broken command to be run manually to get the error. This functionality was requested in #73.