### PR TITLE
Pass frames to x265 for a given chunk.

### DIFF
--- a/Encoders/x265.py
+++ b/Encoders/x265.py
@@ -24,7 +24,7 @@ class X265(Encoder):
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['x265', '--y4m', *a.video_params, '-', '-o', output]
+                ['x265', '--y4m', '--frames', str(c.frames), *a.video_params, '-', '-o', output]
             )
         ]
 
@@ -32,12 +32,12 @@ class X265(Encoder):
         return [
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['x265', '--log-level', 'error', '--no-progress', '--pass', '1', '--y4m', *a.video_params, '--stats', f'{c.fpf}.log',
+                ['x265', '--log-level', 'error', '--no-progress', '--pass', '1', '--y4m', '--frames', str(c.frames), *a.video_params, '--stats', f'{c.fpf}.log',
                  '-', '-o', os.devnull]
             ),
             CommandPair(
                 Encoder.compose_ffmpeg_pipe(a),
-                ['x265', '--log-level', 'error', '--pass', '2', '--y4m', *a.video_params, '--stats', f'{c.fpf}.log',
+                ['x265', '--log-level', 'error', '--pass', '2', '--y4m', '--frames', str(c.frames), *a.video_params, '--stats', f'{c.fpf}.log',
                  '-', '-o', output]
             )
         ]
@@ -62,4 +62,4 @@ class X265(Encoder):
         :param line: one line of text output from the encoder
         :return: match object from re.search matching the number of encoded frames"""
 
-        return re.search(r"^(\d+)", line)
+        return re.search(r"^\[.*\]\s(\d+)\/\d+", line)


### PR DESCRIPTION
Per the x265 documentation, if `--frames` is specified, the rate control
can use the information for better encoding decisions.

In addition, we should be encoding an exact number of frames anyways.

This might benefit x264 as well, but I'm not sure if that's guarranteed.
It's trivial to add, so it may be worth adding anyways.

See docs around `--frames` option: https://x265.readthedocs.io/en/master/cli.html#input-output-file-options

Testing note: I tested what happens with something like vspipe returns
less than the specified number of frames and things work "just fine" -
the encoder exits with no error message and the stream isn't corrupted.