### PR TITLE
Fix missing line in split_locations

### DIFF
--- a/Av1an/chunk_queue.py
+++ b/Av1an/chunk_queue.py
@@ -147,6 +147,8 @@ def create_video_queue_select(args: Args, split_locations: List[int]) -> List[Ch
     """
     # add first frame and last frame
     last_frame = frame_probe(args.input)
+    split_locs_fl = [0] + split_locations + [last_frame]
+    
     # pair up adjacent members of this list ex: [0, 10, 20, 30] -> [(0, 10), (10, 20), (20, 30)]
     chunk_boundaries = zip(split_locs_fl, split_locs_fl[1:])
 


### PR DESCRIPTION
This line got lost in in 3d41cafe625c5589460e8711892bbd212b4255c1 when reverting  69a73343b8e9e0dd9f975f28ced9acdb161829ff