### PR TITLE
Fix English & run validate params after encoder is set up

### DIFF
--- a/Startup/setup.py
+++ b/Startup/setup.py
@@ -49,8 +49,6 @@ def check_exes(args: Args):
         print('No ffmpeg')
         terminate()
 
-    validate_inputs(args)
-
     if args.chunk_method == 'vs_ffms2' and (not find_executable('vspipe')):
         print('vspipe executable not found')
         terminate()
@@ -74,7 +72,9 @@ def setup_encoder(args: Args):
         args.passes = encoder.default_passes
 
     args.video_params = encoder.default_args if args.video_params is None \
-    else shlex.split(args.video_params)
+        else shlex.split(args.video_params)
+
+    validate_inputs(args)
 
 
 def startup_check(args: Args):

--- a/Startup/validate_commands.py
+++ b/Startup/validate_commands.py
@@ -1,12 +1,11 @@
 import re
 import subprocess
-import shlex
 import sys
 from subprocess import PIPE
 from Encoders import ENCODERS
 from typing import List, Union
-from fuzzywuzzy import fuzz
 from fuzzywuzzy import process
+
 
 def run_command(command: List) -> str:
     r = subprocess.run(command, stdout=PIPE, stderr=PIPE)
@@ -16,7 +15,7 @@ def run_command(command: List) -> str:
 def sort_params(params: List) -> List:
     """
     Sort arguments to 2 list based on -/--
-    Return 2 lists of argumens
+    Return 2 lists of arguments
     """
     # Sort Params
     one_params = []
@@ -59,19 +58,18 @@ def get_encoder_args(args):
 
 
 def validate_inputs(args):
-    video_params = args.video_params.split() if args.video_params \
-            else ENCODERS[args.encoder].default_args
+    video_params = args.video_params
 
     video_params = [x.split('=')[0] for x in video_params if not x.isdigit()]
 
     parameters = get_encoder_args(args)
 
-    suggested = [( x, suggest_fix(x, parameters)) for x in match_commands(video_params, parameters)]
+    suggested = [(x, suggest_fix(x, parameters)) for x in match_commands(video_params, parameters)]
 
     if len(suggested) > 0:
-        print('Invalid commands:')
+        print('WARNING: Invalid params:')
         for cmd in suggested:
-            print(f"{cmd[0]} suggest: {cmd[1][0]}")
-        print('If you sure in validity of your commands: use --force')
+            print(f"'{cmd[0]}' isn't a valid param for {args.encoder}. Did you mean '{cmd[1][0]}'?")
         if not args.force:
+            print('To continue anyway, run Av1an with --force')
             sys.exit(0)


### PR DESCRIPTION
Clears up the wording of the parameter validation warning and fixes the SVT-VP9 error when no video params are specified due to `validate_input` being run before `SvtVp9.is_valid`.

Fixes #158