### PR TITLE
Fix using input instead of self.input and add as_posix on Paths

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -221,10 +221,10 @@ class Av1an:
             framenums = split_routine(self.input, self.scenes, self.split_method, self.temp, self.min_scene_len, self.queue, self.threshold, self.ffmpeg_pipe, aom_keyframes_params)
 
             if self.extra_split:
-                framenums = extra_splits(input, framenums, self.extra_split)
+                framenums = extra_splits(self.input, framenums, self.extra_split)
 
             segment(self.input, self.temp, framenums)
-            extract_audio(input, self.temp,  self.audio_params)
+            extract_audio(self.input, self.temp,  self.audio_params)
 
         chunk = get_video_queue(self.temp,  self.resume)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -47,11 +47,11 @@ def process_inputs(inputs):
         return None, inputs[0]
 
 
-def get_keyframes(file):
+def get_keyframes(file: Path):
     """ Read file info and return list of all keyframes """
     keyframes = []
 
-    ff = ["ffmpeg", "-hide_banner", "-i", file,
+    ff = ["ffmpeg", "-hide_banner", "-i", file.as_posix(),
     "-vf", "select=eq(pict_type\,PICT_TYPE_I)",
     "-f", "null", "-loglevel", "debug", "-"]
 
@@ -92,7 +92,7 @@ def frame_probe_fast(source: Path):
 
 def frame_probe(source: Path):
     """Get frame count."""
-    cmd = ["ffmpeg", "-hide_banner", "-i", source.absolute(), "-map", "0:v:0", "-f", "null", "-"]
+    cmd = ["ffmpeg", "-hide_banner", "-i", source.as_posix(), "-map", "0:v:0", "-f", "null", "-"]
     r = subprocess.run(cmd, stdout=PIPE, stderr=PIPE)
     matches = re.findall(r"frame=\s*([0-9]+)\s", r.stderr.decode("utf-8") + r.stdout.decode("utf-8"))
     return int(matches[-1])


### PR DESCRIPTION
A user on the discord reported a bug on Windows. There were some cases where Paths weren't converted to strings. It works fine on linux but causes problems on Windows. This also fixes passing the built in `input` function instead of the input path to a couple functions.