### PR TITLE
Make aom keyframe split 1st pass match chunk 1st pass

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -49,6 +49,9 @@ class Av1an:
                 print(f'No such model: {Path(self.vmaf_path).as_posix()}')
                 terminate()
 
+        if self.video_params is None:
+            self.video_params = get_default_params_for_encoder(self.encoder)
+
     def target_vmaf(self, source):
         # TODO speed up for vmaf stuff
         # TODO reduce complexity
@@ -228,7 +231,7 @@ class Av1an:
         chunk = get_video_queue(self.temp,  self.resume)
 
         # Make encode queue
-        commands, self.video_params = compose_encoding_queue(chunk, self.temp, self.encoder, self.video_params, self.ffmpeg_pipe, self.passes)
+        commands = compose_encoding_queue(chunk, self.temp, self.encoder, self.video_params, self.ffmpeg_pipe, self.passes)
         log(f'Encoding Queue Composed\n'
             f'Encoder: {self.encoder.upper()} Queue Size: {len(commands)} Passes: {self.passes}\n'
             f'Params: {self.video_params}\n\n')

--- a/av1an.py
+++ b/av1an.py
@@ -220,7 +220,9 @@ class Av1an:
             setup(self.temp, self.resume)
             set_logging(self.logging, self.temp)
 
-            framenums = split_routine(self.input, self.scenes, self.split_method, self.temp, self.min_scene_len, self.queue, self.threshold)
+            # inherit video params from aom encode unless we are using a different encoder, then use defaults
+            aom_keyframes_params = self.video_params if (self.encoder == 'aom') else AOM_KEYFRAMES_DEFAULT_PARAMS
+            framenums = split_routine(self.input, self.scenes, self.split_method, self.temp, self.min_scene_len, self.queue, self.threshold, self.ffmpeg_pipe, aom_keyframes_params)
 
             if self.extra_split:
                 framenums = extra_splits(input, framenums, self.extra_split)

--- a/utils/aom_keyframes.py
+++ b/utils/aom_keyframes.py
@@ -7,6 +7,8 @@ from tqdm import tqdm
 import re
 from pathlib import Path
 import cv2
+
+from .compose import compose_aomsplit_first_pass_command
 from .logger import log, set_log_file
 
 # This is a script that returns a list of keyframes that aom would likely place. Port of aom's C code.
@@ -17,6 +19,11 @@ from .logger import log, set_log_file
 
 # All of my contributions to this script are hereby public domain.
 # I retain no rights or control over distribution.
+
+
+# default params for 1st pass when aom isn't the final encoder and -v won't match aom's options
+AOM_KEYFRAMES_DEFAULT_PARAMS = '--threads=12 --cpu-used=0 --end-usage=q --cq-level=40'
+
 
 # Fields meanings: <source root>/av1/encoder/firstpass.h
 fields = ['frame', 'weight', 'intra_error', 'frame_avg_wavelet_energy', 'coded_error', 'sr_coded_error', 'tr_coded_error',
@@ -130,44 +137,39 @@ def find_aom_keyframes(stat_file, key_freq_min):
     return keyframes_list
 
 
-def aom_keyframes(video_path: Path, stat_file, min_scene_len):
-        """[Get frame numbers for splits from aomenc 1 pass stat file]
-        """
+def aom_keyframes(video_path: Path, stat_file, min_scene_len, ffmpeg_pipe, video_params):
+    """[Get frame numbers for splits from aomenc 1 pass stat file]
+    """
 
-        # Getting video width and height in pixels
-        video = cv2.VideoCapture(video_path.as_posix())
-        width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
-        height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    video = cv2.VideoCapture(video_path.as_posix())  # TODO(n9Mtq4): use a frame probe for this?
+    total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
+    video.release()
 
-        # Getting Frame Count from Metadata
-        total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
-        video.release()
+    f, e = compose_aomsplit_first_pass_command(video_path, stat_file, ffmpeg_pipe, video_params)
+    f, e = f.split(), e.split()
 
-        f, e = f'ffmpeg -y -hide_banner -loglevel error -i {video_path.as_posix()} -strict -1 -pix_fmt yuv420p -f yuv4mpegpipe - | aomenc --passes=2 --pass=1 --threads=12 --cpu-used=0 --end-usage=q --cq-level=40 -w {width} -h {height} --fpf={stat_file.as_posix()} -o {os.devnull} -'.split('|')
-        f, e = f.split(), e.split()
+    tqdm_bar = tqdm(total=total, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.2)
 
-        tqdm_bar = tqdm(total=total, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.2)
+    ffmpeg_pipe = subprocess.Popen(f, stdout=PIPE, stderr=STDOUT)
+    pipe = subprocess.Popen(e, stdin=ffmpeg_pipe.stdout, stdout=PIPE,
+                            stderr=STDOUT, universal_newlines=True)
+    frame = 0
+    while True:
+        line = pipe.stdout.readline().strip()
+        if len(line) == 0 and pipe.poll() is not None:
+            break
+        match = re.search(r"frame.*?\/([^ ]+?) ", line)
+        if match:
+            new = int(match.group(1))
+            if new > frame:
+                tqdm_bar.update(new - frame)
+            frame = new
 
-        ffmpeg_pipe = subprocess.Popen(f, stdout=PIPE, stderr=STDOUT)
-        pipe = subprocess.Popen(e, stdin=ffmpeg_pipe.stdout, stdout=PIPE,
-                                stderr=STDOUT, universal_newlines=True)
-        frame = 0
-        while True:
-            line = pipe.stdout.readline().strip()
-            if len(line) == 0 and pipe.poll() is not None:
-                break
-            match = re.search(r"frame.*?\/([^ ]+?) ", line)
-            if match:
-                new = int(match.group(1))
-                if new > frame:
-                    tqdm_bar.update(new - frame)
-                frame = new
+    # aom kf-min-dist defaults to 0, but hardcoded to 3 in pass2_strategy.c test_candidate_kf. 0 matches default aom behavior
+    # https://aomedia.googlesource.com/aom/+/8ac928be918de0d502b7b492708d57ad4d817676/av1/av1_cx_iface.c#2816
+    # https://aomedia.googlesource.com/aom/+/ce97de2724d7ffdfdbe986a14d49366936187298/av1/encoder/pass2_strategy.c#1907
+    min_scene_len = 0 if min_scene_len is None else min_scene_len
 
-        # aom kf-min-dist defaults to 0, but hardcoded to 3 in pass2_strategy.c test_candidate_kf. 0 matches default aom behavior
-        # https://aomedia.googlesource.com/aom/+/8ac928be918de0d502b7b492708d57ad4d817676/av1/av1_cx_iface.c#2816
-        # https://aomedia.googlesource.com/aom/+/ce97de2724d7ffdfdbe986a14d49366936187298/av1/encoder/pass2_strategy.c#1907
-        min_scene_len = 0 if min_scene_len is None else min_scene_len
+    keyframes = find_aom_keyframes(stat_file, min_scene_len)
 
-        keyframes = find_aom_keyframes(stat_file, min_scene_len)
-
-        return keyframes
+    return keyframes

--- a/utils/arg_parse.py
+++ b/utils/arg_parse.py
@@ -24,7 +24,7 @@ def arg_parsing():
 
     # Encoding
     parser.add_argument('--passes', '-p', type=int, default=2, help='Specify encoding passes')
-    parser.add_argument('--video_params', '-v', type=str, default='', help='encoding settings')
+    parser.add_argument('--video_params', '-v', type=str, default=None, help='encoding settings')
     parser.add_argument('--encoder', '-enc', type=str, default='aom', help='Choosing encoder',
                         choices=['aom', 'svt_av1', 'rav1e', 'vpx'])
     parser.add_argument('--workers', '-w', type=int, default=0, help='Number of workers')

--- a/utils/compose.py
+++ b/utils/compose.py
@@ -16,6 +16,27 @@ DEFAULT_ENC_PARAMS = {
 }
 
 
+def compose_aomsplit_first_pass_command(video_path: Path, stat_file, ffmpeg_pipe, video_params):
+    """
+    Generates the command for the first pass of the entire video used for aom keyframe split
+    
+    :param video_path: the video path
+    :param stat_file: the stat_file output
+    :param ffmpeg_pipe: the av1an.ffmpeg_pipe with pix_fmt and -ff option
+    :param video_params: the video params for aomenc first pass
+    :return: ffmpeg, encode
+    """
+
+    ffmpeg_pipe = ffmpeg_pipe[:-2]  # remove the ' |' at the end
+
+    f = f'ffmpeg -y -hide_banner -loglevel error -i {video_path.as_posix()} {ffmpeg_pipe}'
+    # removed -w -h from aomenc since ffmpeg filters can change it and it can be added into video_params
+    # TODO(n9Mtq4): if an encoder other than aom is being used, video_params becomes the default so -w -h may be needed again
+    e = f'aomenc --passes=2 --pass=1 {video_params} --fpf={stat_file.as_posix()} -o {os.devnull} -'
+
+    return f, e
+
+
 def get_default_params_for_encoder(enc):
     """
     Gets the default params for an encoder or terminates the program if the encoder is svt_av1 as

--- a/utils/split.py
+++ b/utils/split.py
@@ -11,7 +11,7 @@ from .pyscenedetect import pyscene
 from .aom_keyframes import aom_keyframes
 
 
-def segment(video:Path, temp, frames):
+def segment(video: Path, temp, frames):
     """Split video by frame numbers, or just copying video."""
 
     log('Split Video\n')
@@ -81,7 +81,7 @@ def extra_splits(video, frames: list, split_distance):
     return result
 
 
-def split_routine(video, scenes, split_method, temp, min_scene_len, queue, threshold):
+def split_routine(video, scenes, split_method, temp, min_scene_len, queue, threshold, ffmpeg_pipe, video_params):
 
     if scenes == '0':
         log('Skipping scene detection\n')
@@ -112,7 +112,7 @@ def split_routine(video, scenes, split_method, temp, min_scene_len, queue, thres
     elif split_method == 'aom_keyframes':
         try:
             stat_file = temp / 'keyframes.log'
-            sc = aom_keyframes(video, stat_file, min_scene_len)
+            sc = aom_keyframes(video, stat_file, min_scene_len, ffmpeg_pipe, video_params)
         except:
             log('Error in aom_keyframes')
             print('Error in aom_keyframes')


### PR DESCRIPTION
This PR makes the aom keyframe split method use similar params to the first pass run on chunks. This will allow for reusing the first pass stat file on the chunks in a later PR.

- [x] Process video params before the splitting
- [x] Generate aom first pass params for other encoders
- [x] Use video params and ffmpeg filters for aom keyframe split first pass