### PR TITLE
Making aom+SVT-AV1 target_quality faster and SVT-AV1 fixes

### DIFF
--- a/av1an/encoder/svtav1.py
+++ b/av1an/encoder/svtav1.py
@@ -13,7 +13,7 @@ class SvtAv1(Encoder):
         super(SvtAv1, self).__init__(
             encoder_bin="SvtAv1EncApp",
             encoder_help="SvtAv1EncApp --help",
-            default_args=["--preset", "4", "--rc", "0", "-q", "25"],
+            default_args=["--preset", "4","--keyint", "240", "--rc", "0", "--crf", "25"],
             default_passes=1,
             default_q_range=(15, 50),
             output_extension="ivf",
@@ -86,7 +86,7 @@ class SvtAv1(Encoder):
         :return: command with new cq value"""
         adjusted_command = command.copy()
 
-        i = list_index_of_regex(adjusted_command, r"(--qp|-q)")
+        i = list_index_of_regex(adjusted_command, r"(--qp|-q|--crf)")
 
         qp_file = chunk.make_q_file(chunk.per_frame_target_quality_q_list)
 
@@ -104,7 +104,7 @@ class SvtAv1(Encoder):
 
         adjusted_command = command.copy()
 
-        i = list_index_of_regex(adjusted_command, r"(--qp|-q)")
+        i = list_index_of_regex(adjusted_command, r"(--qp|-q|--crf)")
         adjusted_command[i + 1] = f"{q}"
 
         return adjusted_command

--- a/av1an/target_quality/target_quality.py
+++ b/av1an/target_quality/target_quality.py
@@ -82,7 +82,7 @@ class TargetQuality:
         vmaf_cq = []
         frames = chunk.frames
 
-        if self.probing_rate not in (1, 2):
+        if self.probing_rate not in (1, 2, 3):
             self.probing_rate = self.adapt_probing_rate(self.probing_rate, frames)
 
         if self.probes < 3:
@@ -399,11 +399,15 @@ class TargetQuality:
                 "--enable-order-hint=0",
                 "--enable-flip-idtx=0",
                 "--enable-dist-wtd-comp=0",
-                "--enable-rect-tx=0",
                 "--enable-interintra-wedge=0",
                 "--enable-onesided-comp=0",
                 "--enable-interintra-comp=0",
                 "--enable-global-motion=0",
+                "--enable-cdef=0",
+                "--max-reference-frames=3",
+                "--cdf-update-mode=2",
+                "--deltaq-mode=0",
+                "--sb-size=64",
                 "--min-partition-size=32",
                 "--max-partition-size=32",
             ]
@@ -470,14 +474,14 @@ class TargetQuality:
                 f"{n_threads}",
                 "--preset",
                 "8",
-                "-q",
+                "--keyint",
+                "240",
+                "--crf",
                 f"{q}",
                 "--tile-rows",
                 "1",
                 "--tile-columns",
                 "2",
-                "--hme",
-                "0",
                 "--pred-struct",
                 "0",
                 "--sg-filter-mode",
@@ -489,8 +493,6 @@ class TargetQuality:
                 "--disable-dlf",
                 "0",
                 "--mrp-level",
-                "0",
-                "--enable-tpl-la",
                 "0",
                 "--enable-mfmv",
                 "0",
@@ -515,8 +517,6 @@ class TargetQuality:
                 "--bipred-3x3",
                 "0",
                 "--compound",
-                "0",
-                "--use-default-me-hme",
                 "0",
                 "--ext-block",
                 "0",


### PR DESCRIPTION
So, these are the small changes I've been working on. 

aomenc: Removing ` "--enable-rect-tx=0"` fixes some crashes, and adding some new options speeds up the quality analysis in target_quality mode without impacting VMAF analysis scores in both live-action and animation.

SVT-AV1: Fixing the command parsing for CRF in target_quality mode, as well as adding `--keyint 240` for better efficiency and speed over the default 33 frame keyframe limit, both in normal default encoding mode and target_quality. Also, reenabling HME since it actually speeds up the encoder a bit. Since CRF is now used, tpl-la has to be kept enabled as well :smile: 

Other: probing_rate fix by making sure that all probing_rates below 4 are active. Before, 3 would go up to 4. Now, it just works.