### PR TITLE
Map all audio tracks in extract_audio()

### DIFF
--- a/Av1an/ffmpeg.py
+++ b/Av1an/ffmpeg.py
@@ -59,6 +59,6 @@ def extract_audio(input_vid: Path, temp, audio_params):
 
     # If source have audio track - process it
     if is_audio_here:
-        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid.as_posix(), '-vn', *audio_params,
-               audio_file.as_posix())
+        cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid.as_posix(),
+               '-map', '0', '-map', '-0:v', *audio_params, audio_file.as_posix())
         subprocess.run(cmd)


### PR DESCRIPTION
Map all audio and subtitle tracks for the audio file instead of just the first (ffmpeg default).