### PR TITLE
Changed default args on SVTAV1

### DIFF
--- a/av1an/encoder/svtav1.py
+++ b/av1an/encoder/svtav1.py
@@ -13,7 +13,7 @@ class SvtAv1(Encoder):
         super(SvtAv1, self).__init__(
             encoder_bin='SvtAv1EncApp',
             encoder_help='SvtAv1EncApp --help',
-            default_args=['--preset', '4', '--rc', '0', '--qp', '25'],
+            default_args=['--preset', '4', '--rc', '0', '-q', '25'],
             default_passes=1,
             default_q_range=(15, 50),
             output_extension='ivf')


### PR DESCRIPTION
SVT-AV1's Docu only specifies using -q instead of --qp. This change was introduced with the introduction of crf based encoding instead of fixed qp.

Changed the value in the default args to match that.