### PR TITLE
Use utf-8 encoding for loadscript.vpy, handles nonstandard characters.

### DIFF
--- a/av1an/vapoursynth.py
+++ b/av1an/vapoursynth.py
@@ -48,7 +48,7 @@ def create_vs_file(temp: Path, source, chunk_method):
             'core.lsmas.LWLibavSource(r"{}", cachefile="{}").set_output()'
         )
 
-    with open(load_script, "w+") as file:
+    with open(load_script, "w+", encoding='utf-8') as file:
         file.write(script.format(Path(source).resolve(), cache_file))
 
     cache_generation = f"vspipe -i {load_script.as_posix()} -i -"


### PR DESCRIPTION
Reported on discord, when using vapoursynth, files with uncommon characters such as ä, ö or ü.

Issue was reproduced and then fixed for me (on Windows 10, vapoursynth with lsmash) by changing loadscript.vpy encoding to utf-8. I believe python defaults to different encodings per system, and uses a different default codec causing this issue on Windows, and potentially on other OSes as well. 