### PR TITLE
TargetQuality: x265 frame-thread max 16

### DIFF
--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -1,5 +1,6 @@
 use crate::Encoder;
 use std::str::FromStr;
+use std::cmp;
 
 pub fn construct_target_quality_command(
   encoder: Encoder,
@@ -171,7 +172,7 @@ pub fn construct_target_quality_command(
       "--no-progress".into(),
       "--y4m".into(),
       "--frame-threads".into(),
-      format!("{}", threads),
+      format!("{}", cmp::min(threads,16.to_string())),
       "--preset".into(),
       "fast".into(),
       "--crf".into(),


### PR DESCRIPTION
x265 frame-thread has a max value of 16 https://x265.readthedocs.io/en/3.1/cli.html#cmdoption-frame-threads setting it to any higher will cause it to fail with a error stating that frame-threads is not set or just freeze causing issues with av1an. This only manifests on machines with lots of cores and with videos that are a big enough length that x265 is able to try to use 16+ frame threads.

Signed-off-by: Luigi311 <luigi311.lg@gmail.com>