### PR TITLE
Support SVT-AV1 -q for target vmaf

### DIFF
--- a/Av1an/encoders/svtav1.py
+++ b/Av1an/encoders/svtav1.py
@@ -47,7 +47,7 @@ class SvtAv1(Encoder):
 
         adjusted_command = command.copy()
 
-        i = list_index_of_regex(adjusted_command, r"--qp")
+        i = list_index_of_regex(adjusted_command, r"(--qp|-q)")
         adjusted_command[i + 1] = f'{q}'
 
         return adjusted_command


### PR DESCRIPTION
SVT-AV1 allows for setting the q value with `--qp` or `-q`, but target vmaf was only looking for `--qp`.