### PR TITLE
FIx for video split using aom_keyframes

### DIFF
--- a/utils/aom_keyframes.py
+++ b/utils/aom_keyframes.py
@@ -132,7 +132,6 @@ def aom_keyframes(videoPath: Path, stat_file ):
         video = cv2.VideoCapture(videoPath.as_posix())
         width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
         height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
-
         
         # Getting Frame Count from Metadata
         total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))

--- a/utils/aom_keyframes.py
+++ b/utils/aom_keyframes.py
@@ -124,18 +124,23 @@ def find_aom_keyframes(stat_file):
     return keyframes_list
 
 
-def aom_keyframes(video: Path, stat_file ):
+def aom_keyframes(videoPath: Path, stat_file ):
         """[Get frame numbers for splits from aomenc 1 pass stat file]
         """
 
-        f, e = f'ffmpeg -y -hide_banner -loglevel error -i {video.as_posix()}   -strict -1 -pix_fmt yuv420p -f yuv4mpegpipe - | aomenc --passes=2 --pass=1 --threads=12 --cpu-used=0 --end-usage=q --cq-level=40 --fpf={stat_file.as_posix()} -o {os.devnull} -'.split('|')
-        f, e = f.split(), e.split()
+        # Getting video width and height in pixels
+        video = cv2.VideoCapture(videoPath.as_posix())
+        width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
+        
         # Getting Frame Count from Metadata
-        video = cv2.VideoCapture(video.as_posix())
         total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
         video.release()
 
+        f, e = f'ffmpeg -y -hide_banner -loglevel error -i {videoPath.as_posix()}   -strict -1 -pix_fmt yuv420p -f yuv4mpegpipe - | aomenc --passes=2 --pass=1 --threads=12 --cpu-used=0 --end-usage=q --cq-level=40 -w {width} -h {height} --fpf={stat_file.as_posix()} -o {os.devnull} -'.split('|')
+        f, e = f.split(), e.split()
+        
         tqdm_bar = tqdm(total=total, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.2)
 
         ffmpeg_pipe = subprocess.Popen(f, stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
Added -w and -h params to the command used to call the aomenc encoder when using aom_keyframes as splitting method. Not using those params cause an error in aomenc with some files.