### PR TITLE
Added support for ' in the input's filename

### DIFF
--- a/utils/ffmpeg.py
+++ b/utils/ffmpeg.py
@@ -34,7 +34,8 @@ def concatenate_video(temp, output, keep=False):
     with open(f'{temp / "concat" }', 'w') as f:
 
         encode_files = sorted((temp / 'encode').iterdir())
-        f.writelines(f"file '{file.absolute()}'\n" for file in encode_files)
+        # Replace all the ' with '/'' so ffmpeg can read the path correctly
+        f.writelines("file '" + str(file.absolute()).replace('\'','\'\\\'\'') + "'\n" for file in encode_files)
 
     # Add the audio file if one was extracted from the input
     audio_file = temp / "audio.mkv"


### PR DESCRIPTION
In the concat file, the files were listed as 

> file 'path'

so if in the path there was a ' the result were 

> file 'path1'path2'

and ffmpge would read only path1 and throw an error because it didn't find the file.
With this commits now all the ' in the path are replaced with '/'' so ffmpeg can read the path correctly.