### PR TITLE
Explicitly terminate on aom keyframe split failure

### DIFF
--- a/utils/aom_kf.py
+++ b/utils/aom_kf.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 from .compose import compose_aomsplit_first_pass_command
 from .logger import log
-from .utils import frame_probe
+from .utils import frame_probe, terminate
 
 # This is a script that returns a list of keyframes that aom would likely place. Port of aom's C code.
 # It requires an aom first-pass stats file as input. FFMPEG first-pass file is not OK. Default filename is stats.bin.
@@ -185,6 +185,11 @@ def aom_keyframes(video_path: Path, stat_file, min_scene_len, ffmpeg_pipe, video
         er = f"\nAom first pass encountered an error: {pipe.returncode}\n{enc_hist}"
         log(er)
         print(er)
+        if not stat_file.exists():
+            terminate()
+        else:
+            # aom crashed, but created keyframes.log, so we will try to continue
+            print("WARNING: Aom first pass crashed, but created a first pass file. Keyframe splitting may not be accurate.")
 
     # aom kf-min-dist defaults to 0, but hardcoded to 3 in pass2_strategy.c test_candidate_kf. 0 matches default aom behavior
     # https://aomedia.googlesource.com/aom/+/8ac928be918de0d502b7b492708d57ad4d817676/av1/av1_cx_iface.c#2816


### PR DESCRIPTION
This prevents a `FileNotFoundError` stack trace being printed out if the first pass for aom_keyframes crashes.

Old error message:
```
Aom first pass encountered an error: 1                                                                                                                                                                                 
Error: Unrecognized option --invalid                                                                                                                                                                                   
Usage: aomenc <options> -o dst_filename src_filename                                                                                                                                                                   
Use --help to see the full list of options.                                                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                     
  File "../av1an.py", line 354, in <module>                                                                                                                                                                            
    main()                                                                                                                                                                                                             
  File "../av1an.py", line 347, in main                                                                                                                                                                                
    Av1an().main_thread()                                                                                                                                                                                              
  File "../av1an.py", line 342, in main_thread                                                                                                                                                                         
    self.main_queue()                                                                                                                                                                                                  
  File "../av1an.py", line 334, in main_queue                                                                                                                                                                          
    self.video_encoding()                                                                                                                                                                                              
  File "../av1an.py", line 285, in video_encoding                                                                                                                                                                      
    framenums = split_routine(self.input, self.scenes, self.split_method, self.temp, self.min_scene_len, self.queue, self.threshold, self.ffmpeg_pipe, aom_keyframes_params)                                           
  File "/mnt/L4/workspace/Av1an/utils/split.py", line 118, in split_routine                                                                                                                                            
    sc = aom_keyframes(video, stat_file, min_scene_len, ffmpeg_pipe, video_params)                                                                                                                                     
  File "/mnt/L4/workspace/Av1an/utils/aom_kf.py", line 194, in aom_keyframes
    keyframes = find_aom_keyframes(stat_file, min_scene_len)
  File "/mnt/L4/workspace/Av1an/utils/aom_kf.py", line 118, in find_aom_keyframes
    number_of_frames = round(os.stat(stat_file).st_size / 208) - 1
FileNotFoundError: [Errno 2] No such file or directory: '.temp/keyframes.log'
```

New error message:
```
Aom first pass encountered an error: 1
Error: Unrecognized option --invalid
Usage: aomenc <options> -o dst_filename src_filename
Use --help to see the full list of options.

```