### PR TITLE
Add testing for vmaf and vmaf_plots, move non target_quality specific functions to vmaf.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,8 @@ jobs:
             flags: -v " --threads=2 --cpu-used=6 --end-usage=q --cq-level=30 " --target_quality 95
           - name: vmaf
             flags: --vmaf
+          - name: vmaf plot
+            flags: --vmaf_plots
           - name: extra splits
             flags: -xs 10
           - name: split method

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,8 @@ jobs:
             flags: -v " --threads=2 --cpu-used=6 --end-usage=q --cq-level=30 "
           - name: target quality
             flags: -v " --threads=2 --cpu-used=6 --end-usage=q --cq-level=30 " --target_quality 95
+          - name: vmaf
+            flags: --vmaf
           - name: extra splits
             flags: -xs 10
           - name: split method
@@ -74,4 +76,4 @@ jobs:
         run: |
           ./av1an.py -i bus_cif.y4m -tr 20 --keep -o "bus_cif.mkv" ${{ matrix.flags }}
           du -h bus_cif.mkv
-          ls -a
+          tree -a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - "*.md"
 
 env:
-  deps: python3-dev libglib2.0-0 libsm6 libxext6 libxrender-dev libgl1-mesa-glx
+  deps: python3-dev libglib2.0-0 libsm6 libxext6 libxrender-dev libgl1-mesa-glx tree
   DEBIAN_FRONTEND: noninteractive
 
 jobs:

--- a/TargetQuality/per_shot.py
+++ b/TargetQuality/per_shot.py
@@ -5,9 +5,6 @@ from math import log as ln
 
 import subprocess
 from subprocess import STDOUT, PIPE
-from .target_quality import vmaf_probe, transform_vmaf, weighted_search, get_target_q, \
-    adapt_probing_rate, read_weighted_vmaf
-from Projects import Project
 
 import matplotlib
 from matplotlib import pyplot as plt
@@ -15,6 +12,10 @@ from matplotlib import pyplot as plt
 import numpy as np
 from scipy import interpolate
 
+from .target_quality import vmaf_probe, weighted_search, get_target_q, \
+    adapt_probing_rate
+from VMAF import read_weighted_vmaf, transform_vmaf
+from Projects import Project
 from Av1an.bar import process_pipe
 from Chunks.chunk import Chunk
 from Av1an.commandtypes import CommandPair, Command
@@ -198,4 +199,3 @@ def per_shot_target_quality(chunk: Chunk, args: Project):
         plot_probes(args, vmaf_cq, chunk, frames)
 
     return q
-

--- a/TargetQuality/target_quality.py
+++ b/TargetQuality/target_quality.py
@@ -1,59 +1,14 @@
 import subprocess
 from subprocess import STDOUT, PIPE
-from Av1an.commandtypes import CommandPair, Command
-from Projects import Project
-from VMAF import call_vmaf, read_json
-from Chunks.chunk import Chunk
-from math import log as ln
-from math import ceil, floor
-from Av1an.bar import process_pipe
+
 import numpy as np
 from scipy import interpolate
 
-
-def transform_vmaf(vmaf):
-    if vmaf<99.99:
-        return -ln(1-vmaf/100)
-    else:
-        # return -ln(1-99.99/100)
-        return 9.210340371976184
-
-
-def read_weighted_vmaf(file, percentile=0):
-    """Reads vmaf file with vmaf scores in it and return N percentile score from it.
-
-    :return: N percentile score
-    :rtype: float
-    """
-
-    jsn = read_json(file)
-
-    vmafs = sorted([x['metrics']['vmaf'] for x in jsn['frames']])
-
-    percentile = percentile if percentile != 0 else 0.25
-    score = get_percentile(vmafs, percentile)
-
-    return round(score, 2)
-
-
-def get_percentile(scores, percent):
-    """
-    Find the percentile of a list of values.
-    :param scores: - is a list of values. Note N MUST BE already sorted.
-    :param percent: - a float value from 0.0 to 1.0.
-    :return: - the percentile of the values
-    """
-    scores = sorted(scores)
-    key = lambda x: x
-
-    k = (len(scores)-1) * percent
-    f = floor(k)
-    c = ceil(k)
-    if f == c:
-        return key(scores[int(k)])
-    d0 = (scores[int(f)]) * (c-k)
-    d1 = (scores[int(c)]) * (k-f)
-    return d0+d1
+from Av1an.commandtypes import CommandPair, Command
+from Projects import Project
+from VMAF import call_vmaf, read_json, transform_vmaf
+from Chunks.chunk import Chunk
+from Av1an.bar import process_pipe
 
 
 def adapt_probing_rate(rate, frames):
@@ -225,7 +180,3 @@ def get_closest(q_list, q, positive=True):
         q_list = [x for x in q_list if x < q]
 
     return min(q_list, key=lambda x: abs(x - q))
-
-
-
-


### PR DESCRIPTION
This will add testing for the vmaf and vmaf_plots arguments since they are currently broken and gets changed every so often.

I also moved generic vmaf functions out of the tartget_quality file since they do not belong there.

Action will also use tree -a instead of ls -a so a more complete output is shown

vmaf and vmaf_plots are currently broken due to the get_percentile function not working