### PR TITLE
Report encoder errors

### DIFF
--- a/utils/dynamic_progress_bar.py
+++ b/utils/dynamic_progress_bar.py
@@ -38,6 +38,9 @@ MyManager.register('Counter', Counter)
 
 def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
     try:
+
+        encoder_history = ''
+
         f, e = i.split('|')
         f = " ffmpeg -y -hide_banner -loglevel error " + f
         f, e = f.split(), e.split()
@@ -48,7 +51,9 @@ def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
                                 universal_newlines=True)
 
         while True:
-            line = pipe.stdout.readline().strip()
+            line = pipe.stdout.readline()
+            encoder_history += line
+            line = line.strip()
             if len(line) == 0 and pipe.poll() is not None:
                 break
 
@@ -77,6 +82,11 @@ def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
 
             if encoder == 'svt_av1':
                 counter.update(frame_probe_source // passes)
+
+        if pipe.returncode != 0 and pipe.returncode != -2:  # -2 is Ctrl+C for aom
+            print(f"Encoder encountered an error: {pipe.returncode}")
+            print(encoder_history)
+
     except Exception as e:
         _, _, exc_tb = sys.exc_info()
         print(f'Error at encode {e}\nAt line {exc_tb.tb_lineno}')

--- a/utils/dynamic_progress_bar.py
+++ b/utils/dynamic_progress_bar.py
@@ -51,9 +51,9 @@ def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
                                 universal_newlines=True)
 
         while True:
-            line = pipe.stdout.readline()
-            encoder_history += line
-            line = line.strip()
+            line = pipe.stdout.readline().strip()
+            if line:
+                encoder_history += line + '\n'
             if len(line) == 0 and pipe.poll() is not None:
                 break
 

--- a/utils/dynamic_progress_bar.py
+++ b/utils/dynamic_progress_bar.py
@@ -2,6 +2,7 @@ import sys
 import subprocess
 from subprocess import PIPE, STDOUT
 import re
+from collections import deque
 from multiprocessing.managers import BaseManager
 from tqdm import tqdm
 from utils.utils import terminate
@@ -39,7 +40,7 @@ MyManager.register('Counter', Counter)
 def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
     try:
 
-        encoder_history = ''
+        encoder_history = deque(maxlen=20)
 
         f, e = i.split('|')
         f = " ffmpeg -y -hide_banner -loglevel error " + f
@@ -53,7 +54,7 @@ def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
         while True:
             line = pipe.stdout.readline().strip()
             if line:
-                encoder_history += line + '\n'
+                encoder_history.append(line)
             if len(line) == 0 and pipe.poll() is not None:
                 break
 
@@ -84,8 +85,8 @@ def tqdm_bar(i, encoder, counter, frame_probe_source, passes):
                 counter.update(frame_probe_source // passes)
 
         if pipe.returncode != 0 and pipe.returncode != -2:  # -2 is Ctrl+C for aom
-            print(f"Encoder encountered an error: {pipe.returncode}")
-            print(encoder_history)
+            print(f"\nEncoder encountered an error: {pipe.returncode}")
+            print('\n'.join(encoder_history))
 
     except Exception as e:
         _, _, exc_tb = sys.exc_info()


### PR DESCRIPTION
This PR prints out encoder errors if the encoder crashes. This helps troubleshoot invalid encoder options.

Consider this invalid command
```
python ./av1an.py -i source.mkv -enc aom -v ' --invalid option '
```

Before, the error message is unhelpful
```
Queue: 2 Workers: 2 Passes: 2
Params: --invalid option
  0%|                                                                                                                               | 0/5111 [00:00<?, ?fr/s]
Encoding failed, check validity of your encoding settings/commands and start again
fish: “python ./av1an.py -i source.mkv…” terminated by signal SIGKILL (Forced quit)
```

Now it detects the encoder error and prints out the encoder's error message
```
Queue: 2 Workers: 2 Passes: 2                                                                                             | 413/5111 [00:11<01:30, 51.77fr/s]
Params: --invalid option

Encoder encountered an error: 1                                                                                                     | 0/5111 [00:00<?, ?fr/s]
Error: Unrecognized option --invalid
Usage: aomenc <options> -o dst_filename src_filename
Use --help to see the full list of options.

Encoder encountered an error: 1
Error: Unrecognized option --invalid
Usage: aomenc <options> -o dst_filename src_filename
Use --help to see the full list of options.
Encoding failed, check validity of your encoding settings/commands and start again
fish: “python ./av1an.py -i site/cw.mk…” terminated by signal SIGKILL (Forced quit)
```