### PR TITLE
Use argparse groups for better help message

### DIFF
--- a/Av1an/arg_parse.py
+++ b/Av1an/arg_parse.py
@@ -2,6 +2,7 @@
 import argparse
 from pathlib import Path
 
+
 class Args(object):
 
     def __init__(self, initial_data):
@@ -64,63 +65,70 @@ class Args(object):
         for key in initial_data:
             setattr(self, key, initial_data[key])
 
+
 def arg_parsing():
     """Command line parsing"""
     parser = argparse.ArgumentParser()
 
     # Input/Output/Temp
-    parser.add_argument('--input', '-i', nargs='+', type=Path, help='Input File')
-    parser.add_argument('--temp', type=Path, default=Path('.temp'), help='Set temp folder path')
-    parser.add_argument('--output_file', '-o', type=Path, default=None, help='Specify output file')
+    io_group = parser.add_argument_group('Input and Output')
+    io_group.add_argument('--input', '-i', nargs='+', type=Path, help='Input File')
+    io_group.add_argument('--temp', type=Path, default=Path('.temp'), help='Set temp folder path')
+    io_group.add_argument('--output_file', '-o', type=Path, default=None, help='Specify output file')
+
+    io_group.add_argument('--logging', '-log', type=str, default=None, help='Enable logging')
+    io_group.add_argument('--resume', '-r', help='Resuming previous session', action='store_true')
+    io_group.add_argument('--keep', help='Keep temporally folder after encode', action='store_true')
 
     # Splitting
-    parser.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')
-    parser.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method',
-                        choices=['pyscene', 'aom_keyframes'])
-    parser.add_argument('--extra_split', '-xs', type=int, default=0, help='Number of frames after which make split')
-    parser.add_argument('--min_scene_len', type=int, default=None, help='Minimum number of frames in a split')
+    split_group = parser.add_argument_group('Splitting')
+    split_group.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')
+    split_group.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method',
+                             choices=['pyscene', 'aom_keyframes'])
+    split_group.add_argument('--extra_split', '-xs', type=int, default=0, help='Number of frames after which make split')
+    split_group.add_argument('--min_scene_len', type=int, default=None, help='Minimum number of frames in a split')
 
     # PySceneDetect split
-    parser.add_argument('--threshold', '-tr', type=float, default=50, help='PySceneDetect Threshold')
+    split_group.add_argument('--threshold', '-tr', type=float, default=50, help='PySceneDetect Threshold')
 
     # AOM Keyframe split
-    parser.add_argument('--reuse_first_pass', help='Reuse the first pass from aom_keyframes split on the chunks', action='store_true')
+    split_group.add_argument('--reuse_first_pass', help='Reuse the first pass from aom_keyframes split on the chunks',
+                             action='store_true')
 
     # Encoding
-    parser.add_argument('--passes', '-p', type=int, default=None, help='Specify encoding passes', choices=[1, 2])
-    parser.add_argument('--video_params', '-v', type=str, default=None, help='encoding settings')
-    parser.add_argument('--encoder', '-enc', type=str, default='aom', help='Choosing encoder',
-                        choices=['aom', 'svt_av1', 'rav1e', 'vpx','x265', 'x264', 'vvc'])
-    parser.add_argument('--workers', '-w', type=int, default=0, help='Number of workers')
-    parser.add_argument('-cfg', '--config', type=Path, help='Parameters file. Save/Read: '
-                                                            'Video, Audio, Encoder, FFmpeg parameteres')
-
-    # FFmpeg params
-    parser.add_argument('--ffmpeg', '-ff', type=str, default='', help='FFmpeg commands')
-    parser.add_argument('--audio_params', '-a', type=str, default='-c:a copy', help='FFmpeg audio settings')
-    parser.add_argument('--pix_format', '-fmt', type=str, default='yuv420p', help='FFmpeg pixel format')
-
-    # Misc
-    parser.add_argument('--logging', '-log', type=str, default=None, help='Enable logging')
-    parser.add_argument('--resume', '-r', help='Resuming previous session', action='store_true')
-    parser.add_argument('--no_check', '-n', help='Do not check encodings', action='store_true')
-    parser.add_argument('--keep', help='Keep temporally folder after encode', action='store_true')
-
-    # Vmaf
-    parser.add_argument('--vmaf', help='Calculating vmaf after encode', action='store_true')
-    parser.add_argument('--vmaf_path', type=Path, default=None, help='Path to vmaf models')
-    parser.add_argument('--vmaf_res', type=str, default="1920x1080", help='Resolution used in vmaf calculation')
-
-    # Target Vmaf
-    parser.add_argument('--vmaf_target', type=float, help='Value of Vmaf to target')
-    parser.add_argument('--vmaf_steps', type=int, default=4, help='Steps between min and max qp for target vmaf')
-    parser.add_argument('--min_q', type=int, default=None, help='Min q for target vmaf')
-    parser.add_argument('--max_q', type=int, default=None, help='Max q for target vmaf')
-    parser.add_argument('--vmaf_plots', help='Make plots of probes in temp folder', action='store_true')
-    parser.add_argument('--vmaf_rate', type=int, default=4, help='Framerate for probes, 0 - original')
-    parser.add_argument('--n_threads', type=int, default=None, help='Threads for vmaf calculation')
+    encode_group = parser.add_argument_group('Encoding')
+    encode_group.add_argument('--passes', '-p', type=int, default=None, help='Specify encoding passes', choices=[1, 2])
+    encode_group.add_argument('--video_params', '-v', type=str, default=None, help='encoding settings')
+    encode_group.add_argument('--encoder', '-enc', type=str, default='aom', help='Choosing encoder',
+                              choices=['aom', 'svt_av1', 'rav1e', 'vpx','x265', 'x264', 'vvc'])
+    encode_group.add_argument('--workers', '-w', type=int, default=0, help='Number of workers')
+    encode_group.add_argument('-cfg', '--config', type=Path, help='Parameters file. Save/Read: '
+                                                                  'Video, Audio, Encoder, FFmpeg parameteres')
+    encode_group.add_argument('--no_check', '-n', help='Do not check encodings', action='store_true')
 
     # VVC
-    parser.add_argument('--vvc_conf', type=Path, default=None, help='Path to VVC confing file')
+    encode_group.add_argument('--vvc_conf', type=Path, default=None, help='Path to VVC confing file')
+
+    # FFmpeg params
+    ffmpeg_group = parser.add_argument_group('FFmpeg')
+    ffmpeg_group.add_argument('--ffmpeg', '-ff', type=str, default='', help='FFmpeg commands')
+    ffmpeg_group.add_argument('--audio_params', '-a', type=str, default='-c:a copy', help='FFmpeg audio settings')
+    ffmpeg_group.add_argument('--pix_format', '-fmt', type=str, default='yuv420p', help='FFmpeg pixel format')
+
+    # Vmaf
+    vmaf_group = parser.add_argument_group('VMAF')
+    vmaf_group.add_argument('--vmaf', help='Calculating vmaf after encode', action='store_true')
+    vmaf_group.add_argument('--vmaf_path', type=Path, default=None, help='Path to vmaf models')
+    vmaf_group.add_argument('--vmaf_res', type=str, default="1920x1080", help='Resolution used in vmaf calculation')
+    vmaf_group.add_argument('--n_threads', type=int, default=None, help='Threads for vmaf calculation')    
+
+    # Target Vmaf
+    tvmaf_group = parser.add_argument_group('Target VMAF')
+    tvmaf_group.add_argument('--vmaf_target', type=float, help='Value of Vmaf to target')
+    tvmaf_group.add_argument('--vmaf_steps', type=int, default=4, help='Steps between min and max qp for target vmaf')
+    tvmaf_group.add_argument('--min_q', type=int, default=None, help='Min q for target vmaf')
+    tvmaf_group.add_argument('--max_q', type=int, default=None, help='Max q for target vmaf')
+    tvmaf_group.add_argument('--vmaf_plots', help='Make plots of probes in temp folder', action='store_true')
+    tvmaf_group.add_argument('--vmaf_rate', type=int, default=4, help='Framerate for probes, 0 - original')
 
     return Args(vars(parser.parse_args()))


### PR DESCRIPTION
This PR takes advantage of argument groups in argparse.

Help message before:
```
optional arguments:
  -h, --help            show this help message and exit
  --input INPUT [INPUT ...], -i INPUT [INPUT ...]
                        Input File
  --temp TEMP           Set temp folder path
  --output_file OUTPUT_FILE, -o OUTPUT_FILE
                        Specify output file
  --scenes SCENES, -s SCENES
                        File location for scenes
  --split_method {pyscene,aom_keyframes}
                        Specify splitting method
  --extra_split EXTRA_SPLIT, -xs EXTRA_SPLIT
                        Number of frames after which make split
  --min_scene_len MIN_SCENE_LEN
                        Minimum number of frames in a split
  --threshold THRESHOLD, -tr THRESHOLD
                        PySceneDetect Threshold
  --reuse_first_pass    Reuse the first pass from aom_keyframes split on the chunks
  --passes {1,2}, -p {1,2}
                        Specify encoding passes
  --video_params VIDEO_PARAMS, -v VIDEO_PARAMS
                        encoding settings
  --encoder {aom,svt_av1,rav1e,vpx,x265,x264,vvc}, -enc {aom,svt_av1,rav1e,vpx,x265,x264,vvc}
                        Choosing encoder
  --workers WORKERS, -w WORKERS
                        Number of workers
  -cfg CONFIG, --config CONFIG
                        Parameters file. Save/Read: Video, Audio, Encoder, FFmpeg parameteres
  --ffmpeg FFMPEG, -ff FFMPEG
                        FFmpeg commands
  --audio_params AUDIO_PARAMS, -a AUDIO_PARAMS
                        FFmpeg audio settings
  --pix_format PIX_FORMAT, -fmt PIX_FORMAT
                        FFmpeg pixel format
  --logging LOGGING, -log LOGGING
                        Enable logging
  --resume, -r          Resuming previous session
  --no_check, -n        Do not check encodings
  --keep                Keep temporally folder after encode
  --vmaf                Calculating vmaf after encode
  --vmaf_path VMAF_PATH
                        Path to vmaf models
  --vmaf_res VMAF_RES   Resolution used in vmaf calculation
  --vmaf_target VMAF_TARGET
                        Value of Vmaf to target
  --vmaf_steps VMAF_STEPS
                        Steps between min and max qp for target vmaf
  --min_q MIN_Q         Min q for target vmaf
  --max_q MAX_Q         Max q for target vmaf
  --vmaf_plots          Make plots of probes in temp folder
  --vmaf_rate VMAF_RATE
                        Framerate for probes, 0 - original
  --n_threads N_THREADS
                        Threads for vmaf calculation
  --vvc_conf VVC_CONF   Path to VVC confing file
```

Help message after:
```
optional arguments:
  -h, --help            show this help message and exit

Input and Output:
  --input INPUT [INPUT ...], -i INPUT [INPUT ...]
                        Input File
  --temp TEMP           Set temp folder path
  --output_file OUTPUT_FILE, -o OUTPUT_FILE
                        Specify output file
  --logging LOGGING, -log LOGGING
                        Enable logging
  --resume, -r          Resuming previous session
  --keep                Keep temporally folder after encode

Splitting:
  --scenes SCENES, -s SCENES
                        File location for scenes
  --split_method {pyscene,aom_keyframes}
                        Specify splitting method
  --extra_split EXTRA_SPLIT, -xs EXTRA_SPLIT
                        Number of frames after which make split
  --min_scene_len MIN_SCENE_LEN
                        Minimum number of frames in a split
  --threshold THRESHOLD, -tr THRESHOLD
                        PySceneDetect Threshold
  --reuse_first_pass    Reuse the first pass from aom_keyframes split on the chunks

Encoding:
  --passes {1,2}, -p {1,2}
                        Specify encoding passes
  --video_params VIDEO_PARAMS, -v VIDEO_PARAMS
                        encoding settings
  --encoder {aom,svt_av1,rav1e,vpx,x265,x264,vvc}, -enc {aom,svt_av1,rav1e,vpx,x265,x264,vvc}
                        Choosing encoder
  --workers WORKERS, -w WORKERS
                        Number of workers
  -cfg CONFIG, --config CONFIG
                        Parameters file. Save/Read: Video, Audio, Encoder, FFmpeg parameteres
  --no_check, -n        Do not check encodings
  --vvc_conf VVC_CONF   Path to VVC confing file

FFmpeg:
  --ffmpeg FFMPEG, -ff FFMPEG
                        FFmpeg commands
  --audio_params AUDIO_PARAMS, -a AUDIO_PARAMS
                        FFmpeg audio settings
  --pix_format PIX_FORMAT, -fmt PIX_FORMAT
                        FFmpeg pixel format

VMAF:
  --vmaf                Calculating vmaf after encode
  --vmaf_path VMAF_PATH
                        Path to vmaf models
  --vmaf_res VMAF_RES   Resolution used in vmaf calculation
  --n_threads N_THREADS
                        Threads for vmaf calculation

Target VMAF:
  --vmaf_target VMAF_TARGET
                        Value of Vmaf to target
  --vmaf_steps VMAF_STEPS
                        Steps between min and max qp for target vmaf
  --min_q MIN_Q         Min q for target vmaf
  --max_q MAX_Q         Max q for target vmaf
  --vmaf_plots          Make plots of probes in temp folder
  --vmaf_rate VMAF_RATE
                        Framerate for probes, 0 - original
```