### PR TITLE
use log to improve linearity

### DIFF
--- a/Av1an/VMAF/target_vmaf.py
+++ b/Av1an/VMAF/target_vmaf.py
@@ -210,8 +210,8 @@ def weighted_search(num1, vmaf1, num2, vmaf2, target):
     :return: Q for new probe
     """
 
-    dif1 = abs(target - vmaf2)
-    dif2 = abs(target - vmaf1)
+    dif1 = abs(-math.log(1-target/100) - (-math.log(1-vmaf2/100)))
+    dif2 = abs(-math.log(1-target/100) - (-math.log(1-vmaf1/100)))
 
     tot = dif1 + dif2
 


### PR DESCRIPTION
This transformation of vmaf values maps more linearly to cq values, which should improve the search accuracy.

![vmaf vs cq](https://cdn.discordapp.com/attachments/686197633181810720/751408070390841424/image_2020-09-04_04-46-26.png)

![transformed vmaf vs cq](https://cdn.discordapp.com/attachments/686197633181810720/751408110756954112/image_2020-09-04_04-47-04.png)