### PR TITLE
Add the option for chunks to use the select filter instead of segmenting to disk

### DIFF
--- a/Av1an/arg_parse.py
+++ b/Av1an/arg_parse.py
@@ -12,6 +12,7 @@ class Args(object):
         self.output_file = None
 
         # Splitting
+        self.chunk_method = None
         self.scenes = None
         self.split_method = None
         self.extra_split = None
@@ -82,6 +83,8 @@ def arg_parsing():
 
     # Splitting
     split_group = parser.add_argument_group('Splitting')
+    split_group.add_argument('--chunk_method', '-cs', type=str, default='segment', help='Method for creating chunks',
+                             choices=['segment', 'select'])
     split_group.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')
     split_group.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method',
                              choices=['pyscene', 'aom_keyframes'])


### PR DESCRIPTION
This PR introduces the option of using [ffmpeg's select filter](https://ffmpeg.org/ffmpeg-filters.html#select_002c-aselect) to create the chunks. This is enabled with `--chunk_method select`. This has the advantage of not requiring intermediate chunk files written to disk and being able to split on non-keyframes. The downside to this is increased time as ffmpeg needs to seek to the frames.

Performance on 53000 frame 1080p encode with libaom cpu-used 6:
segment: 4813.7s
select: 6853.3s

An extra 34 minutes, but this depends on the number of frames and becomes less important on lower cpu-used values. In addition, the select encode had an extra chunk because it was able to split on non-keyframes.