### PR TITLE
Use argparse for split method choice validation

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -342,9 +342,6 @@ class Av1an:
                 self.log('Error in aom_keyframes')
                 print('Error in aom_keyframes')
                 terminate()
-        else:
-            print(f'No valid split option: {split_method}\nValid options: "pyscene", "aom_keyframes"')
-            terminate()
 
         self.log(f'Found scenes: {len(sc)}\n')
 

--- a/utils/arg_parse.py
+++ b/utils/arg_parse.py
@@ -12,10 +12,9 @@ def arg_parsing():
         parser.add_argument('--output_file', '-o', type=Path, default=None, help='Specify output file')
 
         # Splitting
-        parser.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method')
+        parser.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method', choices=['pyscene', 'aom_keyframes'])
         parser.add_argument('--extra_split', '-xs', type=int, default=0, help='Number of frames after which make split')
         parser.add_argument('--min_scene_len', type=int, default=None, help='Minimum number of frames in a split')
-
 
         # PySceneDetect split
         parser.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')


### PR DESCRIPTION
This PR uses the choices option in argparse for validating if the split method is correct. This allows for argparse to print an error so 3 lines in av1an.py checking for an invalid choice can be removed.

The new error message.
```
av1an.py: error: argument --split_method: invalid choice: '1324' (choose from 'pyscene', 'aom_keyframes')
```

It also prints out the choices in `--help`.
```
  --split_method {pyscene,aom_keyframes}
                        Specify splitting method
```

