### PR TITLE
Explicitly convert path to string for windows support. Fixes #131

### DIFF
--- a/Av1an/ffmpeg.py
+++ b/Av1an/ffmpeg.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 import re
+import shlex
 import subprocess
 from pathlib import Path
 from subprocess import PIPE, STDOUT
@@ -51,12 +52,15 @@ def extract_audio(input_vid: Path, temp, audio_params):
     log(f'Audio processing\nParams: {" ".join(audio_params)}\n')
     audio_file = temp / 'audio.mkv'
 
+    input_vid_posix = shlex.quote(input_vid.as_posix())
+
     # Checking is source have audio track
-    check = ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-ss', '0', '-i', input_vid, '-t', '0', '-vn',
-             '-c:a', 'copy', '-f', 'null', '-']
+    check = ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-ss', '0', '-i', input_vid_posix, '-t', '0',
+             '-vn', '-c:a', 'copy', '-f', 'null', '-']
     is_audio_here = len(subprocess.run(check, stdout=PIPE, stderr=STDOUT).stdout) == 0
 
     # If source have audio track - process it
     if is_audio_here:
-        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid, '-vn', *audio_params, audio_file)
+        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid_posix, '-vn', *audio_params,
+               shlex.quote(audio_file.as_posix()))
         subprocess.run(cmd)


### PR DESCRIPTION
`pathlib` uses different classes for windows (`WindowsPath`) and linux/mac (`PosixPath`) with different behavior. We need to explicitly convert paths to strings with `as_posix()` to work on windows.