### PR TITLE
Vapoursynth Support - Part 1

### DIFF
--- a/Av1an/arg_parse.py
+++ b/Av1an/arg_parse.py
@@ -73,6 +73,9 @@ class Args(object):
         # Inner
         self.counter = None
 
+        # Vapoursynth
+        self.is_vs: bool = None
+
 
 def arg_parsing():
     """Command line parsing"""

--- a/Av1an/ffmpeg.py
+++ b/Av1an/ffmpeg.py
@@ -9,10 +9,10 @@ from typing import List
 from .logger import log
 
 
-def frame_probe(source: Path):
+def frame_probe_ffmpeg(source: Path):
     """
     Get frame count.
-    Direct counting of frame count. Slow, Precise.
+    Direct counting of frame count using ffmpeg. Slow, Precise.
     :param: source: Path to input file
     """
     cmd = ["ffmpeg", "-hide_banner", "-i", source.as_posix(), "-map", "0:v:0", "-f", "null", "-"]

--- a/Av1an/split.py
+++ b/Av1an/split.py
@@ -8,10 +8,9 @@ from typing import List
 from numpy import linspace
 
 from .arg_parse import Args
-from .ffmpeg import frame_probe, get_keyframes
 from Scenedetection import aom_keyframes, AOM_KEYFRAMES_DEFAULT_PARAMS, pyscene
 from .logger import log
-from .utils import terminate
+from .utils import terminate, frame_probe
 
 
 def split_routine(args: Args, resuming: bool) -> List[int]:
@@ -147,7 +146,7 @@ def calc_split_locations(args: Args) -> List[int]:
     if args.split_method == 'pyscene':
         log(f'Starting scene detection Threshold: {args.threshold}, Min_scene_length: {args.min_scene_len}\n')
         try:
-            sc = pyscene(args.input, args.threshold, args.min_scene_len)
+            sc = pyscene(args.input, args.threshold, args.min_scene_len, args.is_vs, args.temp)
         except Exception as e:
             log(f'Error in PySceneDetect: {e}\n')
             print(f'Error in PySceneDetect{e}\n')
@@ -156,7 +155,7 @@ def calc_split_locations(args: Args) -> List[int]:
     # Splitting based on aom keyframe placement
     elif args.split_method == 'aom_keyframes':
         stat_file = args.temp / 'keyframes.log'
-        sc = aom_keyframes(args.input, stat_file, args.min_scene_len, args.ffmpeg_pipe, aom_keyframes_params)
+        sc = aom_keyframes(args.input, stat_file, args.min_scene_len, args.ffmpeg_pipe, aom_keyframes_params, args.is_vs)
     else:
         print(f'No valid split option: {args.split_method}\nValid options: "pyscene", "aom_keyframes"')
         terminate()

--- a/Av1an/vapoursynth.py
+++ b/Av1an/vapoursynth.py
@@ -1,0 +1,26 @@
+import re
+import subprocess
+from subprocess import PIPE 
+from pathlib import Path
+
+VS_EXTENSIONS = ['.vpy', '.py']
+
+
+def is_vapoursynth(path: Path):
+    return path.suffix in VS_EXTENSIONS
+
+
+def frame_probe_vspipe(source: Path):
+    """
+    Get frame count from vspipe.
+    :param: source: Path to input vapoursynth (vpy/py) file
+    """
+    cmd = ["vspipe", "--info", "-i", source.as_posix(), "-"]
+    r = subprocess.run(cmd, stdout=PIPE, stderr=PIPE)
+    # TODO: This regex process is overbuilt, as the output of vspipe is very simple and only has one "Frames" result.
+    matches = re.findall(r"Frames:\s*([0-9]+)\s", r.stderr.decode("utf-8") + r.stdout.decode("utf-8"))
+    return int(matches[-1])
+
+
+def compose_vapoursynth_pipe(source: Path, fifo: Path = None):
+    return ["vspipe", "-y", source.as_posix(), fifo.as_posix() if fifo else "-"]

--- a/Scenedetection/pyscene.py
+++ b/Scenedetection/pyscene.py
@@ -1,13 +1,19 @@
 #!/bin/env python
 
+from os import mkfifo
+from subprocess import Popen
+
 from scenedetect.detectors import ContentDetector
 from scenedetect.scene_manager import SceneManager
 from scenedetect.video_manager import VideoManager
+from scenedetect.frame_timecode import FrameTimecode
 
 from Av1an.logger import log
+from Av1an.utils import frame_probe
+from Av1an.vapoursynth import compose_vapoursynth_pipe
 
 
-def pyscene(video, threshold, min_scene_len):
+def pyscene(video, threshold, min_scene_len, is_vs, temp):
     """
     Running PySceneDetect detection on source video for segmenting.
     Optimal threshold settings 15-50
@@ -15,14 +21,28 @@ def pyscene(video, threshold, min_scene_len):
     if not min_scene_len:
         min_scene_len = 15
 
-    log(f'Starting PySceneDetect:\nThreshold: {threshold}, Min scene lenght: {min_scene_len}\n')
-    video_manager = VideoManager([str(video)])
+    log(f'Starting PySceneDetect:\nThreshold: {threshold}, Min scene lenght: {min_scene_len}, Is Vapoursynth input: {is_vs}\n')
+
+    if is_vs:
+        # Handling vapoursynth, so we need to create a named pipe to feed to VideoManager.
+        # TODO: Do we clean this up after pyscenedetect has run, or leave it as part of the temp dir, where it will be cleaned up later?
+        vspipe_fifo = temp / 'vspipe.y4m'
+        mkfifo(vspipe_fifo)
+        vspipe_cmd = compose_vapoursynth_pipe(video, vspipe_fifo)
+        vspipe_process = Popen(vspipe_cmd)
+
+        # Get number of frames from Vapoursynth script to pass as duration to VideoManager.
+        # We need to pass the number of frames to the manager, otherwise it won't close the
+        # receiving end of the pipe, and will simply sit waiting after vspipe has finished sending
+        # the last frame.
+        frames = frame_probe(video)
+
+    video_manager = VideoManager([str(vspipe_fifo if is_vs else video)])
     scene_manager = SceneManager()
     scene_manager.add_detector(ContentDetector(threshold=threshold, min_scene_len=min_scene_len))
     base_timecode = video_manager.get_base_timecode()
 
-    # Work on whole video
-    video_manager.set_duration()
+    video_manager.set_duration(duration=FrameTimecode(frames, video_manager.get_framerate()) if is_vs else None)
 
     # Set downscale factor to improve processing speed.
     video_manager.set_downscale_factor()
@@ -31,6 +51,10 @@ def pyscene(video, threshold, min_scene_len):
     video_manager.start()
 
     scene_manager.detect_scenes(frame_source=video_manager, show_progress=True)
+
+    # If fed using a vspipe process, ensure that vspipe has finished.
+    if is_vs:
+        vspipe_process.wait()
 
     # Obtain list of detected scenes.
     scene_list = scene_manager.get_scene_list(base_timecode)


### PR DESCRIPTION
Supports:
  * Pyscenedetect chunking
  * aom_keyframes chunking
  * Automatic detection of input as Vapoursynth script.
  * Cleaned up fast frame counting into unified method "frame_probe_fast"

Areas for improvement:
  * Windows support
  * vspipe arg passing
  * Update README with details on Vapoursynth integration
  * Cleanup piping command generation that's sprinkled throughout the project, including moving ffmpeg pipe generation into the `ffmpeg.py` file.
  * Clean up names that include "ffmpeg" in a few places, when they aren't actually guarranteed to be ffmpeg any more (and may be vspipe instead). 

Fixes #173