### PR TITLE
Fix module 'concurrent' has no attribute 'futures'

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -26,6 +26,7 @@ from scenedetect.scene_manager import SceneManager
 from scenedetect.detectors import ContentDetector
 from multiprocessing.managers import BaseManager
 import concurrent
+import concurrent.futures
 
 # Todo: Separation, Clip encoder objects, Threading instead of multiprocessing.
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "av1an.py", line 1151, in <module>
    main()
  File "av1an.py", line 1144, in main
    Av1an().main_thread()
  File "av1an.py", line 1138, in main_thread
    self.main_queue()
  File "av1an.py", line 1124, in main_queue
    self.video_encoding()
  File "av1an.py", line 1106, in video_encoding
    self.encoding_loop(commands)
  File "av1an.py", line 1018, in encoding_loop
    with concurrent.futures.ThreadPoolExecutor(max_workers=self.d.get('workers')) as executor:
AttributeError: module 'concurrent' has no attribute 'futures'
```