### PR TITLE
Fix x265 commands

### DIFF
--- a/Startup/validate_commands.py
+++ b/Startup/validate_commands.py
@@ -61,7 +61,7 @@ def validate_inputs(args):
     video_params = args.video_params
 
     video_params = [x.split('=')[0] for x in video_params if x[0] == "-"]
-    
+
     parameters = get_encoder_args(args)
 
     suggested = [(x, suggest_fix(x, parameters)) for x in match_commands(video_params, parameters)]

--- a/Startup/validate_commands.py
+++ b/Startup/validate_commands.py
@@ -61,7 +61,7 @@ def validate_inputs(args):
     video_params = args.video_params
 
     video_params = [x.split('=')[0] for x in video_params if x[0] == "-"]
-
+    
     parameters = get_encoder_args(args)
 
     suggested = [(x, suggest_fix(x, parameters)) for x in match_commands(video_params, parameters)]
@@ -72,4 +72,4 @@ def validate_inputs(args):
             print(f"'{cmd[0]}' isn't a valid param for {args.encoder}. Did you mean '{cmd[1][0]}'?")
         if not args.force:
             print('To continue anyway, run Av1an with --force')
-            sys.exit(0)
+            sys.exit(1)

--- a/Startup/validate_commands.py
+++ b/Startup/validate_commands.py
@@ -60,7 +60,7 @@ def get_encoder_args(args):
 def validate_inputs(args):
     video_params = args.video_params
 
-    video_params = [x.split('=')[0] for x in video_params if not x.isdigit()]
+    video_params = [x.split('=')[0] for x in video_params if x[0] == "-"]
 
     parameters = get_encoder_args(args)
 


### PR DESCRIPTION
x265 was failing because the video parameter list was only discarding digits but not string arguments. So it was doing a check on ["-p","slow","--crf"] so when it got to slow and checked if it was a validate argument for x265 it was failing. This now changes it to generate the list with everything that starts with - which should be all the flags and leave out any strings or numbers. 

Changes the exit code to 1 if not using --force to report that there was an error.

Signed-off-by: Luis Garcia <luigi311.lg@gmail.com>