### PR TITLE
Fix output double suffix, default will append _{encoder} instead of _av1

### DIFF
--- a/Startup/setup.py
+++ b/Startup/setup.py
@@ -162,5 +162,5 @@ def outputs_filenames(args: Args):
     :param args: the Args
     """
     suffix = '.mkv'
-    args.output_file = Path(f'{args.output_file}{suffix}') if args.output_file \
-                  else Path(f'{args.input.stem}_av1{suffix}')
+    args.output_file = Path(f'{args.output_file.stem}{suffix}') if args.output_file \
+                  else Path(f'{args.input.stem}_{args.encoder}{suffix}')


### PR DESCRIPTION
Fix double suffix issue and if no output is provided it will now use _{encoder} instead of always appending _av1 even when not encoding in av1.

Signed-off-by: Luis Garcia <luigi311.lg@gmail.com>