### PR TITLE
Fix handling path with spaces

### DIFF
--- a/Av1an/aom_kf.py
+++ b/Av1an/aom_kf.py
@@ -154,7 +154,6 @@ def aom_keyframes(video_path: Path, stat_file, min_scene_len, ffmpeg_pipe, video
         total = frame_probe(video_path)
 
     f, e = compose_aomsplit_first_pass_command(video_path, stat_file, ffmpeg_pipe, video_params)
-    f, e = f.split(), e.split()
 
     tqdm_bar = tqdm(total=total, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.2)
 

--- a/Av1an/bar.py
+++ b/Av1an/bar.py
@@ -62,7 +62,7 @@ def process_pipe(pipe):
 
 
 def make_vvc_pipe(command):
-    pipe = subprocess.Popen(command[0], stdout=PIPE,
+    pipe = subprocess.Popen(command, stdout=PIPE,
                             stderr=STDOUT,
                             universal_newlines=True)
     return pipe

--- a/Av1an/bar.py
+++ b/Av1an/bar.py
@@ -3,6 +3,7 @@
 import re
 import subprocess
 import sys
+from typing import Tuple
 from collections import deque
 from multiprocessing.managers import BaseManager
 from subprocess import PIPE, STDOUT

--- a/Av1an/bar.py
+++ b/Av1an/bar.py
@@ -34,13 +34,11 @@ class Counter():
 BaseManager.register('Counter', Counter)
 
 
-def make_pipes(ffmpeg_gen, command):
+def make_pipes(ffmpeg_gen_cmd: list, command: list):
 
-    f, e = command.split('|')
-    f, e = f.split(), e.split()
-    ffmpeg_gen_pipe = subprocess.Popen(ffmpeg_gen.split(), stdout=PIPE, stderr=STDOUT)
-    ffmpeg_pipe = subprocess.Popen(f, stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT)
-    pipe = subprocess.Popen(e, stdin=ffmpeg_pipe.stdout, stdout=PIPE,
+    ffmpeg_gen_pipe = subprocess.Popen(ffmpeg_gen_cmd, stdout=PIPE, stderr=STDOUT)
+    ffmpeg_pipe = subprocess.Popen(command[0], stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT)
+    pipe = subprocess.Popen(command[1], stdin=ffmpeg_pipe.stdout, stdout=PIPE,
                             stderr=STDOUT,
                             universal_newlines=True)
 
@@ -64,7 +62,7 @@ def process_pipe(pipe):
 
 
 def make_vvc_pipe(command):
-    pipe = subprocess.Popen(command.split(), stdout=PIPE,
+    pipe = subprocess.Popen(command[0], stdout=PIPE,
                             stderr=STDOUT,
                             universal_newlines=True)
     return pipe

--- a/Av1an/bar.py
+++ b/Av1an/bar.py
@@ -34,7 +34,7 @@ class Counter():
 BaseManager.register('Counter', Counter)
 
 
-def make_pipes(ffmpeg_gen_cmd: list, command: list):
+def make_pipes(ffmpeg_gen_cmd: Tuple[str], command: Tuple[Tuple[str]]):
 
     ffmpeg_gen_pipe = subprocess.Popen(ffmpeg_gen_cmd, stdout=PIPE, stderr=STDOUT)
     ffmpeg_pipe = subprocess.Popen(command[0], stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT)

--- a/Av1an/chunk.py
+++ b/Av1an/chunk.py
@@ -11,7 +11,7 @@ class Chunk:
     to be run on this chunk.
     """
 
-    def __init__(self, temp: Path, index: int, ffmpeg_gen_cmd: str, output_ext: str, size: int, frames: int):
+    def __init__(self, temp: Path, index: int, ffmpeg_gen_cmd: list, output_ext: str, size: int, frames: int):
         """
         Chunk class constructor
 

--- a/Av1an/chunk.py
+++ b/Av1an/chunk.py
@@ -11,7 +11,7 @@ class Chunk:
     to be run on this chunk.
     """
 
-    def __init__(self, temp: Path, index: int, ffmpeg_gen_cmd: list, output_ext: str, size: int, frames: int):
+    def __init__(self, temp: Path, index: int, ffmpeg_gen_cmd: Tuple[str], output_ext: str, size: int, frames: int):
         """
         Chunk class constructor
 

--- a/Av1an/chunk.py
+++ b/Av1an/chunk.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 
 from .arg_parse import Args
 import Av1an

--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -127,7 +127,7 @@ def create_vsffms2_chunk(args: Args, index: int, load_script: Path, frame_start:
     frames = frame_end - frame_start
     frame_end -= 1  # the frame end boundary is actually a frame that should be included in the next chunk
 
-    ffmpeg_gen_cmd = f'vspipe {load_script} -y - -s {frame_start} -e {frame_end}'
+    ffmpeg_gen_cmd = ('vspipe', load_script, '-y', '-', '-s', frame_start, '-e', frame_end)
     extension = get_file_extension_for_encoder(args.encoder)
     size = frames  # use the number of frames to prioritize which chunks encode first, since we don't have file size
 
@@ -176,7 +176,7 @@ def create_select_chunk(args: Args, index: int, src_path: Path, frame_start: int
     frames = frame_end - frame_start
     frame_end -= 1  # the frame end boundary is actually a frame that should be included in the next chunk
 
-    ffmpeg_gen_cmd = f'ffmpeg -y -hide_banner -loglevel error -i {src_path.as_posix()} -vf select=between(n\\,{frame_start}\\,{frame_end}),setpts=PTS-STARTPTS {args.pix_format} -bufsize 50000K -f yuv4mpegpipe -'
+    ffmpeg_gen_cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', src_path.as_posix(), '-vf', f'select=between(n\,{frame_start}\,{frame_end}),setpts=PTS-STARTPTS', *args.pix_format, '-bufsize', '50000K', '-f', 'yuv4mpegpipe', '-')
     extension = get_file_extension_for_encoder(args.encoder)
     size = frames  # use the number of frames to prioritize which chunks encode first, since we don't have file size
 
@@ -223,7 +223,7 @@ def create_chunk_from_segment(args: Args, index: int, file: Path) -> Chunk:
     :param file: the segmented file
     :return: A Chunk
     """
-    ffmpeg_gen_cmd = f'ffmpeg -y -hide_banner -loglevel error -i {file.as_posix()} {args.pix_format} -bufsize 50000K -f yuv4mpegpipe -'
+    ffmpeg_gen_cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', file.as_posix(), *args.pix_format, '-bufsize', '50000K', '-f', 'yuv4mpegpipe', '-')
     file_size = file.stat().st_size
     frames = frame_probe(file)
     extension = get_file_extension_for_encoder(args.encoder)

--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -147,7 +147,10 @@ def create_video_queue_select(args: Args, split_locations: List[int]) -> List[Ch
     """
     # add first frame and last frame
     last_frame = frame_probe(args.input)
-    split_locs_fl = [0] + split_locations + [last_frame]
+    if 0 not in split_locations:
+        split_locs_fl = [0] + split_locations
+    if last_frame not in split_locations:
+        split_locations = split_locations + [last_frame]
 
     # pair up adjacent members of this list ex: [0, 10, 20, 30] -> [(0, 10), (10, 20), (20, 30)]
     chunk_boundaries = zip(split_locs_fl, split_locs_fl[1:])

--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -147,11 +147,6 @@ def create_video_queue_select(args: Args, split_locations: List[int]) -> List[Ch
     """
     # add first frame and last frame
     last_frame = frame_probe(args.input)
-    if 0 not in split_locations:
-        split_locs_fl = [0] + split_locations
-    if last_frame not in split_locations:
-        split_locations = split_locations + [last_frame]
-
     # pair up adjacent members of this list ex: [0, 10, 20, 30] -> [(0, 10), (10, 20), (20, 30)]
     chunk_boundaries = zip(split_locs_fl, split_locs_fl[1:])
 

--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -127,7 +127,7 @@ def create_vsffms2_chunk(args: Args, index: int, load_script: Path, frame_start:
     frames = frame_end - frame_start
     frame_end -= 1  # the frame end boundary is actually a frame that should be included in the next chunk
 
-    ffmpeg_gen_cmd = ('vspipe', load_script, '-y', '-', '-s', frame_start, '-e', frame_end)
+    ffmpeg_gen_cmd = ('vspipe', load_script.as_posix(), '-y', '-', '-s', str(frame_start), '-e', str(frame_end))
     extension = get_file_extension_for_encoder(args.encoder)
     size = frames  # use the number of frames to prioritize which chunks encode first, since we don't have file size
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -91,7 +91,7 @@ def compose_ffmpeg_pipe(a: Args) -> str:
     return ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', *a.ffmpeg_pipe)
 
 
-def compose_svt_av1(a: Args, c: Chunk) -> List[str]:
+def compose_svt_av1(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and svt-av1 command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -9,7 +9,7 @@ from .chunk import Chunk
 from .vvc import get_yuv_file_path
 
 
-def gen_pass_commands(args: Args, chunk: Chunk) -> List[List]:
+def gen_pass_commands(args: Args, chunk: Chunk) -> Tuple[Tuple[str]]:
     """
     Generates commands for ffmpeg and the encoder specified in args for the given chunk
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -187,7 +187,7 @@ def compose_x265(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_x264(a: Args, c: Chunk) -> List[str]:
+def compose_x264(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and x264 command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -110,7 +110,7 @@ def compose_svt_av1(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_rav1e(a: Args, c: Chunk) -> List[str]:
+def compose_rav1e(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and rav1e command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 from .arg_parse import Args
 from .chunk import Chunk

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -216,7 +216,7 @@ def compose_vvc(a: Args, c: Chunk) -> List[str]:
     """
     yuv_file = get_yuv_file_path(c).as_posix()
     return (
-        ('vvc_encoder', '-c', a.vvc_conf, '-i', yuv_file, *a.video_params, '-f', c.frames, '--InputBitDepth=10', '--OutputBitDepth=10', '-b', c.output),
+        ('vvc_encoder', '-c', a.vvc_conf, '-i', yuv_file, *a.video_params, '-f', str(c.frames), '--InputBitDepth=10', '--OutputBitDepth=10', '-b', c.output),
     )
 
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -206,7 +206,7 @@ def compose_x264(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_vvc(a: Args, c: Chunk) -> List[str]:
+def compose_vvc(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the vvc command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -130,7 +130,7 @@ def compose_rav1e(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_aom(a: Args, c: Chunk) -> List[str]:
+def compose_aom(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and libaom command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -168,7 +168,7 @@ def compose_vpx(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_x265(a: Args, c: Chunk) -> List[str]:
+def compose_x265(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and x265 command(s) for the chunk with respect to args
 

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -88,7 +88,7 @@ def compose_ffmpeg_pipe(a: Args) -> str:
     :param a: the Args
     :return: the ffmpeg command as a list
     """
-    return ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', *a.ffmpeg_pipe]
+    return ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', *a.ffmpeg_pipe)
 
 
 def compose_svt_av1(a: Args, c: Chunk) -> List[str]:

--- a/Av1an/compose.py
+++ b/Av1an/compose.py
@@ -149,7 +149,7 @@ def compose_aom(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
         )
 
 
-def compose_vpx(a: Args, c: Chunk) -> List[str]:
+def compose_vpx(a: Args, c: Chunk) -> Tuple[Tuple[str]]:
     """
     Composes the ffmpeg and vpx command(s) for the chunk with respect to args
 

--- a/Av1an/concat.py
+++ b/Av1an/concat.py
@@ -73,7 +73,7 @@ def concatenate_video(temp: Path, output, encoder: str):
     if encoder == 'x265':
 
         cmd = ('ffmpeg', '-y', '-fflags', '+genpts', '-hide_banner', '-loglevel', 'error', '-f', 'concat', '-safe', '0', '-i', temp / "concat", *audio, '-c', 'copy', '-movflags', 'frag_keyframe+empty_moov', '-map', '0', '-f', 'mp4', output)
-        concat = subprocess.run(cmd, shell=False, stdout=PIPE, stderr=STDOUT).stdout
+        concat = subprocess.run(cmd, stdout=PIPE, stderr=STDOUT).stdout
 
     else:
         cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-f', 'concat', '-safe', '0', '-i', temp / "concat", *audio, '-c', 'copy', '-map', '0', output)

--- a/Av1an/concat.py
+++ b/Av1an/concat.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 from subprocess import PIPE, STDOUT
 from pathlib import Path
+import shlex
 
 from Av1an.arg_parse import Args
 from Av1an.logger import log
@@ -60,26 +61,24 @@ def concatenate_video(temp: Path, output, encoder: str):
 
         encode_files = sorted((temp / 'encode').iterdir())
         # Replace all the ' with '/'' so ffmpeg can read the path correctly
-        f.writelines("file '" + str(file.absolute()).replace('\'','\'\\\'\'') + "'\n" for file in encode_files)
+        f.writelines(f'file {shlex.quote(str(file.absolute()))}\n' for file in encode_files)
 
     # Add the audio file if one was extracted from the input
     audio_file = temp / "audio.mkv"
     if audio_file.exists():
-        audio = f'-i {audio_file} -c:a copy -map 1'
+        audio = ('-i', audio_file, '-c:a', 'copy', '-map', '1')
     else:
-        audio = ''
+        audio = ()
 
     if encoder == 'x265':
 
-        cmd = f' ffmpeg -y -fflags +genpts  -hide_banner -loglevel error -f concat -safe 0 -i {temp / "concat"} ' \
-            f'{audio} -c copy -movflags frag_keyframe+empty_moov -map 0  -f mp4 - | ffmpeg -y -hide_banner -loglevel error -i - -c copy {output} '
-        concat = subprocess.run(cmd, shell=True, stdout=PIPE, stderr=STDOUT).stdout
+        cmd = ('ffmpeg', '-y', '-fflags', '+genpts', '-hide_banner', '-loglevel', 'error', '-f', 'concat', '-safe', '0', '-i', temp / "concat", *audio, '-c', 'copy', '-movflags', 'frag_keyframe+empty_moov', '-map', '0', '-f', 'mp4', output)
+        concat = subprocess.run(cmd, shell=False, stdout=PIPE, stderr=STDOUT).stdout
 
     else:
-        cmd = f' ffmpeg -y -hide_banner -loglevel error -f concat -safe 0 -i {temp / "concat"} ' \
-            f'{audio} -c copy -map 0  -y "{output}"'
+        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-f', 'concat', '-safe', '0', '-i', temp / "concat", *audio, '-c', 'copy', '-map', '0', output)
 
-        concat = subprocess.run(cmd, shell=True, stdout=PIPE, stderr=STDOUT).stdout
+        concat = subprocess.run(cmd, shell=False, stdout=PIPE, stderr=STDOUT).stdout
 
     if len(concat) > 0:
         log(concat.decode())

--- a/Av1an/concat.py
+++ b/Av1an/concat.py
@@ -78,7 +78,7 @@ def concatenate_video(temp: Path, output, encoder: str):
     else:
         cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-f', 'concat', '-safe', '0', '-i', temp / "concat", *audio, '-c', 'copy', '-map', '0', output)
 
-        concat = subprocess.run(cmd, shell=False, stdout=PIPE, stderr=STDOUT).stdout
+        concat = subprocess.run(cmd, stdout=PIPE, stderr=STDOUT).stdout
 
     if len(concat) > 0:
         log(concat.decode())

--- a/Av1an/encode.py
+++ b/Av1an/encode.py
@@ -125,7 +125,7 @@ def startup(args: Args, chunk_queue: List[Chunk]):
     counter = Manager().Counter(total, initial)
     args.counter = counter
     print(f'\rQueue: {clips} Workers: {args.workers} Passes: {args.passes}\n'
-          f'Params: {args.video_params.strip()}'   )
+          f'Params: {" ".join(args.video_params)}')
 
 
 def encoding_loop(args: Args, chunk_queue: List[Chunk]):

--- a/Av1an/ffmpeg.py
+++ b/Av1an/ffmpeg.py
@@ -47,15 +47,14 @@ def get_keyframes(file: Path):
 
 def extract_audio(input_vid: Path, temp, audio_params):
     """Extracting audio from source, transcoding if needed."""
-    log(f'Audio processing\nParams: {audio_params}\n')
+    log(f'Audio processing\nParams: {" ".join(audio_params)}\n')
     audio_file = temp / 'audio.mkv'
 
     # Checking is source have audio track
-    check = fr' ffmpeg -y -hide_banner -loglevel error -ss 0 -i "{input_vid}" -t 0 -vn -c:a copy -f null -'
-    is_audio_here = len(subprocess.run(check, shell=True, stdout=PIPE, stderr=STDOUT).stdout) == 0
+    check = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-ss', '0', '-i', input_vid, '-t', '0', '-vn', '-c:a', 'copy', '-f', 'null', '-')
+    is_audio_here = len(subprocess.run(check, stdout=PIPE, stderr=STDOUT).stdout) == 0
 
     # If source have audio track - process it
     if is_audio_here:
-        cmd = f'ffmpeg -y -hide_banner -loglevel error -i "{input_vid}" -vn ' \
-              f'{audio_params} {audio_file}'
-        subprocess.run(cmd, shell=True)
+        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid, '-vn', *audio_params, audio_file)
+        subprocess.run(cmd)

--- a/Av1an/setup.py
+++ b/Av1an/setup.py
@@ -109,8 +109,8 @@ def startup_check(args):
 
     if args.video_params is None:
         args.video_params = get_default_params_for_encoder(args.encoder)
-
-    args.video_params = shlex.split(args.video_params)
+    else:
+        args.video_params = shlex.split(args.video_params)
     args.audio_params = shlex.split(args.audio_params)
     args.ffmpeg = shlex.split(args.ffmpeg)
 

--- a/Av1an/setup.py
+++ b/Av1an/setup.py
@@ -4,6 +4,7 @@ import os
 import sys
 import shutil
 import atexit
+import shlex
 from distutils.spawn import find_executable
 from pathlib import Path
 
@@ -109,10 +110,12 @@ def startup_check(args):
     if args.video_params is None:
         args.video_params = get_default_params_for_encoder(args.encoder)
 
+    args.video_params = shlex.split(args.video_params)
+    args.audio_params = shlex.split(args.audio_params)
+    args.ffmpeg = shlex.split(args.ffmpeg)
 
-
-    args.pix_format = f'-strict -1 -pix_fmt {args.pix_format}'
-    args.ffmpeg_pipe = f' {args.ffmpeg} {args.pix_format} -bufsize 50000K -f yuv4mpegpipe - |'
+    args.pix_format = ('-strict', '-1', '-pix_fmt', args.pix_format)
+    args.ffmpeg_pipe = (*args.ffmpeg, *args.pix_format, '-bufsize', '50000K', '-f', 'yuv4mpegpipe', '-')
 
 
 def determine_resources(encoder, workers):

--- a/Av1an/target_vmaf.py
+++ b/Av1an/target_vmaf.py
@@ -33,7 +33,7 @@ def target_vmaf_routine(args: Args, chunk: Chunk):
     :return: None
     """
     tg_cq = target_vmaf(chunk, args)
-    chunk.pass_cmds = [man_q(command, tg_cq) for command in chunk.pass_cmds]
+    chunk.pass_cmds = (man_q(command, tg_cq) for command in chunk.pass_cmds)
 
 
 def gen_probes_names(chunk: Chunk, q):
@@ -45,33 +45,33 @@ def gen_probes_names(chunk: Chunk, q):
 def probe_cmd(chunk: Chunk, q, ffmpeg_pipe, encoder, vmaf_rate):
     """Generate and return commands for probes at set Q values
     """
-    pipe = fr'ffmpeg -y -hide_banner -loglevel error -i - -vf select=not(mod(n\,{vmaf_rate})) {ffmpeg_pipe}'
+    pipe = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', '-vf', f'select=not(mod(n\,{vmaf_rate}))', *ffmpeg_pipe)
 
     probe_name = gen_probes_names(chunk, q).with_suffix('.ivf').as_posix()
 
     if encoder == 'aom':
-        params = " aomenc  --passes=1 --threads=8 --end-usage=q --cpu-used=6 --cq-level="
-        cmd = f'{pipe} {params}{q} -o {probe_name} - '
+        params = ('aomenc',  '--passes=1', '--threads=8', '--end-usage=q', '--cpu-used=6', f'--cq-level={q}')
+        cmd = (pipe, (*params, '-o', probe_name, '-'))
 
     elif encoder == 'x265':
-        params = "x265  --log-level 0  --no-progress --y4m --preset faster --crf "
-        cmd = f'{pipe} {params}{q} -o {probe_name} - '
+        params = ('x265',  '--log-level', '0', '--no-progress', '--y4m', '--preset', 'faster', '--crf', f'{q}')
+        cmd = (pipe, (*params, '-o', probe_name, '-'))
 
     elif encoder == 'rav1e':
-        params = "rav1e - -q -s 10 --tiles 8 --quantizer "
-        cmd = f'{pipe} {params}{q} -o {probe_name}'
+        params = ('rav1e', '-s', '10', '--tiles', '8', '--quantizer', f'{q}')
+        cmd = (pipe, (*params, '-o', probe_name, '-'))
 
     elif encoder == 'vpx':
-        params = "vpxenc --passes=1 --pass=1 --codec=vp9 --threads=4 --cpu-used=9 --end-usage=q --cq-level="
-        cmd = f'{pipe} {params}{q} -o {probe_name} - '
+        params = ('vpxenc', '--passes=1', '--pass=1', '--codec=vp9', '--threads=4', '--cpu-used=9', '--end-usage=q', f'--cq-level={q}')
+        cmd = (pipe, (*params, '-o', probe_name, '-'))
 
     elif encoder == 'svt_av1':
-        params = " SvtAv1EncApp -i stdin --preset 8 --rc 0 --qp "
-        cmd = f'{pipe} {params}{q} -b {probe_name}'
+        params = ('SvtAv1EncApp', '-i', 'stdin', '--preset', '8', '--rc', '0', '--qp', f'{q}')
+        cmd = (pipe, (*params, '-b', probe_name, '-'))
 
     elif encoder == 'x264':
-        params = "x264 --log-level error --demuxer y4m - --no-progress --preset slow --crf "
-        cmd = f'{pipe} {params}{q} -o {probe_name}'
+        params = ('x264', '--log-level', 'error', '--demuxer', 'y4m', '-', '--no-progress', '--preset', 'slow', '--crf', f'{q}')
+        cmd = (pipe, (*params, '-o', probe_name, '-'))
 
     return cmd
 

--- a/Av1an/utils.py
+++ b/Av1an/utils.py
@@ -45,25 +45,31 @@ def get_cq(command):
     return int(matches[-1])
 
 
-def man_q(command: str, q: int):
+def man_q(command: list, q: int):
     """Return command with new cq value"""
 
-    if 'aomenc' in command or 'vpxenc' in command:
-        mt = '--cq-level='
-        cmd = command[:command.find(mt) + 11] + str(q) + ' ' + command[command.find(mt) + 13:]
+    adjusted_command = []
+    for cmd in command:
+        if 'aomenc' in command or 'vpxenc' in command:
+            mt = '--cq-level='
+            for x in command:
+                if mt in x:
+                    adjusted_command.append(command[:command.index(x) - 1] + (f'{mt}{q}',) + command[command.index(mt) + 1:])
 
-    elif 'x265' in command or 'x264' in command:
-        mt = '--crf'
-        cmd = command[:command.find(mt) + 6] + str(q) + ' ' +  command[command.find(mt) + 9:]
+        elif 'x265' in command or 'x264' in command:
+            mt = '--crf'
+            adjusted_command.append(command[:command.index(mt)] + (str(q),) + command[command.index(mt) + 2:])
 
-    elif 'rav1e' in command:
-        mt = '--quantizer'
-        cmd = command[:command.find(mt) + 11] + ' ' + str(q) + ' ' +  command[command.find(mt) + 15:]
+        elif 'rav1e' in command:
+            mt = '--quantizer'
+            adjusted_command.append(command[:command.index(mt)] + (str(q),) + command[command.index(mt) + 2:])
 
-    elif 'SvtAv1EncApp' in command:
-        mt = '--qp'
-        cmd = command[:command.find(mt) + 4] + ' ' + str(q) + ' ' +  command[command.find(mt) + 7:]
-    return cmd
+        elif 'SvtAv1EncApp' in command:
+            mt = '--qp'
+            adjusted_command.append(command[:command.index(mt)] + (str(q),) + command[command.index(mt) + 2:])
+        else:
+            adjusted_command.append(cmd)
+    return tuple(adjusted_command)
 
 
 def frame_probe_cv2(source: Path):

--- a/Av1an/utils.py
+++ b/Av1an/utils.py
@@ -45,7 +45,7 @@ def get_cq(command):
     return int(matches[-1])
 
 
-def man_q(command: list, q: int):
+def man_q(command: Tuple[str], q: int):
     """Return command with new cq value"""
 
     adjusted_command = []
@@ -76,4 +76,3 @@ def frame_probe_cv2(source: Path):
     video = cv2.VideoCapture(source.as_posix())
     total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
     return total
-

--- a/Av1an/utils.py
+++ b/Av1an/utils.py
@@ -5,6 +5,7 @@ import re
 import statistics
 import subprocess
 import sys
+from typing import Tuple
 from pathlib import Path
 from subprocess import PIPE
 

--- a/Av1an/vmaf.py
+++ b/Av1an/vmaf.py
@@ -9,6 +9,8 @@ from matplotlib import pyplot as plt
 import json
 import numpy as np
 from .bar import process_pipe
+import shlex
+
 from .chunk import Chunk
 from .utils import terminate
 
@@ -54,20 +56,22 @@ def call_vmaf(chunk: Chunk, encoded: Path, n_threads, model, res, fl_path: Path 
     # For vmaf calculation both source and encoded segment scaled to 1080
     # Also it's required to use -r before both files of vmaf calculation to avoid errors
 
-    cmd = f"ffmpeg -loglevel info -y -thread_queue_size 1024 -hide_banner -r 60 -i {encoded.as_posix()} -r 60 -i - "
+    cmd_in = ('ffmpeg', '-loglevel', 'info', '-y', '-thread_queue_size', '1024', '-hide_banner', '-r', '60', '-i', encoded.as_posix(), '-r', '60', '-i', '-')
 
-    filter_complex = ' -filter_complex '
+    filter_complex = ('-filter_complex',)
 
-    distorted = f'\"[0:v]{select_frames}scale={res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];'
+    distorted = f'[0:v]{select_frames}scale={res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];'
 
-    ref = fr"[1:v]{select_frames}scale={res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];"
+    ref = fr'[1:v]{select_frames}scale={res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];'
 
-    vmaf_filter = f"[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={fl}{mod}{n_threads}\" -f null - "
+    vmaf_filter = f"[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={shlex.quote(fl)}{mod}{n_threads}"
 
-    cmd = cmd + filter_complex + distorted + ref + vmaf_filter
+    cmd_out = ('-f', 'null', '-')
 
-    ffmpeg_gen_pipe = subprocess.Popen(chunk.ffmpeg_gen_cmd.split(), stdout=PIPE, stderr=STDOUT)
-    pipe = subprocess.Popen(cmd, stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT, shell=True, universal_newlines=True)
+    cmd = (*cmd_in, *filter_complex, distorted + ref + vmaf_filter, *cmd_out)
+
+    ffmpeg_gen_pipe = subprocess.Popen(chunk.ffmpeg_gen_cmd, stdout=PIPE, stderr=STDOUT)
+    pipe = subprocess.Popen(cmd, stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT, shell=False, universal_newlines=True)
     process_pipe(pipe)
 
 
@@ -81,7 +85,7 @@ def plot_vmaf(source: Path, encoded: Path, args, model, vmaf_res):
     fl_path = encoded.with_name(f'{encoded.stem}_vmaflog').with_suffix(".json")
 
     # call_vmaf takes a chunk, so make a chunk of the entire source
-    ffmpeg_gen_cmd = f'ffmpeg -y -hide_banner -loglevel error -i {source.as_posix()} {args.pix_format} -f yuv4mpegpipe -'
+    ffmpeg_gen_cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', source.as_posix(), *args.pix_format, '-f', 'yuv4mpegpipe', '-')
     input_chunk = Chunk(args.temp, 0, ffmpeg_gen_cmd, '', 0, 0)
 
     scores = call_vmaf(input_chunk, encoded, 0, model, vmaf_res, fl_path=fl_path)

--- a/Av1an/vmaf.py
+++ b/Av1an/vmaf.py
@@ -71,7 +71,7 @@ def call_vmaf(chunk: Chunk, encoded: Path, n_threads, model, res, fl_path: Path 
     cmd = (*cmd_in, *filter_complex, distorted + ref + vmaf_filter, *cmd_out)
 
     ffmpeg_gen_pipe = subprocess.Popen(chunk.ffmpeg_gen_cmd, stdout=PIPE, stderr=STDOUT)
-    pipe = subprocess.Popen(cmd, stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT, shell=False, universal_newlines=True)
+    pipe = subprocess.Popen(cmd, stdin=ffmpeg_gen_pipe.stdout, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
     process_pipe(pipe)
 
 

--- a/Av1an/vvc.py
+++ b/Av1an/vvc.py
@@ -26,7 +26,7 @@ def to_yuv(chunk: Chunk) -> Path:
     """
     output = get_yuv_file_path(chunk)
 
-    ffmpeg_gen_pipe = subprocess.Popen(chunk.ffmpeg_gen_cmd.split(), stdout=PIPE, stderr=STDOUT)
+    ffmpeg_gen_pipe = subprocess.Popen(chunk.ffmpeg_gen_cmd, stdout=PIPE, stderr=STDOUT)
 
     # TODO: apply ffmpeg filter to the yuv file
     cmd = f'ffmpeg -y -loglevel error -i - -f rawvideo -vf format=yuv420p10le {output.as_posix()}'


### PR DESCRIPTION
This fixes handling path with spaces in them.
av1an stores commands in strings, which are split before passing them to the subproces module. This causes any path with spaces in it to be split in multiple parts.
This patch changes all commands (i hope i found all) to be stored in tupel, which can be directly passed to the subprocess module, eliminating the need for splitting them.
For concat i have used shlex to quote paths, which can quote/escape most (if not all) unicode charactes correctly so that ffmpeg sees the correct path.