### PR TITLE
Annotate methods for probe logging and simplified case distinction

### DIFF
--- a/av1an/target_quality/target_quality.py
+++ b/av1an/target_quality/target_quality.py
@@ -113,7 +113,7 @@ class TargetQuality:
         score = VMAF.read_weighted_vmaf(self.vmaf_probe(chunk, next_q))
         vmaf_cq.append((score, next_q))
 
-        if next_q == self.min_q or next_q == self.max_q:
+        if (next_q == self.min_q and score < self.target) or (next_q == self.max_q and score > self.target):
             self.log_probes(vmaf_cq, frames, chunk.name, next_q, score,
                             skip='low' if score < self.target else 'high')
             return next_q


### PR DESCRIPTION
Hi, 

just some minor changes that happened when I tried to fully understand your probe logging code.

P.S.: I think the log is not ideal for the fast_search results. It will print the targeted VMAF as the desired VMAF should be met by encoding with the calculated q.