### PR TITLE
Simplify first pass reuse command generation

### DIFF
--- a/av1an.py
+++ b/av1an.py
@@ -144,6 +144,10 @@ class Av1an:
             if self.boost:
                 commands = boosting(self.boost_limit, self.boost_range, source, commands, self.passes)
 
+            # first pass reuse
+            if self.reuse_first_pass:
+                commands = remove_first_pass_from_commands(commands, self.passes)
+
             log(f'Enc: {source.name}, {frame_probe_source} fr\n')
 
             # Queue execution

--- a/av1an.py
+++ b/av1an.py
@@ -129,7 +129,6 @@ class Av1an:
             source, target = Path(commands[-1][0]), Path(commands[-1][1])
             frame_probe_source = frame_probe(source)
 
-            # TODO(n9Mtq4): reuse of first pass doesn't work with boosting and vmaf_target
             # Target Vmaf Mode
             if self.vmaf_target:
                 tg_cq = self.target_vmaf(source)
@@ -237,7 +236,7 @@ class Av1an:
         chunk = get_video_queue(self.temp,  self.resume)
 
         # Make encode queue
-        commands = compose_encoding_queue(chunk, self.temp, self.encoder, self.video_params, self.ffmpeg_pipe, self.passes, self.reuse_first_pass)
+        commands = compose_encoding_queue(chunk, self.temp, self.encoder, self.video_params, self.ffmpeg_pipe, self.passes)
         log(f'Encoding Queue Composed\n'
             f'Encoder: {self.encoder.upper()} Queue Size: {len(commands)} Passes: {self.passes}\n'
             f'Params: {self.video_params}\n\n')

--- a/av1an.py
+++ b/av1an.py
@@ -129,12 +129,13 @@ class Av1an:
             source, target = Path(commands[-1][0]), Path(commands[-1][1])
             frame_probe_source = frame_probe(source)
 
+            # TODO(n9Mtq4): reuse of first pass doesn't work with boosting and vmaf_target
             # Target Vmaf Mode
             if self.vmaf_target:
                 tg_cq = self.target_vmaf(source)
                 cm1 = man_cq(commands[0], tg_cq)
 
-                if self.passes == 2 and (not self.reuse_first_pass):
+                if self.passes == 2:
                     cm2 = man_cq(commands[1], tg_cq)
                     commands = (cm1, cm2) + commands[2:]
                 else:
@@ -142,7 +143,7 @@ class Av1an:
 
             # Boost
             if self.boost:
-                commands = boosting(self.boost_limit, self.boost_range, source, commands, self.passes, self.reuse_first_pass)
+                commands = boosting(self.boost_limit, self.boost_range, source, commands, self.passes)
 
             log(f'Enc: {source.name}, {frame_probe_source} fr\n')
 

--- a/utils/boost.py
+++ b/utils/boost.py
@@ -26,12 +26,12 @@ def boost(command: str, brightness, b_limit, b_range, new_cq=0):
         print(f'Error in encoding loop {e}\nAt line {exc_tb.tb_lineno}')
 
 
-def boosting(bl, br, source, commands, passes, reuse_first_pass):
+def boosting(bl, br, source, commands, passes):
     try:
         brightness = get_brightness(source.absolute().as_posix())
         com0, cq = boost(commands[0], brightness, bl, br )
 
-        if passes == 2 and (not reuse_first_pass):
+        if passes == 2:
             com1, _ = boost(commands[1], brightness, bl, br, new_cq=cq)
             commands = (com0, com1) + commands[2:]
         else:

--- a/utils/compose.py
+++ b/utils/compose.py
@@ -90,7 +90,7 @@ def svt_av1_encode(inputs, passes, pipe, params):
     return commands
 
 
-def aom_vpx_encode(inputs, enc, passes, pipe, params, skip_first_pass):
+def aom_vpx_encode(inputs, enc, passes, pipe, params):
     """
     Generates commands for AOM, VPX encoders
 
@@ -110,18 +110,14 @@ def aom_vpx_encode(inputs, enc, passes, pipe, params, skip_first_pass):
              (file[0], file[1].with_suffix('.ivf')))
             for file in inputs]
 
-    if passes == 2 and skip_first_pass:
-        return [
-            (f'-i {file[0]} {pipe} {two_p_2} {params} --fpf={file[0].with_suffix(".log")} -o {file[1].with_suffix(".ivf")} - ',
-             (file[0], file[1].with_suffix('.ivf')))
-            for file in inputs]
-
     if passes == 2:
         return [
             (f'-i {file[0]} {pipe} {two_p_1} {params} --fpf={file[0].with_suffix(".log")} -o {os.devnull} - ',
              f'-i {file[0]} {pipe} {two_p_2} {params} --fpf={file[0].with_suffix(".log")} -o {file[1].with_suffix(".ivf")} - ',
              (file[0], file[1].with_suffix('.ivf')))
             for file in inputs]
+
+    return []
 
 
 def rav1e_encode(inputs, passes, pipe, params):
@@ -163,7 +159,7 @@ def rav1e_encode(inputs, passes, pipe, params):
     return commands
 
 
-def compose_encoding_queue(files, temp, encoder, params, pipe, passes, reuse_first_pass):
+def compose_encoding_queue(files, temp, encoder, params, pipe, passes):
     """
     Composing encoding queue with split videos.
     :param files: List of files that need to be encoded
@@ -183,7 +179,7 @@ def compose_encoding_queue(files, temp, encoder, params, pipe, passes, reuse_fir
                file) for file in files]
 
     if encoder in ('aom', 'vpx'):
-        queue = aom_vpx_encode(inputs, enc_exe, passes, pipe, params, reuse_first_pass)
+        queue = aom_vpx_encode(inputs, enc_exe, passes, pipe, params)
 
     elif encoder == 'rav1e':
         queue = rav1e_encode(inputs, passes, pipe, params)

--- a/utils/firstpassreuse.py
+++ b/utils/firstpassreuse.py
@@ -6,6 +6,22 @@ from typing import List, Dict
 from .aom_keyframes import fields
 
 
+def remove_first_pass_from_commands(commands, passes):
+    """
+    Removes the first pass command from the list of commands since we generated the first pass file ourselves.
+
+    :param commands: the list of commands
+    :param passes: the number of passes
+    :return: The new list of commands
+    """
+    # just one pass to begin with, do nothing
+    if passes == 1:
+        return commands
+
+    # passes >= 2, remove the command for first pass (commands[0])
+    return commands[1:]
+
+
 def read_first_pass(log_path):
     """
     Reads libaom first pass log into a list of dictionaries.


### PR DESCRIPTION
This simplifies the logic so that first pass reuse modifies the commands directly instead of relying on aom composing function, boost, and target vmaf.