### PR TITLE
Qencoder compatibility patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ With your own parameters:
 
     --keep                  Not deleting temprally folders after encode finished.
 
+    -q --quiet              Do not print tqdm to terminal.
+
     -log --logging          Path to .log file(By default created in temp folder)
 
     --temp                  Set path for temporally folders. Default: .temp
@@ -103,7 +105,10 @@ With your own parameters:
                             `aom_keyframes` - using stat file of 1 pass of aomenc encode
                             to get exact place where encoder will place new keyframes.
                             (Keep in mind that speed also depends on set aomenc parameters)
-                            `none` -  skips scenedetection.
+                            `ffmpeg` - Uses ffmpeg built in content based scene detection
+                            with threshold. Slower and less precise than pyscene but requires
+                            fewer dependencies.
+                            `none` -  skips scenedetection. Useful for splitting by time
 
     -cm  --chunk_method     Determine way in which chunks made for encoding.
                             By default selected best one avalable.
@@ -118,7 +123,8 @@ With your own parameters:
                             Example: "-s scenes.csv"
 
     -xs  --extra_split      Adding extra splits if frame distance beetween splits bigger than
-                            given value. Works with/without PySceneDetect
+                            given value. Pair with none for time based splitting or with any
+                            other splitting method to break up massive scenes.
                             Example: 1000 frames video with single scene,
                             -xs 200 will add splits at 200,400,600,800.
 

--- a/av1an/arg_parse.py
+++ b/av1an/arg_parse.py
@@ -76,6 +76,7 @@ class Args:
         io_group.add_argument('--output_file', '-o', type=Path, default=None, help='Specify output file')
         io_group.add_argument('--mkvmerge', help='Use mkvmerge instead of ffmpeg to concatenate', action='store_true')
 
+        io_group.add_argument('--quiet', '-q', help='Disable printing tqdm and scenedetect data to terminal', action='store_true')
         io_group.add_argument('--logging', '-log', type=str, default=None, help='Enable logging')
         io_group.add_argument('--resume', '-r', help='Resuming previous session', action='store_true')
         io_group.add_argument('--keep', help='Keep temporally folder after encode', action='store_true')
@@ -88,7 +89,7 @@ class Args:
                                  choices=['select', 'vs_ffms2', 'vs_lsmash', 'hybrid'])
         split_group.add_argument('--scenes', '-s', type=str, default=None, help='File location for scenes')
         split_group.add_argument('--split_method', type=str, default='pyscene', help='Specify splitting method',
-                                 choices=['none', 'pyscene', 'aom_keyframes'])
+                                 choices=['none', 'pyscene', 'aom_keyframes', 'ffmpeg'])
         split_group.add_argument('--extra_split', '-xs', type=int, default=240,
                                  help='Number of frames after which make split')
 

--- a/av1an/manager/Counter.py
+++ b/av1an/manager/Counter.py
@@ -1,5 +1,10 @@
 from multiprocessing.managers import BaseManager
-from tqdm import tqdm
+has_tqdm = 1
+try:
+    from tqdm import tqdm
+except ImportError:
+    has_tqdm = 0
+
 
 def Manager():
     """
@@ -19,7 +24,7 @@ class Counter:
         self.initial = initial
         self.left = total - initial
         self.current = 0
-        self.use_tqdm = use_tqdm
+        self.use_tqdm = (use_tqdm and has_tqdm)
         if use_tqdm:
             self.tqdm_bar = tqdm(total=self.left, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.01)
 
@@ -33,7 +38,8 @@ class Counter:
             self.current += value
 
     def close(self):
-        self.tqdm_bar.close()
+        if self.use_tqdm:
+            self.tqdm_bar.close()
 
     def get_frames(self):
         return self.current

--- a/av1an/manager/Counter.py
+++ b/av1an/manager/Counter.py
@@ -1,9 +1,8 @@
 from multiprocessing.managers import BaseManager
-has_tqdm = 1
 try:
     from tqdm import tqdm
 except ImportError:
-    has_tqdm = 0
+    tqdm = None
 
 
 def Manager():
@@ -24,7 +23,7 @@ class Counter:
         self.initial = initial
         self.left = total - initial
         self.current = 0
-        self.use_tqdm = (use_tqdm and has_tqdm)
+        self.use_tqdm = (use_tqdm and tqdm is not None)
         if use_tqdm:
             self.tqdm_bar = tqdm(total=self.left, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.01)
 

--- a/av1an/project/Project.py
+++ b/av1an/project/Project.py
@@ -53,6 +53,7 @@ class Project(object):
         self.pix_format: Command = None
 
         # Misc
+        self.quiet = False
         self.logging = None
         self.resume: bool = None
         self.no_check: bool = None

--- a/av1an/scenedetection/__init__.py
+++ b/av1an/scenedetection/__init__.py
@@ -1,2 +1,3 @@
 from .pyscene import pyscene
 from .aom_kf import aom_keyframes, AOM_KEYFRAMES_DEFAULT_PARAMS
+from .ffmpeg import ffmpeg

--- a/av1an/scenedetection/aom_kf.py
+++ b/av1an/scenedetection/aom_kf.py
@@ -8,11 +8,10 @@ from pathlib import Path
 from subprocess import PIPE, STDOUT
 
 import cv2
-has_tqdm = 1
 try:
     from tqdm import tqdm
 except ImportError:
-    has_tqdm = 0
+    tqdm = None
 
 from av1an.commandtypes import CommandPair
 from av1an.logger import log
@@ -194,7 +193,7 @@ def aom_keyframes(video_path: Path, stat_file, min_scene_len, ffmpeg_pipe, video
     f, e = compose_aomsplit_first_pass_command(video_path, stat_file, ffmpeg_pipe, video_params, is_vs)
 
     tqdm_bar = None
-    if not quiet and has_tqdm:
+    if not quiet and tqdm is not None:
         tqdm_bar = tqdm(total=total, initial=0, dynamic_ncols=True, unit="fr", leave=True, smoothing=0.2)
 
     ffmpeg_pipe = subprocess.Popen(f, stdout=PIPE, stderr=STDOUT)
@@ -213,7 +212,7 @@ def aom_keyframes(video_path: Path, stat_file, min_scene_len, ffmpeg_pipe, video
         if line:
             encoder_history.append(line)
 
-        if quiet or not has_tqdm:
+        if quiet or tqdm is None:
             continue
 
         match = re.search(r"frame.*?/([^ ]+?) ", line)

--- a/av1an/scenedetection/ffmpeg.py
+++ b/av1an/scenedetection/ffmpeg.py
@@ -12,8 +12,9 @@ if sys.platform == "linux":
 
 def ffmpeg(video, threshold, is_vs, temp):
     """
-    Running PySceneDetect detection on source video for segmenting.
-    Optimal threshold settings 15-50
+    Running FFMPEG detection on source video for segmenting.
+    Usually the optimal threshold is 0.1 - 0.3 but it can vary a lot
+    based on your source content.
     """
 
     log(f'Starting FFMPEG detection:\nThreshold: {threshold}, Is Vapoursynth input: {is_vs}\n')
@@ -29,7 +30,7 @@ def ffmpeg(video, threshold, is_vs, temp):
         vspipe_cmd = compose_vapoursynth_pipe(video, vspipe_fifo)
         vspipe_process = Popen(vspipe_cmd)
 
-    finfo = "showinfo,select=gt(scene\\," + str(threshold) + "),select=eq(key\\,1),showinfo"
+    finfo = "showinfo,select=gt(scene\\," + str(threshold) + "),showinfo"
     ffmpeg_cmd = ["ffmpeg", "-i", str(vspipe_fifo if is_vs else video.as_posix()), "-hide_banner", "-loglevel", "32",
                   "-filter_complex", finfo, "-an", "-f", "null", "-"]
     pipe = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/av1an/scenedetection/ffmpeg.py
+++ b/av1an/scenedetection/ffmpeg.py
@@ -10,7 +10,7 @@ if sys.platform == "linux":
     from os import mkfifo
 
 
-def ffmpeg(video, threshold, is_vs, temp):
+def ffmpeg(video, threshold, min_scene_len, total_frames, is_vs, temp):
     """
     Running FFMPEG detection on source video for segmenting.
     Usually the optimal threshold is 0.1 - 0.3 but it can vary a lot
@@ -57,6 +57,33 @@ def ffmpeg(video, threshold, is_vs, temp):
     # If fed using a vspipe process, ensure that vspipe has finished.
     if is_vs:
         vspipe_process.wait()
+
+    # General purpose min_scene_len implementation that works if "scenes" are sorted from smallest
+    # to largest.
+
+    # First add the first and last frame so you can test if those are too close
+    scenes = [0] + scenes + [total_frames]
+    index = 1
+
+    while index < len(scenes):
+        # Check if this current split is too close to the previous split
+        if scenes[index] < (scenes[index - 1] + min_scene_len):
+            # if so remove the current split and then recheck if index < len(scenes)
+            scenes.pop(index)
+        else:
+            index = index + 1
+
+    # Remove the first and last splits. the first split will always be at frame 0 which is bad
+    # and the last split will either be the last frame of video, or the actual last split.
+    # if it's the last frame of video it should be removed
+    # and if it's the last split it means that the last frame of video was too close to that
+    # last split and thus the duration of the last split was too small and should have been removed
+    if len(scenes) > 2:
+        scenes.pop(0)
+        scenes.pop(len(scenes) - 1)
+    else:
+        # Will only occur if literally all possible splits were removed for the min_scene_len
+        return []
 
     # Remove 0 from list
     if len(scenes) > 0 and scenes[0] == 0:

--- a/av1an/scenedetection/ffmpeg.py
+++ b/av1an/scenedetection/ffmpeg.py
@@ -1,0 +1,66 @@
+import re
+import subprocess
+import sys
+from subprocess import Popen
+
+from av1an.logger import log
+from av1an.vapoursynth import compose_vapoursynth_pipe
+
+if sys.platform == "linux":
+    from os import mkfifo
+
+
+def ffmpeg(video, threshold, is_vs, temp):
+    """
+    Running PySceneDetect detection on source video for segmenting.
+    Optimal threshold settings 15-50
+    """
+
+    log(f'Starting FFMPEG detection:\nThreshold: {threshold}, Is Vapoursynth input: {is_vs}\n')
+
+    if is_vs:
+        # Handling vapoursynth. Outputs vs to a file so ffmpeg can handle it.
+        if sys.platform == "linux":
+            vspipe_fifo = temp / 'vspipe.y4m'
+            mkfifo(vspipe_fifo)
+        else:
+            vspipe_fifo = None
+
+        vspipe_cmd = compose_vapoursynth_pipe(video, vspipe_fifo)
+        vspipe_process = Popen(vspipe_cmd)
+
+    finfo = "showinfo,select=gt(scene\\," + str(threshold) + "),select=eq(key\\,1),showinfo"
+    ffmpeg_cmd = ["ffmpeg", "-i", str(vspipe_fifo if is_vs else video.as_posix()), "-hide_banner", "-loglevel", "32",
+                  "-filter_complex", finfo, "-an", "-f", "null", "-"]
+    pipe = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    last_frame = -1
+    scenes = []
+    while True:
+        line = pipe.stderr.readline().strip()
+        if len(line) == 0 and pipe.poll() is not None:
+            print(pipe.poll())
+            break
+        if len(line) == 0:
+            continue
+        if line:
+            cur_frame = re.search("n:\\ *[0-9]+", str(line))
+            if cur_frame is not None:
+                frame_num = re.search("[0-9]+", cur_frame.group(0))
+                if frame_num is not None:
+                    frame_num = int(frame_num.group(0))
+                    if frame_num < last_frame:
+                        scenes += [last_frame]
+                    else:
+                        last_frame = frame_num
+
+    # If fed using a vspipe process, ensure that vspipe has finished.
+    if is_vs:
+        vspipe_process.wait()
+
+    # Remove 0 from list
+    if len(scenes) > 0 and scenes[0] == 0:
+        scenes.remove(0)
+    log(f'Found split points: {len(scenes)}\n')
+    log(f'Splits: {scenes}\n')
+
+    return scenes

--- a/av1an/scenedetection/pyscene.py
+++ b/av1an/scenedetection/pyscene.py
@@ -3,14 +3,13 @@
 import sys
 from subprocess import Popen
 
-scenedetect = True
 try:
     from scenedetect.detectors import ContentDetector
     from scenedetect.scene_manager import SceneManager
     from scenedetect.video_manager import VideoManager
     from scenedetect.frame_timecode import FrameTimecode
 except ImportError:
-    scenedetect = False
+    ContentDetector = None
 
 from av1an.logger import log
 from av1an.utils import frame_probe
@@ -28,7 +27,7 @@ def pyscene(video, threshold, min_scene_len, is_vs, temp, quiet):
     if not min_scene_len:
         min_scene_len = 15
 
-    if not scenedetect:
+    if ContentDetector is None:
         log(f'Unable to start PySceneDetect because it was not found. Please install scenedetect[opencv] to use')
         return []
 

--- a/av1an/scenedetection/pyscene.py
+++ b/av1an/scenedetection/pyscene.py
@@ -3,14 +3,14 @@
 import sys
 from subprocess import Popen
 
-scenedetect = 1
+scenedetect = True
 try:
     from scenedetect.detectors import ContentDetector
     from scenedetect.scene_manager import SceneManager
     from scenedetect.video_manager import VideoManager
     from scenedetect.frame_timecode import FrameTimecode
 except ImportError:
-    scenedetect = 0
+    scenedetect = False
 
 from av1an.logger import log
 from av1an.utils import frame_probe
@@ -28,7 +28,7 @@ def pyscene(video, threshold, min_scene_len, is_vs, temp, quiet):
     if not min_scene_len:
         min_scene_len = 15
 
-    if scenedetect == 0:
+    if not scenedetect:
         log(f'Unable to start PySceneDetect because it was not found. Please install scenedetect[opencv] to use')
         return []
 

--- a/av1an/scenedetection/pyscene.py
+++ b/av1an/scenedetection/pyscene.py
@@ -3,10 +3,14 @@
 import sys
 from subprocess import Popen
 
-from scenedetect.detectors import ContentDetector
-from scenedetect.scene_manager import SceneManager
-from scenedetect.video_manager import VideoManager
-from scenedetect.frame_timecode import FrameTimecode
+scenedetect = 1
+try:
+    from scenedetect.detectors import ContentDetector
+    from scenedetect.scene_manager import SceneManager
+    from scenedetect.video_manager import VideoManager
+    from scenedetect.frame_timecode import FrameTimecode
+except ImportError:
+    scenedetect = 0
 
 from av1an.logger import log
 from av1an.utils import frame_probe
@@ -16,13 +20,17 @@ if sys.platform == "linux":
     from os import mkfifo
 
 
-def pyscene(video, threshold, min_scene_len, is_vs, temp):
+def pyscene(video, threshold, min_scene_len, is_vs, temp, quiet):
     """
     Running PySceneDetect detection on source video for segmenting.
     Optimal threshold settings 15-50
     """
     if not min_scene_len:
         min_scene_len = 15
+
+    if scenedetect == 0:
+        log(f'Unable to start PySceneDetect because it was not found. Please install scenedetect[opencv] to use')
+        return []
 
     log(f'Starting PySceneDetect:\nThreshold: {threshold}, Min scene length: {min_scene_len}\n Is Vapoursynth input: {is_vs}\n')
 
@@ -57,7 +65,7 @@ def pyscene(video, threshold, min_scene_len, is_vs, temp):
     # Start video_manager.
     video_manager.start()
 
-    scene_manager.detect_scenes(frame_source=video_manager, show_progress=True)
+    scene_manager.detect_scenes(frame_source=video_manager, show_progress=(not quiet))
 
     # If fed using a vspipe process, ensure that vspipe has finished.
     if is_vs:

--- a/av1an/split.py
+++ b/av1an/split.py
@@ -9,7 +9,7 @@ from typing import List
 from numpy import linspace
 
 from .project import Project
-from .scenedetection import aom_keyframes, AOM_KEYFRAMES_DEFAULT_PARAMS, pyscene
+from .scenedetection import aom_keyframes, AOM_KEYFRAMES_DEFAULT_PARAMS, pyscene, ffmpeg
 from .logger import log
 from .utils import terminate, frame_probe
 
@@ -161,7 +161,7 @@ def calc_split_locations(project: Project) -> List[int]:
     if project.split_method == 'pyscene':
         log(f'Starting scene detection Threshold: {project.threshold}, Min_scene_length: {project.min_scene_len}\n')
         try:
-            sc = pyscene(project.input, project.threshold, project.min_scene_len, project.is_vs, project.temp)
+            sc = pyscene(project.input, project.threshold, project.min_scene_len, project.is_vs, project.temp, project.quiet)
         except Exception as e:
             log(f'Error in PySceneDetect: {e}\n')
             print(f'Error in PySceneDetect{e}\n')
@@ -170,7 +170,10 @@ def calc_split_locations(project: Project) -> List[int]:
     # Splitting based on aom keyframe placement
     elif project.split_method == 'aom_keyframes':
         stat_file = project.temp / 'keyframes.log'
-        sc = aom_keyframes(project.input, stat_file, project.min_scene_len, project.ffmpeg_pipe, aom_keyframes_params, project.is_vs)
+        sc = aom_keyframes(project.input, stat_file, project.min_scene_len, project.ffmpeg_pipe, aom_keyframes_params, project.is_vs, project.quiet)
+
+    elif project.split_method == 'ffmpeg':
+        sc = ffmpeg(project.input, project.threshold, project.is_vs, project.temp)
 
     # Write scenes to file
 

--- a/av1an/split.py
+++ b/av1an/split.py
@@ -173,7 +173,7 @@ def calc_split_locations(project: Project) -> List[int]:
         sc = aom_keyframes(project.input, stat_file, project.min_scene_len, project.ffmpeg_pipe, aom_keyframes_params, project.is_vs, project.quiet)
 
     elif project.split_method == 'ffmpeg':
-        sc = ffmpeg(project.input, project.threshold, project.is_vs, project.temp)
+        sc = ffmpeg(project.input, project.threshold, project.min_scene_len, project.get_frames(), project.is_vs, project.temp)
 
     # Write scenes to file
 

--- a/av1an/target_quality/target_quality.py
+++ b/av1an/target_quality/target_quality.py
@@ -13,8 +13,12 @@ from av1an.commandtypes import CommandPair, Command
 from av1an.project import Project
 from av1an.chunk import Chunk
 from av1an.manager.Pipes import process_pipe
-import matplotlib
-from matplotlib import pyplot as plt
+try:
+    import matplotlib
+    from matplotlib import pyplot as plt
+except ImportError:
+    matplotlib = None
+    plt = None
 
 # TODO: rework to class, account for dark scenes/banding
 
@@ -270,6 +274,9 @@ def interpolate_data(vmaf_cq: list, target_quality):
 
 
 def plot_probes(project, vmaf_cq, chunk: Chunk, frames):
+    if plt is None:
+        log(f'Matplotlib is not installed or could not be loaded. Unable to plot probes.')
+        return
     # Saving plot of vmaf calculation
 
     x = [x[1] for x in sorted(vmaf_cq)]

--- a/av1an/vmaf/vmaf.py
+++ b/av1an/vmaf/vmaf.py
@@ -13,13 +13,18 @@ import numpy as np
 from math import log10, ceil, floor
 from math import log as ln
 
-import matplotlib
-from matplotlib import pyplot as plt
+from av1an.logger import log
+
+try:
+    import matplotlib
+    from matplotlib import pyplot as plt
+    matplotlib.use('Agg')
+except ImportError:
+    matplotlib = None
+    plt = None
 
 from av1an.manager.Pipes import process_pipe
 from av1an.chunk import Chunk
-
-matplotlib.use('Agg')
 
 
 class VMAF:
@@ -255,6 +260,9 @@ class VMAF:
         """
         Read vmaf json and plot VMAF values for each frame
         """
+        if plt is None:
+            log(f'Matplotlib is not installed or could not be loaded, aborting plot_vmaf')
+            return
 
         perc_1 = self.read_weighted_vmaf(scores, 0.01)
         perc_25 = self.read_weighted_vmaf(scores, 0.25)

--- a/setup-minimal.py
+++ b/setup-minimal.py
@@ -1,0 +1,34 @@
+import setuptools
+
+REQUIRES = [
+    'numpy',
+    'psutil',
+    'scipy',
+    'matplotlib',
+]
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+version = "5.4-1"
+
+setuptools.setup(
+    name="Av1an-minimal",
+    version=version,
+    author="Master_Of_Zen",
+    author_email="master_of_zen@protonmail.com",
+    description="Cross-platform command-line AV1 / VP9 / HEVC / H264 / VVC encoding framework with per scene quality encoding",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/master-of-zen/Av1an",
+    packages=setuptools.find_packages('.', exclude='tests'),
+    install_requires=REQUIRES,
+    py_modules=['av1an'],
+    entry_points={"console_scripts": ["av1an=av1an:main"]},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/setup-minimal.py
+++ b/setup-minimal.py
@@ -4,7 +4,6 @@ REQUIRES = [
     'numpy',
     'psutil',
     'scipy',
-    'matplotlib',
 ]
 
 with open("README.md", "r") as f:


### PR DESCRIPTION
Add ffmpeg splitting, add --quiet to stop tqdm from loading, make scenedetect and tqdm not strictly required, add setup-minimal for av1an-minimal, a version with much fewer deps, when using --quiet av1an exposes the number of frames that have been encoded