### PR TITLE
Docker: Use luigi311/encoders-docker, Update readme, update actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,10 +85,17 @@ jobs:
           tree -a
 
   docker:
-    runs-on: ubuntu-latest
-    needs: validate
+    runs-on: ubuntu-18.04
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/av1an # list of Docker images to use as base name for tags
+          tag-sha: true # add git short SHA as Docker tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -102,8 +109,10 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
+          file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/av1an:latest
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install requirements
         run: |
           apt-get update && apt-get install -y ${{ env.deps }}
-          pip3 install --no-cache-dir -r requirements.txt
+          python3 setup.py install
       - name: Download videos
         run: |
           for url in raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master randomderp.com; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,9 +86,12 @@ jobs:
           tar xf video.tar.gz
       - name: Testing ${{ matrix.name }}
         run: |
-          ./av1an.py -i bus_cif.y4m -enc ${{ matrix.enc }} -tr 20 --keep -o "bus_cif.mkv" ${{ matrix.flags }}
+          ./av1an.py -i bus_cif.y4m -enc ${{ matrix.enc }} -log log_av1an -tr 20 --keep -o "bus_cif.mkv" ${{ matrix.flags }}
           du -h bus_cif.mkv
           tree -a
+      - name: Cat log
+        if: always()
+        run: cat log_av1an.log
 
   docker:
     runs-on: ubuntu-18.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - "*.md"
 
 env:
-  deps: python3-dev libglib2.0-0 libsm6 libxext6 libxrender-dev libgl1-mesa-glx tree
+  deps: tree
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
@@ -36,6 +36,12 @@ jobs:
           - name: chunk_select
             enc: aom
             flags: --chunk_method select
+          - name: chunk_ffms2
+            enc: aom
+            flags: --chunk_method vs_ffms2
+          - name: chunk_lsmash
+            enc: aom
+            flags: --chunk_method vs_lsmash
           - name: scenes
             enc: aom
             flags: -s scenes.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,7 @@
-FROM archlinux:base-devel
+FROM luigi311/encoders-docker:latest
 
 ENV MPLCONFIGDIR="/home/app_user/"
-
-# Fix keyring
-RUN rm -fr /etc/pacman.d/gnupg && \
-    pacman-key --init && \
-    pacman-key --populate archlinux
-
-# Create user
-RUN useradd app_user --system --shell /usr/bin/nologin --create-home && \
-    echo "app_user ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/allow_app_user"
-
-# Speed up compile
-RUN sed -i 's,^#MAKEFLAGS=.*,MAKEFLAGS="-j$(nproc)",g' /etc/makepkg.conf
-
-# Recommended to update entire base image due to rolling release
-RUN pacman -Syu --noprogressbar --noconfirm
-
-# Install requirements
-RUN pacman -S --noprogressbar --noconfirm opencv opencv-samples hdf5 qt5-base git cmake yasm doxygen python python-pip go dpkg wget
-
-# Install x265 and x264
-RUN pacman -S --noprogressbar --noconfirm x265 x264
-
-# Install makemkv vapoursynth
-RUN pacman -S --noprogressbar --noconfirm mkvtoolnix-cli vapoursynth
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install VTM
 RUN git clone https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM.git /home/app_user/VTM && \
@@ -34,54 +11,10 @@ RUN cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j"$(nproc)" && \
     ln -s ../bin/EncoderAppStatic /usr/local/bin/vvc_encoder
 
-USER app_user
-
-# Install aomenc
-RUN git clone https://aur.archlinux.org/aom-git.git /home/app_user/aom-git
-WORKDIR /home/app_user/aom-git
-RUN yes | makepkg -sri
-
-# Install rav1e
-RUN git clone https://aur.archlinux.org/rav1e-git.git /home/app_user/rav1e-git
-WORKDIR /home/app_user/rav1e-git
-RUN yes | makepkg -sri
-
-# Install svt-av1
-RUN git clone https://aur.archlinux.org/svt-av1-git.git /home/app_user/svt-av1-git
-WORKDIR /home/app_user/svt-av1-git
-RUN yes | makepkg -sri
-
-# Install svt-vp9
-RUN git clone https://aur.archlinux.org/svt-vp9-git.git /home/app_user/svt-vp9-git
-WORKDIR /home/app_user/svt-vp9-git
-RUN yes | makepkg -sri
-
-# Install vpx
-RUN git clone https://aur.archlinux.org/libvpx-full-git.git /home/app_user/libvpx-full-git
-WORKDIR /home/app_user/libvpx-full-git
-RUN yes | makepkg -sri
-
-# Install ffms2
-RUN git clone https://aur.archlinux.org/ffms2-git.git /home/app_user/ffms2-git
-WORKDIR /home/app_user/ffms2-git
-RUN yes | makepkg -sri
-
-# Install lsmash
-RUN git clone https://aur.archlinux.org/vapoursynth-plugin-lsmashsource-git.git /home/app_user/vapoursynth-plugin-lsmashsource-git
-WORKDIR /home/app_user/vapoursynth-plugin-lsmashsource-git
-RUN yes | makepkg -sri
-
-USER root
-
-# Install johnvansickle ffmpeg
-RUN mkdir -p "/home/app_user/ffmpeg" && curl -L https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz -o /home/app_user/ffmpeg/ffmpeg-git-amd64-static.tar.xz
-WORKDIR /home/app_user/ffmpeg
-RUN tar xf ffmpeg-* && mv ffmpeg-*/* /usr/sbin/
-
 # Install av1an
 COPY . /home/app_user/Av1an
 WORKDIR /home/app_user/Av1an
-RUN python setup.py install
+RUN python3 setup.py install
 
 # Change permissions
 RUN chmod 777 -R /home/app_user

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ With your own parameters:
 Docker can be ran with the following command if you are in the current directory
 
 ```bash
-docker run -v "$(pwd)":/videos --user $(id -u):$(id -g) -it masterofzen/av1an -i S01E01.mkv {options}
+docker run -v "$(pwd)":/videos --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
 ```
 
 Docker can also be built by using
@@ -243,8 +243,19 @@ docker build -t "av1an" .
 To specify a different directory to use you would replace $(pwd) with the directory
 
 ```bash
-docker run -v /c/Users/masterofzen/Videos:/videos --user $(id -u):$(id -g) -it masterofzen/av1an -i S01E01.mkv {options}
+docker run -v /c/Users/masterofzen/Videos:/videos --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
 ```
+
+### Docker tags
+
+The docker image has the following tags
+
+|    Tag    | Description                                           |
+| :-------: | ----------------------------------------------------- |
+|   latest  | Contains the latest stable av1an version release      |
+|   master  | Contains the latest av1an commit to the master branch |
+| sha-##### | Contains the commit of the hash that is referenced    |
+|    #.##   | Stable av1an version release                          |
 
 The --user flag is require to avoid permission issues with the docker container not being able to write to the location, if you get permission issues ensure your user has access to the folder that you are using to encode.
 


### PR DESCRIPTION
Docker:
 - The docker image will now be based on luigi311/encoders-docker where all the encoders and other tools are built so the docker build github action doesnt take forever.

README:
 - Updated docker readme information to include :latest tag and --rm to prevent stale images
 - Added descriptions for all the available tags 

Actions:
 - Cleanup dependencies since the base image contains almost everything
 - Add vs chunking test
 - Use python setup.py install as pip install -r requirements was broken
 - Cat av1an log for success and failures
 - Will now tag with latest, master, #.## and sha-###### to allow users to backtrack to a previous version if necessary

