### PR TITLE
Move more encoder specific logic to encoder classes.

### DIFF
--- a/Av1an/chunk.py
+++ b/Av1an/chunk.py
@@ -37,6 +37,7 @@ class Chunk:
         self.pass_cmds: MPCommands = []
         self.frames: int = frames
         self.output_ext: str = output_ext
+        self.vmaf_target_cq = None
 
     def generate_pass_cmds(self, args: Args) -> None:
         """

--- a/Av1an/chunk.py
+++ b/Av1an/chunk.py
@@ -49,20 +49,6 @@ class Chunk:
         encoder = Av1an.ENCODERS[args.encoder]
         self.pass_cmds = encoder.compose_1_pass(args, self) if args.passes == 1 else encoder.compose_2_pass(args, self)
 
-    def remove_first_pass_from_commands(self) -> None:
-        """
-        Removes the first pass command from the list of commands.
-        Used with first pass reuse
-
-        :return: None
-        """
-        # just one pass to begin with, do nothing
-        if len(self.pass_cmds) == 1:
-            return
-
-        # passes >= 2, remove the command for first pass (pass_cmds[0])
-        self.pass_cmds = self.pass_cmds[1:]
-
     def to_dict(self) -> Dict[str, Any]:
         """
         Converts this chunk to a dictionary for easy json serialization

--- a/Av1an/encode.py
+++ b/Av1an/encode.py
@@ -163,18 +163,20 @@ def encode(chunk: Chunk, args: Args):
         if args.vmaf_target:
             target_vmaf_routine(args, chunk)
 
-        # remove first pass command if reusing
-        if args.reuse_first_pass:
-            chunk.remove_first_pass_from_commands()
-
         # if vvc, we need to create a yuv file
         if args.encoder == 'vvc':
             log(f'Creating yuv for chunk {chunk.name}\n')
             vvc_yuv_file = Vvc.to_yuv(chunk)
             log(f'Created yuv for chunk {chunk.name}\n')
 
+        # skip first pass if reusing
+        if args.reuse_first_pass and args.passes >= 2:
+            start = 2
+        else:
+            start = 1
+
         # Run all passes for this chunk
-        for current_pass in range(1, args.passes + 1):
+        for current_pass in range(start, args.passes + 1):
             tqdm_bar(args, chunk, args.encoder, args.counter, chunk_frames, args.passes, current_pass)
 
         # if vvc, we need to delete the yuv file

--- a/Av1an/encode.py
+++ b/Av1an/encode.py
@@ -174,8 +174,8 @@ def encode(chunk: Chunk, args: Args):
             log(f'Created yuv for chunk {chunk.name}\n')
 
         # Run all passes for this chunk
-        for pass_cmd in chunk.pass_cmds:
-            tqdm_bar(chunk.ffmpeg_gen_cmd, pass_cmd, args.encoder, args.counter, chunk_frames, args.passes)
+        for current_pass in range(1, args.passes + 1):
+            tqdm_bar(args, chunk, args.encoder, args.counter, chunk_frames, args.passes, current_pass)
 
         # if vvc, we need to delete the yuv file
         if args.encoder == 'vvc':

--- a/Av1an/encoders/aom.py
+++ b/Av1an/encoders/aom.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class Aom(Encoder):
@@ -15,15 +16,19 @@ class Aom(Encoder):
             output_extension='ivf'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['aomenc', '--passes=1', *a.video_params, '-o', c.output, '-']
+                ['aomenc', '--passes=1', *a.video_params, '-o', output, '-']
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -31,6 +36,16 @@ class Aom(Encoder):
             ),
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['aomenc', '--passes=2', '--pass=2', *a.video_params, f'--fpf={c.fpf}.log', '-o', c.output, '-']
+                ['aomenc', '--passes=2', '--pass=2', *a.video_params, f'--fpf={c.fpf}.log', '-o', output, '-']
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--cq-level=.+")
+        adjusted_command[i] = f'--cq-level={q}'
+
+        return adjusted_command

--- a/Av1an/encoders/rav1e.py
+++ b/Av1an/encoders/rav1e.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class Rav1e(Encoder):
@@ -15,15 +16,19 @@ class Rav1e(Encoder):
             output_extension='ivf'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['rav1e', '-', *a.video_params, '--output', c.output]
+                ['rav1e', '-', *a.video_params, '--output', output]
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -31,6 +36,20 @@ class Rav1e(Encoder):
             ),
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['rav1e', '-', '--second-pass', f'{c.fpf}.stat', *a.video_params, '--output', c.output]
+                ['rav1e', '-', '--second-pass', f'{c.fpf}.stat', *a.video_params, '--output', output]
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--quantizer")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command

--- a/Av1an/encoders/svtav1.py
+++ b/Av1an/encoders/svtav1.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class SvtAv1(Encoder):
@@ -15,15 +16,19 @@ class SvtAv1(Encoder):
             output_extension='ivf'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['SvtAv1EncApp', '-i', 'stdin', *a.video_params, '-b', c.output, '-']
+                ['SvtAv1EncApp', '-i', 'stdin', *a.video_params, '-b', output, '-']
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -32,7 +37,21 @@ class SvtAv1(Encoder):
             ),
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['SvtAv1EncApp', '-i', 'stdin', *a.video_params, '-input-stat-file', f'{c.fpf}.stat', '-b', c.output,
+                ['SvtAv1EncApp', '-i', 'stdin', *a.video_params, '-input-stat-file', f'{c.fpf}.stat', '-b', output,
                  '-']
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--qp")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command

--- a/Av1an/encoders/svtvp9.py
+++ b/Av1an/encoders/svtvp9.py
@@ -2,6 +2,7 @@ from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
 from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class SvtVp9(Encoder):
@@ -25,13 +26,29 @@ class SvtVp9(Encoder):
         return ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', *a.ffmpeg, *a.pix_format, '-bufsize',
                 '50000K', '-f', 'rawvideo', '-']
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 SvtVp9.compose_ffmpeg_raw_pipe(a),
-                ['SvtVp9EncApp', '-i', 'stdin', '-n', f'{c.frames}', *a.video_params, '-b', c.output]
+                ['SvtVp9EncApp', '-i', 'stdin', '-n', f'{c.frames}', *a.video_params, '-b', output]
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
         raise ValueError("SVT-VP9 doesn't support 2 pass")
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"-q")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command

--- a/Av1an/encoders/vpx.py
+++ b/Av1an/encoders/vpx.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class Vpx(Encoder):
@@ -15,15 +16,19 @@ class Vpx(Encoder):
             output_extension='ivf'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['vpxenc', '--passes=1', *a.video_params, '-o', c.output, '-']
+                ['vpxenc', '--passes=1', *a.video_params, '-o', output, '-']
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -31,6 +36,20 @@ class Vpx(Encoder):
             ),
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['vpxenc', '--passes=2', '--pass=2', *a.video_params, f'--fpf={c.fpf}', '-o', c.output, '-']
+                ['vpxenc', '--passes=2', '--pass=2', *a.video_params, f'--fpf={c.fpf}', '-o', output, '-']
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--cq-level=.+")
+        adjusted_command[i] = f'--cq-level={q}'
+
+        return adjusted_command

--- a/Av1an/encoders/vvc.py
+++ b/Av1an/encoders/vvc.py
@@ -5,8 +5,9 @@ from subprocess import PIPE, STDOUT
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class Vvc(Encoder):
@@ -18,18 +19,62 @@ class Vvc(Encoder):
             output_extension='h266'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         yuv_file: str = Vvc.get_yuv_file_path(c).as_posix()
         return [
             CommandPair(
                 [],
                 ['vvc_encoder', '-c', a.vvc_conf, '-i', yuv_file, *a.video_params, '-f', str(c.frames),
-                 '--InputBitDepth=10', '--OutputBitDepth=10', '-b', c.output]
+                 '--InputBitDepth=10', '--OutputBitDepth=10', '-b', output]
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
         raise ValueError('VVC does not support 2 pass encoding')
+
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+
+        i = list_index_of_regex(adjusted_command, r"-q")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command
+
+    def make_pipes(self, a: Args, c: Chunk, passes, current_pass, man_q=None, output=None):
+        """
+        reates a pipe for the given chunk with the given args
+
+        :param a: the Args
+        :param c: the Chunk
+        :param passes: the total number of passes (1 or 2)
+        :param current_pass: the current_pass
+        :param man_q: use a diffrent quality
+        :return: a Pipe attached to the encoders stdout
+        """
+
+        filter_cmd, enc_cmd = self.compose_1_pass(a, c, output)[0] if passes == 1 else \
+                              self.compose_2_pass(a, c, output)[current_pass - 1]
+
+        if man_q:
+            enc_cmd = self.man_q(enc_cmd, man_q)
+        elif c.vmaf_target_cq:
+            enc_cmd = self.man_q(enc_cmd, c.vmaf_target_cq)
+
+        pipe = subprocess.Popen(enc_cmd, stdout=PIPE,
+                                stderr=STDOUT,
+                                universal_newlines=True)
+        return pipe
+
 
     def check_exists(self) -> bool:
         # vvc also requires a special concat executable

--- a/Av1an/encoders/x264.py
+++ b/Av1an/encoders/x264.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class X264(Encoder):
@@ -15,16 +16,20 @@ class X264(Encoder):
             output_extension='mkv'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
                 ['x264', '--stitchable', '--log-level', 'error', '--demuxer', 'y4m', *a.video_params, '-', '-o',
-                 c.output]
+                 output]
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -34,6 +39,20 @@ class X264(Encoder):
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
                 ['x264', '--stitchable', '--log-level', 'error', '--pass', '2', '--demuxer', 'y4m', *a.video_params,
-                 '-', '--stats', f'{c.fpf}.log', '-', '-o', c.output]
+                 '-', '--stats', f'{c.fpf}.log', '-', '-o', output]
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--crf")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command

--- a/Av1an/encoders/x265.py
+++ b/Av1an/encoders/x265.py
@@ -2,8 +2,9 @@ import os
 
 from Av1an.arg_parse import Args
 from Av1an.chunk import Chunk
-from Av1an.commandtypes import MPCommands, CommandPair
+from Av1an.commandtypes import MPCommands, CommandPair, Command
 from Av1an.encoders.encoder import Encoder
+from Av1an.utils import list_index_of_regex
 
 
 class X265(Encoder):
@@ -15,15 +16,19 @@ class X265(Encoder):
             output_extension='mkv'
         )
 
-    def compose_1_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_1_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['x265', '--y4m', *a.video_params, '-', '-o', c.output]
+                ['x265', '--y4m', *a.video_params, '-', '-o', output]
             )
         ]
 
-    def compose_2_pass(self, a: Args, c: Chunk) -> MPCommands:
+    def compose_2_pass(self, a: Args, c: Chunk, output=None) -> MPCommands:
+        if not output:
+            output = c.output
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
@@ -33,6 +38,20 @@ class X265(Encoder):
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
                 ['x265', '--log-level', 'error', '--pass', '2', '--y4m', *a.video_params, '--stats', f'{c.fpf}.log',
-                 '-', '-o', c.output]
+                 '-', '-o', output]
             )
         ]
+
+    def man_q(self, command: Command, q: int):
+        """Return command with new cq value
+
+        :param command: old command
+        :param q: new cq value
+        :return: command with new cq value"""
+
+        adjusted_command = command.copy()
+
+        i = list_index_of_regex(adjusted_command, r"--crf")
+        adjusted_command[i + 1] = f'{q}'
+
+        return adjusted_command

--- a/Av1an/target_vmaf.py
+++ b/Av1an/target_vmaf.py
@@ -14,9 +14,9 @@ from .bar import make_pipes, process_pipe
 from .chunk import Chunk
 from .commandtypes import CommandPair
 from .logger import log
-from .utils import man_q
 from .utils import terminate
 from .vmaf import call_vmaf, read_vmaf_json
+from .encoders import ENCODERS
 
 
 def target_vmaf_routine(args: Args, chunk: Chunk):
@@ -28,8 +28,7 @@ def target_vmaf_routine(args: Args, chunk: Chunk):
     :param chunk: the Chunk
     :return: None
     """
-    tg_cq = target_vmaf(chunk, args)
-    chunk.pass_cmds = [CommandPair(f, man_q(e, tg_cq)) for f, e in chunk.pass_cmds]
+    chunk.vmaf_target_cq = target_vmaf(chunk, args)
 
 
 def gen_probes_names(chunk: Chunk, q):
@@ -38,46 +37,11 @@ def gen_probes_names(chunk: Chunk, q):
     return chunk.fake_input_path.with_name(f'v_{q}{chunk.name}').with_suffix('.ivf')
 
 
-def probe_cmd(chunk: Chunk, q, ffmpeg_pipe, encoder, vmaf_rate) -> CommandPair:
-    """Generate and return commands for probes at set Q values
-    """
-    pipe = ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', '-', '-vf', f'select=not(mod(n\\,{vmaf_rate}))',
-            *ffmpeg_pipe]
-
+def probe_pipe(args: Args, chunk: Chunk, q):
     probe_name = gen_probes_names(chunk, q).with_suffix('.ivf').as_posix()
+    pipe = ENCODERS[args.encoder].make_pipes(args, chunk, 1, 1, q, probe_name)
 
-    if encoder == 'aom':
-        params = ['aomenc', '--passes=1', '--threads=8', '--end-usage=q', '--cpu-used=6', f'--cq-level={q}']
-        cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
-
-    elif encoder == 'x265':
-        params = ['x265', '--log-level', '0', '--no-progress', '--y4m', '--preset', 'faster', '--crf', f'{q}']
-        cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
-
-    elif encoder == 'rav1e':
-        params = ['rav1e', '-s', '10', '--tiles', '8', '--quantizer', f'{q}']
-        cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
-
-    elif encoder == 'vpx':
-        params = ['vpxenc', '--passes=1', '--pass=1', '--codec=vp9', '--threads=4', '--cpu-used=9', '--end-usage=q',
-                  f'--cq-level={q}']
-        cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
-
-    elif encoder == 'svt_av1':
-        params = ['SvtAv1EncApp', '-i', 'stdin', '--preset', '8', '--rc', '0', '--qp', f'{q}']
-        cmd = CommandPair(pipe, [*params, '-b', probe_name, '-'])
-
-    elif encoder == 'svt_vp9':
-        params = ['SvtVp9EncApp', '-i', 'stdin', '-enc-mode', '8', '-q', f'{q}']
-        # TODO: pipe needs to output rawvideo
-        cmd = CommandPair(pipe, [*params, '-b', probe_name, '-'])
-
-    elif encoder == 'x264':
-        params = ['x264', '--log-level', 'error', '--demuxer', 'y4m', '-', '--no-progress', '--preset', 'slow', '--crf',
-                  f'{q}']
-        cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
-
-    return cmd
+    return pipe
 
 
 def get_target_q(scores, vmaf_target):
@@ -129,10 +93,9 @@ def plot_probes(args, vmaf_cq, chunk: Chunk, frames):
     plt.close()
 
 
-def vmaf_probe(chunk: Chunk, q, args):
-    cmd = probe_cmd(chunk, q, args.ffmpeg_pipe, args.encoder, args.vmaf_rate)
+def vmaf_probe(chunk: Chunk, q, args: Args):
 
-    pipe = make_pipes(chunk.ffmpeg_gen_cmd, cmd)
+    pipe = probe_pipe(args, chunk, q)
     process_pipe(pipe)
 
     file = call_vmaf(chunk, gen_probes_names(chunk, q), args.n_threads, args.vmaf_path, args.vmaf_res,
@@ -166,7 +129,7 @@ def weighted_search(num1, vmaf1, num2, vmaf2, target):
     return new_point
 
 
-def target_vmaf_search(chunk: Chunk, frames, args):
+def target_vmaf_search(chunk: Chunk, frames, args: Args):
     vmaf_cq = []
     q_list = []
     score = 0

--- a/Av1an/utils.py
+++ b/Av1an/utils.py
@@ -59,30 +59,6 @@ def list_index_of_regex(lst: List[str], regex_str: str) -> int:
     raise ValueError(f'{reg} is not in list')
 
 
-def man_q(command: Command, q: int):
-    """Return command with new cq value"""
-
-    adjusted_command = command.copy()
-
-    if ('aomenc' in command) or ('vpxenc' in command):
-        i = list_index_of_regex(adjusted_command, r"--cq-level=.+")
-        adjusted_command[i] = f'--cq-level={q}'
-
-    elif ('x265' in command) or ('x264' in command):
-        i = list_index_of_regex(adjusted_command, r"--crf")
-        adjusted_command[i + 1] = f'{q}'
-
-    elif 'rav1e' in command:
-        i = list_index_of_regex(adjusted_command, r"--quantizer")
-        adjusted_command[i + 1] = f'{q}'
-
-    elif 'SvtAv1EncApp' in command:
-        i = list_index_of_regex(adjusted_command, r"--qp")
-        adjusted_command[i + 1] = f'{q}'
-
-    return adjusted_command
-
-
 def frame_probe_cv2(source: Path):
     video = cv2.VideoCapture(source.as_posix())
     total = int(video.get(cv2.CAP_PROP_FRAME_COUNT))


### PR DESCRIPTION
Ideally everything encoder specific should be included in the encoder classes, so that the rest of the program can treat every encoder in the same way and does not need to care which encoder is used.

todo:
- move match_aom/vpx/rav1e ... from bar to encoder
- probably some fixes and cleanups I missed.