### PR TITLE
Fix failing x265 test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.encoder == 'x265'
         run: |
           apt-get install -y ${{ env.x265_deps }}
-          hg clone https://bitbucket.org/multicoreware/x265
+          git clone https://github.com/videolan/x265.git
           cd x265/build/linux
           cmake -G "Unix Makefiles" -DENABLE_SHARED=off ../../source
           make -j$(nproc)


### PR DESCRIPTION
Recently, Bitbucket stopped supporting Mercurial repositories. x265 didn't migrate in time, so their repository can no longer be accessed until they migrate to git. This PR switches from mercurial on bitbucket to git on github for installing x265.