### PR TITLE
Improve extract_audio ffmpeg command.

### DIFF
--- a/Av1an/ffmpeg.py
+++ b/Av1an/ffmpeg.py
@@ -64,5 +64,5 @@ def extract_audio(input_vid: Path, temp, audio_params):
     # If source have audio track - process it
     if is_audio_here:
         cmd = ('ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-i', input_vid.as_posix(),
-               '-map', '0', '-map', '-0:v', *audio_params, audio_file.as_posix())
+               '-vn', '-sn', '-dn', *audio_params, audio_file.as_posix())
         subprocess.run(cmd)


### PR DESCRIPTION
Since we only have one input file, the '-map 0' was unnecessary,
and using '-vn' is a more reliable method for disabling video.

Added '-sn' and '-dn' for good measure, which disables subtitles and
data streams, respectively.

Fixes #151