### PR TITLE
Fixes VMAF calculation using the native VMAF n_subsample

### DIFF
--- a/av1an/vmaf/vmaf.py
+++ b/av1an/vmaf/vmaf.py
@@ -115,13 +115,13 @@ class VMAF:
         filter_complex = ('-filter_complex', )
 
         # Change framerate of comparison to framerate of probe
-        select_frames = f"select=not(mod(n\\,{vmaf_rate}))," if vmaf_rate else ''
+        n_subsamples = f':n_subsample={vmaf_rate}' if vmaf_rate else ''
 
-        distorted = f'[0:v]{select_frames}scale={self.res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];'
+        distorted = f'[0:v]scale={self.res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];'
+        
+        ref = fr'[1:v]{self.vmaf_filter}scale={self.res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];'
 
-        ref = fr'[1:v]{select_frames}{self.vmaf_filter}scale={self.res}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];'
-
-        vmaf_filter = f"[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={shlex.quote(fl)}{self.model}{self.n_threads}"
+        vmaf_filter = f"[distorted][ref]libvmaf=log_fmt='json'{n_subsamples}:eof_action=endall:log_path={shlex.quote(fl)}{self.model}{self.n_threads}"
 
         cmd_out = ('-f', 'null', '-')
 


### PR DESCRIPTION
Mitigates the uncommon 100VMAF issue in continuous motion scenes.

https://slow.pics/c/lUAHEERa

1st pic is what happens normally:
```
01:06:54 AM Chunk: 00000, Rate: 4, Fr: 127
Q: [32, 55], Early Skip High CQ
Vmaf: [100.0, 100.0]
Target Q: 55 VMAF: 100.0

01:06:56 AM Chunk: 00001, Rate: 4, Fr: 127
Q: [32, 55], Early Skip High CQ
Vmaf: [100.0, 98.65]
Target Q: 55 VMAF: 98.65

```
2nd pic is what happens with the patched build:
```
06:45:49 PM Chunk: 00000, Rate: 4, Fr: 127
Q: [32, 50, 52, 55]
Vmaf: [100.0, 94.36, 92.91, 90.82]
Target Q: 47 VMAF: 95.86

06:45:51 PM Chunk: 00001, Rate: 4, Fr: 127
Q: [32, 50, 52, 55]
Vmaf: [100.0, 92.23, 91.15, 88.29]
Target Q: 41 VMAF: 96.2
```
with this sample: https://drive.google.com/file/d/1YBY7sbO2-3SvNajIAOFtvzWKRFX5cGW-/view?usp=sharing

This basically fixes the 100VMAF issue in scenes with continuous motion/high motion scenes, allowing for more consistent quality targets. :+1: 