### PR TITLE
Allow folder as output for Av1an

### DIFF
--- a/av1an/arg_parse.py
+++ b/av1an/arg_parse.py
@@ -81,10 +81,10 @@ class Args:
             help="Input File or Vapoursynth (.py,.vpy) script",
         )
         io_group.add_argument(
-            "--temp", type=Path, default=None, help="Set temp folder path"
+            "--temp", type=str, default=None, help="Set temp folder path"
         )
         io_group.add_argument(
-            "--output_file", "-o", type=Path, default=None, help="Specify output file"
+            "--output_file", "-o", type=str, default=None, help="Specify output file"
         )
         io_group.add_argument(
             "--mkvmerge",

--- a/av1an/project/Project.py
+++ b/av1an/project/Project.py
@@ -135,11 +135,14 @@ class Project(object):
         else:
             suffix = ".mkv"
 
-        self.output_file = (
-            Path(self.output_file).with_suffix(suffix)
-            if self.output_file
-            else Path(f"{self.input.stem}_{self.encoder}{suffix}")
-        )
+        # Check for non-empty string
+        if isinstance(self.output_file, str) and self.output_file:
+            if self.output_file[-1] in ('\\', '/'):
+                self.output_file = Path(f"{self.output_file}{self.input.stem}_{self.encoder}{suffix}")
+            else:
+                self.output_file = Path(f"{self.input.stem}_{self.encoder}{suffix}")
+        else:
+            self.output_file = Path(self.output_file).with_suffix(suffix)
 
     def load_project_from_file(self, path_string):
         """
@@ -197,7 +200,10 @@ class Project(object):
         """Creating temporally folders when needed."""
 
         if self.temp:
-            self.temp = Path(str(self.temp))
+            if self.temp[-1] in ('\\', '/'):
+                self.temp = Path(f"{self.temp}{'.' + str(hash_path(str(self.input)))}")
+            else:
+                self.temp = Path(str(self.temp))
         else:
             self.temp = Path("." + str(hash_path(str(self.input))))
 

--- a/av1an/project/Project.py
+++ b/av1an/project/Project.py
@@ -138,6 +138,8 @@ class Project(object):
         # Check for non-empty string
         if isinstance(self.output_file, str) and self.output_file:
             if self.output_file[-1] in ('\\', '/'):
+                if not Path(self.output_file).exists():
+                    os.makedirs(Path(self.output_file), exist_ok=True)
                 self.output_file = Path(f"{self.output_file}{self.input.stem}_{self.encoder}{suffix}")
             else:
                 self.output_file = Path(f"{self.input.stem}_{self.encoder}{suffix}")

--- a/av1an/project/Project.py
+++ b/av1an/project/Project.py
@@ -142,9 +142,9 @@ class Project(object):
                     os.makedirs(Path(self.output_file), exist_ok=True)
                 self.output_file = Path(f"{self.output_file}{self.input.stem}_{self.encoder}{suffix}")
             else:
-                self.output_file = Path(f"{self.input.stem}_{self.encoder}{suffix}")
+                self.output_file = Path(self.output_file).with_suffix(suffix)
         else:
-            self.output_file = Path(self.output_file).with_suffix(suffix)
+            self.output_file = Path(f"{self.input.stem}_{self.encoder}{suffix}")
 
     def load_project_from_file(self, path_string):
         """


### PR DESCRIPTION
By ending the output filename with `\` or `/`, it will be interpreted as a folder. Users will therefore be able to output encoded files to that folder. Encoded files take the standard name as if no output name were specified. The same applies to temp paths.  

Note that the temp folder will be created if it does not exist, but it will not be deleted. Each project/encode temp folder will respect the setting, but the temp folder that is specified by the user will not be deleted, in case that folder is used for other purposes, or in the event that user specifies both temp and output as the same folder. (Which is fully supported in with this pull request!)

This change forced me to change the default arg  type from Path to str, since it seems like Path objects remove the slashes at the ends of the path, which would prevent this implementation. The output file and temp attributes are saved as Path objects after processing to make sure nothing else gets broken by this change. 

If a user specifies an output folder, it will be created once a project starts, as this is the only time that folder information is present. This behavior might be worth changing to create the folder before concatenation happens. It'll require more tinkering however, whereas the current change works well without any large code changes. So I propose changing that later if that is desired. 