### PR TITLE
Add the option for chunks to use vapoursynth + ffms2

### DIFF
--- a/Av1an/arg_parse.py
+++ b/Av1an/arg_parse.py
@@ -84,7 +84,7 @@ def arg_parsing():
     # Splitting
     split_group = parser.add_argument_group('Splitting')
     split_group.add_argument('--chunk_method', '-cs', type=str, default='segment', help='Method for creating chunks',
-                             choices=['segment', 'select'])
+                             choices=['segment', 'select', 'vs_ffms2'])
     split_group.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')
     split_group.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method',
                              choices=['pyscene', 'aom_keyframes'])

--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -72,12 +72,69 @@ def create_encoding_queue(args: Args, split_locations: List[int]) -> List[Chunk]
     chunk_method_gen = {
         'segment': create_video_queue_segment,
         'select': create_video_queue_select,
+        'vs_ffms2': create_video_queue_vsffms2,
     }
     chunk_queue = chunk_method_gen[args.chunk_method](args, split_locations)
 
     # Sort largest first so chunks that take a long time to encode start first
     chunk_queue.sort(key=lambda c: c.size, reverse=True)
     return chunk_queue
+
+
+def create_video_queue_vsffms2(args: Args, split_locations: List[int]) -> List[Chunk]:
+    """
+    Create a list of chunks using vspipe and ffms2 for frame accurate seeking
+
+    :param args: the Args
+    :param split_locations: a list of frames to split on
+    :return: A list of chunks
+    """
+    # add first frame and last frame
+    last_frame = frame_probe(args.input)
+    split_locs_fl = [0] + split_locations + [last_frame]
+
+    # pair up adjacent members of this list ex: [0, 10, 20, 30] -> [(0, 10), (10, 20), (20, 30)]
+    chunk_boundaries = zip(split_locs_fl, split_locs_fl[1:])
+
+    # create a vapoursynth script that will load the source with ffms2
+    load_script = args.temp / 'split' / 'loadscript.vpy'
+    source_file = args.input.absolute().as_posix()
+    cache_file = (args.temp / 'split' / 'ffms2cache.ffindex').absolute().as_posix()
+    with open(load_script, 'w') as file:
+        file.writelines([
+            'from vapoursynth import core\n',
+            f'core.ffms2.Source("{source_file}", cachefile="{cache_file}").set_output()\n',
+        ])
+
+    chunk_queue = [create_vsffms2_chunk(args, index, load_script, *cb) for index, cb in enumerate(chunk_boundaries)]
+
+    return chunk_queue
+
+
+def create_vsffms2_chunk(args: Args, index: int, load_script: Path, frame_start: int, frame_end: int) -> Chunk:
+    """
+    Creates a chunk using vspipe and ffms2
+
+    :param args: the Args
+    :param load_script: the path to the .vpy script for vspipe
+    :param index: the index of the chunk
+    :param frame_start: frame that this chunk should start on (0-based, inclusive)
+    :param frame_end: frame that this chunk should end on (0-based, exclusive)
+    :return: a Chunk
+    """
+    assert frame_end > frame_start, "Can't make a chunk with <= 0 frames!"
+
+    frames = frame_end - frame_start
+    frame_end -= 1  # the frame end boundary is actually a frame that should be included in the next chunk
+
+    ffmpeg_gen_cmd = f'vspipe {load_script} -y - -s {frame_start} -e {frame_end}'
+    extension = get_file_extension_for_encoder(args.encoder)
+    size = frames  # use the number of frames to prioritize which chunks encode first, since we don't have file size
+
+    chunk = Chunk(args.temp, index, ffmpeg_gen_cmd, extension, size, frames)
+    chunk.generate_pass_cmds(args)
+
+    return chunk
 
 
 def create_video_queue_select(args: Args, split_locations: List[int]) -> List[Chunk]:

--- a/Av1an/setup.py
+++ b/Av1an/setup.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from psutil import virtual_memory
 
+from .arg_parse import Args
 from .utils import terminate
 from .compose import get_default_params_for_encoder
 
@@ -31,7 +32,7 @@ def set_vmaf(args):
         args.min_q, args.max_q = defaul_ranges.get(args.encoder)
 
 
-def check_exes(args):
+def check_exes(args: Args):
     if not find_executable('ffmpeg'):
         print('No ffmpeg')
         terminate()
@@ -52,6 +53,11 @@ def check_exes(args):
     if args.encoder == 'vvc':
         if not find_executable('vvc_concat'):
             print('vvc concatenation executabe "vvc_concat" not found')
+            terminate()
+
+    if args.chunk_method == 'vs_ffms2':
+        if not find_executable('vspipe'):
+            print('vspipe executable not found')
             terminate()
 
 


### PR DESCRIPTION
This PR introduces the option of using vapoursynth and ffms2 to create the chunks. This is enabled with `--chunk_method vs_ffms2`. This has the advantage of being quick, not requiring intermediate chunk files written to disk, and being able to split on non-keyframes. The only downside is the requirement of having vapoursynth and ffms2 installed.

Performance on 53000 frame 1080p encode with libaom cpu-used 6:
segment: 4813.7s
vs_ffms2: 4796.0s
