### PR TITLE
remove fuzzywuzzy/levenshtein and use difflib sequencematcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Install requirements
         run: |
           apt-get update && apt-get install -y ${{ env.deps }}
-          pip3 install --no-cache-dir -r requirements.txt 
-          pip3 install --no-cache-dir ${{ env.pip_deps }}
+          pip3 install --no-cache-dir -r requirements.txt
       - name: Download videos
         run: |
           for url in raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master randomderp.com; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   deps: python3-dev libglib2.0-0 libsm6 libxext6 libxrender-dev libgl1-mesa-glx
-  pip_deps: python-Levenshtein
   DEBIAN_FRONTEND: noninteractive
 
 jobs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ tqdm
 psutil
 scipy
 matplotlib
-fuzzywuzzy

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ REQUIRES = [
     'psutil',
     'scipy',
     'matplotlib',
-    'fuzzywuzzy',
-    'python-Levenshtein',
 ]
 
 with open("README.md", "r") as f:


### PR DESCRIPTION
I also found it to be more accurate for this use case

levenshtein:
'--kxf-max-dusst' isn't a valid param for aom. Did you mean '--qm-max'?

sequencematcher:
'--kxf-max-dusst' isn't a valid param for aom. Did you mean '--kf-max-dist'?
