### PR TITLE
Kill auxiliary pipes when main encode/process is finished

### DIFF
--- a/av1an/encoder/encoder.py
+++ b/av1an/encoder/encoder.py
@@ -128,7 +128,8 @@ class Encoder(ABC):
                                 stderr=STDOUT,
                                 universal_newlines=True)
 
-        return pipe
+        utility = (ffmpeg_gen_pipe, ffmpeg_pipe)
+        return pipe, utility
 
     def is_valid(self, project: Project) -> Tuple[bool, Optional[str]]:
         """

--- a/av1an/encoder/vvc.py
+++ b/av1an/encoder/vvc.py
@@ -93,7 +93,7 @@ class Vvc(Encoder):
                                 stdout=PIPE,
                                 stderr=STDOUT,
                                 universal_newlines=True)
-        return pipe
+        return pipe, tuple()
 
     def is_valid(self, project: Project) -> Tuple[bool, Optional[str]]:
         # vvc requires a special concat executable

--- a/av1an/manager/Pipes.py
+++ b/av1an/manager/Pipes.py
@@ -25,19 +25,12 @@ def process_pipe(pipe, chunk: Chunk, utility: Iterable[Popen]):
     for u_pipe in utility:
         if u_pipe.poll() is None:
             u_pipe.kill()
-            log(f'[process_pipe] Killed unclosed utility pipe.')
 
     if pipe.returncode != 0 and pipe.returncode != -2:
         msg1 = f'Encoder encountered an error: {pipe.returncode}'
         msg2 = f'Chunk: {chunk.index}' + \
              '\n'.join(encoder_history)
         log(msg1, msg2)
-        try:
-            for u_pipe in utility:
-                # print(u_pipe.stderr.readlines())
-                log(u_pipe.stdout.readlines())
-        except:
-            log('Failed to get stderr for a pipe')
         tb = sys.exc_info()[2]
         raise RuntimeError("Error in processing encoding pipe").with_traceback(
             tb)
@@ -70,7 +63,6 @@ def process_encoding_pipe(pipe, encoder, counter, chunk: Chunk, utility: Iterabl
     for u_pipe in utility:
         if u_pipe.poll() is None:
             u_pipe.kill()
-            log(f'[process_encoding_pipe] Killed unclosed utility pipe.')
 
     if pipe.returncode != 0 and pipe.returncode != -2:  # -2 is Ctrl+C for aom
         msg1 = f'Encoder encountered an error: {pipe.returncode}'

--- a/av1an/manager/Pipes.py
+++ b/av1an/manager/Pipes.py
@@ -1,6 +1,8 @@
 import sys
 
 from collections import deque
+from typing import Iterable
+from subprocess import Popen
 
 from av1an.chunk import Chunk
 from av1an.encoder import ENCODERS
@@ -9,7 +11,7 @@ from av1an.project import Project
 from av1an.logger import log
 
 
-def process_pipe(pipe, chunk: Chunk):
+def process_pipe(pipe, chunk: Chunk, utility: Iterable[Popen]):
     encoder_history = deque(maxlen=20)
     while True:
         line = pipe.stdout.readline().strip()
@@ -20,17 +22,28 @@ def process_pipe(pipe, chunk: Chunk):
         if line:
             encoder_history.append(line)
 
+    for u_pipe in utility:
+        if u_pipe.poll() is None:
+            u_pipe.kill()
+            log(f'[process_pipe] Killed unclosed utility pipe.')
+
     if pipe.returncode != 0 and pipe.returncode != -2:
         msg1 = f'Encoder encountered an error: {pipe.returncode}'
         msg2 = f'Chunk: {chunk.index}' + \
              '\n'.join(encoder_history)
         log(msg1, msg2)
+        try:
+            for u_pipe in utility:
+                # print(u_pipe.stderr.readlines())
+                log(u_pipe.stdout.readlines())
+        except:
+            log('Failed to get stderr for a pipe')
         tb = sys.exc_info()[2]
         raise RuntimeError("Error in processing encoding pipe").with_traceback(
             tb)
 
 
-def process_encoding_pipe(pipe, encoder, counter, chunk: Chunk):
+def process_encoding_pipe(pipe, encoder, counter, chunk: Chunk, utility: Iterable[Popen]):
     encoder_history = deque(maxlen=20)
     frame = 0
     enc = ENCODERS[encoder]
@@ -54,6 +67,11 @@ def process_encoding_pipe(pipe, encoder, counter, chunk: Chunk):
         if line:
             encoder_history.append(line)
 
+    for u_pipe in utility:
+        if u_pipe.poll() is None:
+            u_pipe.kill()
+            log(f'[process_encoding_pipe] Killed unclosed utility pipe.')
+
     if pipe.returncode != 0 and pipe.returncode != -2:  # -2 is Ctrl+C for aom
         msg1 = f'Encoder encountered an error: {pipe.returncode}'
         msg2 = f'Chunk: {chunk.index}'
@@ -68,12 +86,12 @@ def process_encoding_pipe(pipe, encoder, counter, chunk: Chunk):
 def tqdm_bar(a: Project, c: Chunk, encoder, counter, frame_probe_source,
              passes, current_pass):
     enc = ENCODERS[encoder]
-    pipe = enc.make_pipes(a, c, passes, current_pass, c.output)
+    pipe, utility = enc.make_pipes(a, c, passes, current_pass, c.output)
 
     if encoder in ('aom', 'vpx', 'rav1e', 'x265', 'x264', 'vvc', 'svt_av1'):
-        process_encoding_pipe(pipe, encoder, counter, c)
+        process_encoding_pipe(pipe, encoder, counter, c, utility)
 
     if encoder in ('svt_vp9'):
         # SVT-VP9 is special
-        process_pipe(pipe, c)
+        process_pipe(pipe, c, utility)
         counter.update(frame_probe_source // passes)

--- a/av1an/target_quality/target_quality.py
+++ b/av1an/target_quality/target_quality.py
@@ -290,8 +290,8 @@ class TargetQuality:
         n_threads = self.n_threads if self.n_threads else 12
         cmd = self.probe_cmd(chunk, q, self.ffmpeg_pipe, self.encoder,
                              self.probing_rate, n_threads)
-        pipe = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
-        process_pipe(pipe, chunk)
+        pipe, utility = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
+        process_pipe(pipe, chunk, utility)
         fl = self.vmaf_runner.call_vmaf(chunk,
                                         self.gen_probes_names(chunk, q),
                                         vmaf_rate=self.probing_rate)
@@ -345,7 +345,7 @@ class TargetQuality:
                 '--enable-rect-tx=0', '--enable-interintra-wedge=0',
                 '--enable-onesided-comp=0', '--enable-interintra-comp=0',
                 '--enable-global-motion=0', '--min-partition-size=32',
-                '--max-partition-size=32'
+                '--max-partition-size=32', '--vmaf-model-path=vmaf_v0.6.1.json'
             ]
             cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
 
@@ -468,7 +468,7 @@ class TargetQuality:
             'select=\'gte(scene,0)\',metadata=print', '-f', 'null', '-'
         ]
         cmd = CommandPair(pipecmd, [*params])
-        pipe = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
+        pipe, utility = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
 
         history = []
 
@@ -480,6 +480,11 @@ class TargetQuality:
                 continue
             if line:
                 history.append(line)
+
+        for u_pipe in utility:
+            if u_pipe.poll() is None:
+                u_pipe.kill()
+                log(f'[get_scene scores] Killed unclosed utility pipe.')
 
         if pipe.returncode != 0 and pipe.returncode != -2:
             print(f"\n:: Error in getting scene score {pipe.returncode}")
@@ -522,7 +527,8 @@ class TargetQuality:
                                 stderr=subprocess.STDOUT,
                                 universal_newlines=True)
 
-        return pipe
+        utility = (ffmpeg_gen_pipe, ffmpeg_pipe)
+        return pipe, utility
 
     def plot_probes(self, vmaf_cq, chunk: Chunk, frames):
         """
@@ -609,8 +615,8 @@ class TargetQuality:
     def per_frame_probe(self, q_list, q, chunk):
         qfile = chunk.make_q_file(q_list)
         cmd = self.per_frame_probe_cmd(chunk, q, self.encoder, 1, qfile)
-        pipe = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
-        process_pipe(pipe, chunk)
+        pipe, utility = self.make_pipes(chunk.ffmpeg_gen_cmd, cmd)
+        process_pipe(pipe, chunk, utility)
         fl = self.vmaf_runner.call_vmaf(chunk, self.gen_probes_names(chunk, q))
         jsn = VMAF.read_json(fl)
         vmafs = [x['metrics']['vmaf'] for x in jsn['frames']]

--- a/av1an/target_quality/target_quality.py
+++ b/av1an/target_quality/target_quality.py
@@ -345,7 +345,7 @@ class TargetQuality:
                 '--enable-rect-tx=0', '--enable-interintra-wedge=0',
                 '--enable-onesided-comp=0', '--enable-interintra-comp=0',
                 '--enable-global-motion=0', '--min-partition-size=32',
-                '--max-partition-size=32', '--vmaf-model-path=vmaf_v0.6.1.json'
+                '--max-partition-size=32'
             ]
             cmd = CommandPair(pipe, [*params, '-o', probe_name, '-'])
 
@@ -484,7 +484,6 @@ class TargetQuality:
         for u_pipe in utility:
             if u_pipe.poll() is None:
                 u_pipe.kill()
-                log(f'[get_scene scores] Killed unclosed utility pipe.')
 
         if pipe.returncode != 0 and pipe.returncode != -2:
             print(f"\n:: Error in getting scene score {pipe.returncode}")

--- a/av1an/vmaf/vmaf.py
+++ b/av1an/vmaf/vmaf.py
@@ -139,7 +139,8 @@ class VMAF:
                                 stdout=PIPE,
                                 stderr=STDOUT,
                                 universal_newlines=True)
-        process_pipe(pipe, chunk)
+        utility = (ffmpeg_gen_pipe,)
+        process_pipe(pipe, chunk, utility)
 
         return fl_path
 


### PR DESCRIPTION
Pass references to created pipes to the process_pipe functions, such that any remaining pipes can get killed. Prevents stray applications taking up RAM.

For the future, this might also make it easier to log error output from these pipes when an encoder error occurs due to issues with the piping or input files. 

Tested on Windows 10, with vspipe (lsmash I believe).