### PR TITLE
Added lock to I/O operations on done.json

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -11,6 +11,7 @@ import sys
 import shutil
 from .logger import log, set_log_file
 import numpy as np
+from threading import Lock
 
 
 def startup_check():
@@ -99,34 +100,40 @@ def frame_probe(source: Path):
     return int(matches[-1])
 
 
+doneFileLock = Lock()
 def frame_check(source: Path, encoded: Path, temp, check):
     """Checking is source and encoded video frame count match."""
     try:
         status_file = Path(temp / 'done.json')
-        with status_file.open() as f:
-            d = json.load(f)
 
         if check:
             s1 = frame_probe(source)
-            d['done'][source.name] = s1
-            with status_file.open('w') as f:
-                json.dump(d, f)
-                return
-
-        s1, s2 = [frame_probe(i) for i in (source, encoded)]
-
-        if s1 == s2:
+            doneFileLock.acquire()
+            with status_file.open() as f:
+                d = json.load(f)
             d['done'][source.name] = s1
             with status_file.open('w') as f:
                 json.dump(d, f)
         else:
-            print(f'Frame Count Differ for Source {source.name}: {s2}/{s1}')
+            s1, s2 = [frame_probe(i) for i in (source, encoded)]
+            if s1 == s2:
+                doneFileLock.acquire()
+                with status_file.open() as f:
+                    d = json.load(f)
+                d['done'][source.name] = s1
+                with status_file.open('w') as f:
+                    json.dump(d, f)
+            else:
+                print(f'Frame Count Differ for Source {source.name}: {s2}/{s1}')
     except IndexError:
         print('Encoding failed, check validity of your encoding settings/commands and start again')
         terminate()
     except Exception as e:
         _, _, exc_tb = sys.exc_info()
         print(f'\nError frame_check: {e}\nAt line: {exc_tb.tb_lineno}\n')
+    finally:
+        if doneFileLock.locked():
+            doneFileLock.release()
 
 
 def get_brightness(video):


### PR DESCRIPTION
I added a lock for when a encoding process need to read/write the done.json file. Without it, it may happen that two process read the file before writing the result, and then the second one to write the result would overwrite the result of the first.