### PR TITLE
Add option for minimum number of frames in a chunk

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -380,9 +380,10 @@ class Av1an:
         if split_method == 'pyscene':
             queue_fix = not self.d.get('queue')
             threshold = self.d.get("threshold")
-            self.log(f'Starting scene detection Threshold: {threshold}\n')
+            min_scene_len = self.d.get('min_scene_len')
+            self.log(f'Starting scene detection Threshold: {threshold}, Min_scene_length: {min_scene_len}\n')
             try:
-                sc = pyscene(video, threshold, progress_show=queue_fix )
+                sc = pyscene(video, threshold, queue_fix, min_scene_len)
             except Exception as e:
                 self.log(f'Error in PySceneDetect: {e}\n')
                 print(f'Error in PySceneDetect{e}\n')

--- a/av1an.py
+++ b/av1an.py
@@ -394,7 +394,8 @@ class Av1an:
             try:
                 video: Path = self.d.get("input")
                 stat_file = self.d.get('temp') / 'keyframes.log'
-                sc = aom_keyframes(video, stat_file)
+                min_scene_len = self.d.get('min_scene_len')
+                sc = aom_keyframes(video, stat_file, min_scene_len)
             except:
                 self.log('Error in aom_keyframes')
                 print('Error in aom_keyframes')

--- a/utils/arg_parse.py
+++ b/utils/arg_parse.py
@@ -14,6 +14,7 @@ def arg_parsing():
         # Splitting
         parser.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method')
         parser.add_argument('--extra_split', '-xs', type=int, default=0, help='Number of frames after which make split')
+        parser.add_argument('--min_scene_len', type=int, default=None, help='Minimum number of frames in a split')
 
 
         # PySceneDetect split

--- a/utils/pyscenedetect.py
+++ b/utils/pyscenedetect.py
@@ -4,15 +4,17 @@ from scenedetect.video_manager import VideoManager
 from scenedetect.scene_manager import SceneManager
 from scenedetect.detectors import ContentDetector
 
-def pyscene(video, threshold, progress_show):
+def pyscene(video, threshold, progress_show, min_scene_len):
     """
     Running PySceneDetect detection on source video for segmenting.
     Optimal threshold settings 15-50
     """
-
+    
+    min_scene_len = 15 if (min_scene_len is None) else min_scene_len  # pyscenedetect ContentDetector's default is 15
+    
     video_manager = VideoManager([str(video)])
     scene_manager = SceneManager()
-    scene_manager.add_detector(ContentDetector(threshold=threshold))
+    scene_manager.add_detector(ContentDetector(threshold=threshold, min_scene_len=min_scene_len))
     base_timecode = video_manager.get_base_timecode()
 
     # Work on whole video


### PR DESCRIPTION
This PR works towards making splits less frequent than the encoder's key frame placement.

This PR adds the option `--min_scene_len` to specify the minimum number of frames in a chunk. This applies to scenedetect and aom_keyframe split methods. When this option is not set, the split behavior is unchanged.

Libaom's key frame placement was recently changed to include a lower bound on the distance between key frames (used by specifying`--kf-min-dist`) ([libaom commit](https://aomedia.googlesource.com/aom/+/ce97de2724d7ffdfdbe986a14d49366936187298)). This changes the way aom decides key frame placements. This PR updates the aom key frame split method to match the new aom code that accounts for this minimum distance.