### PR TITLE
Fix extra tqdm print

### DIFF
--- a/Av1an/bar.py
+++ b/Av1an/bar.py
@@ -39,6 +39,9 @@ class Counter:
             self.tqdm_bar.reset(self.left)
             self.first_update = False
         self.tqdm_bar.update(value)
+    
+    def close(self):
+        self.tqdm_bar.close()
 
 
 BaseManager.register('Counter', Counter)

--- a/Av1an/encode.py
+++ b/Av1an/encode.py
@@ -128,6 +128,7 @@ def startup(args: Args, chunk_queue: List[Chunk]):
     counter = Manager().Counter(total, initial)
     args.counter = counter
 
+
 def encoding_loop(args: Args, chunk_queue: List[Chunk]):
     """Creating process pool for encoders, creating progress bar."""
     if args.workers != 0:
@@ -140,6 +141,7 @@ def encoding_loop(args: Args, chunk_queue: List[Chunk]):
                     _, _, exc_tb = sys.exc_info()
                     print(f'Encoding error {exc}\nAt line {exc_tb.tb_lineno}')
                     terminate()
+    args.counter.close()
 
 
 def encode(chunk: Chunk, args: Args):


### PR DESCRIPTION
`tqdm` bar has an `__exit__` method run when the bar is destroyed on program exit. This causes the bar to be printed out after the finished message. Calling `tqdm.close()` explicitly before printing the finish method fixes this problem.

Before:
```
Queue: 2 Workers: 16 Passes: 2
Params: --cpu-used=6 --end-usage=q --cq-level=40
 99%|████████████████████████████████████████▋| 280/282 [00:54<00:00,  4.86fr/s]Finished: 92.2s

100%|█████████████████████████████████████████| 282/282 [00:54<00:00,  5.15fr/s]
```

After:
```
Queue: 2 Workers: 16 Passes: 2
Params: --cpu-used=6 --end-usage=q --cq-level=40
100%|█████████████████████████████████████████| 282/282 [00:55<00:00,  5.12fr/s]
Finished: 92.4s
```