### PR TITLE
input: to be able to have several directories and files

### DIFF
--- a/Startup/file_validation.py
+++ b/Startup/file_validation.py
@@ -8,16 +8,19 @@ def process_inputs(inputs):
         print('No input file')
         exit()
 
-    if inputs[0].is_dir():
-        inputs = [x for x in inputs[0].iterdir() if x.suffix in (".mkv", ".mp4", ".mov", ".avi", ".flv", ".m2ts")]
+    input_list = []
 
-    valid = np.array([i.exists() for i in inputs])
+    for item in inputs:
+        if item.is_dir():
+            new_inputs = [x for x in item.iterdir() if x.suffix in (".mkv", ".mp4", ".mov", ".avi", ".flv", ".m2ts")]
+            input_list.extend(new_inputs)
+        else:
+            input_list.append(item)
+
+    valid = np.array([i.exists() for i in input_list])
 
     if not all(valid):
-        print(f'File(s) do not exist: {", ".join([str(inputs[i]) for i in np.where(not valid)[0]])}')
+        print(f'File(s) do not exist: {", ".join([str(input_list[i]) for i in np.where(not valid)[0]])}')
         exit()
 
-    return inputs
-
-
-
+    return input_list


### PR DESCRIPTION
Currently in the inputs list if a directory is in first position the following inputs are ignored. The PR allows to have several directories or files in input, in any order. All input files and files in directories will be taken into account.

For example if we have : -i dir1 file1 dir2 file2
the files taken into account will be file1, file2 and all relevant files from dir1 and dir2