### PR TITLE
Add av-scenechange as the new and default scene detector

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -53,8 +53,8 @@ pub struct Args {
   scenes: Option<PathBuf>,
 
   /// Specify splitting method
-  #[clap(long, possible_values = &["ffmpeg", "pyscene"])]
-  split_method: Option<String>,
+  #[clap(long, possible_values = &["ffmpeg", "pyscene", "av-scenechange", "none"], default_value = "av-scenechange")]
+  split_method: String,
 
   /// Number of frames after which make split
   #[clap(short = 'x', long, default_value = "240")]
@@ -120,7 +120,7 @@ pub struct Args {
   target_quality: Option<f64>,
 
   /// Method selection for target quality
-  #[clap(long, possible_values = &[ "per_shot"], default_value = "per_shot")]
+  #[clap(long, possible_values = &["per_shot"], default_value = "per_shot")]
   target_quality_method: String,
 
   /// Number of probes to make for target_quality

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -131,9 +131,9 @@ pub struct Args {
   #[clap(long, default_value = "4")]
   probing_rate: usize,
 
-   /// Use encoding settings for probes
-   #[clap(long)]
-   probe_slow: bool,
+  /// Use encoding settings for probes
+  #[clap(long)]
+  probe_slow: bool,
 
   /// Min q for target_quality
   #[clap(long)]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.40"
 num_cpus = "1.13.0"
 serde_json = "1.0"
 serde = { version="1.0", features=["derive"] }
-sysinfo = "0.18.2"
+sysinfo = "0.19.1"
 vapoursynth = { version="0.3.0", features=["vsscript-functions", "vapoursynth-functions"] }
 clap = "2.33.3"
 num-rational = "0.4.0"

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -114,7 +114,7 @@ pub fn have_audio(file: &Path) -> bool {
 }
 
 /// Extracting audio
-pub fn extract_audio(input: &Path, temp: &Path, audio_params: Vec<String>) {
+pub fn extract_audio(input: &Path, temp: &Path, audio_params: &[String]) {
   let have_audio = have_audio(input);
 
   if have_audio {

--- a/av1an-core/src/file_validation.rs
+++ b/av1an-core/src/file_validation.rs
@@ -3,9 +3,11 @@ use std::process::exit;
 
 /// Returns file if it have suffix of media file
 fn match_file_type(input: &PathBuf) -> bool {
-  ["mkv", "mp4", "mov", "avi", "flv", "m2ts", "y4m"]
-    .iter()
-    .any(|&v| input.extension().map_or(false, |u| v == u))
+  [
+    "mkv", "mp4", "mov", "avi", "flv", "m2ts", "y4m", "py", "vpy",
+  ]
+  .iter()
+  .any(|&v| input.extension().map_or(false, |u| v == u))
 }
 
 fn validate_files(files: &[PathBuf]) -> Vec<PathBuf> {

--- a/av1an-core/src/file_validation.rs
+++ b/av1an-core/src/file_validation.rs
@@ -2,13 +2,13 @@ use std::path::PathBuf;
 use std::process::exit;
 
 /// Returns file if it have suffix of media file
-fn match_file_type(input: PathBuf) -> bool {
+fn match_file_type(input: &PathBuf) -> bool {
   ["mkv", "mp4", "mov", "avi", "flv", "m2ts", "y4m"]
     .iter()
     .any(|&v| input.extension().map_or(false, |u| v == u))
 }
 
-fn validate_files(files: Vec<PathBuf>) -> Vec<PathBuf> {
+fn validate_files(files: &[PathBuf]) -> Vec<PathBuf> {
   let valid: Vec<PathBuf> = files
     .iter()
     .cloned()
@@ -19,7 +19,7 @@ fn validate_files(files: Vec<PathBuf>) -> Vec<PathBuf> {
 
 /// Process given input file/dir
 /// Returns vector of files to process
-pub fn process_inputs(inputs: Vec<PathBuf>) -> Vec<PathBuf> {
+pub fn process_inputs(inputs: &[PathBuf]) -> Vec<PathBuf> {
   if inputs.is_empty() {
     println!("No inputs");
     exit(0);
@@ -29,7 +29,7 @@ pub fn process_inputs(inputs: Vec<PathBuf>) -> Vec<PathBuf> {
 
   // Process all inputs (folders and files)
   // into single path vector
-  for fl in &inputs {
+  for fl in inputs {
     if fl.as_path().is_dir() {
       for file in fl.as_path().read_dir().unwrap() {
         let entry = file.unwrap();
@@ -42,12 +42,12 @@ pub fn process_inputs(inputs: Vec<PathBuf>) -> Vec<PathBuf> {
   }
 
   // Check are all files real
-  let valid_input = validate_files(input_files);
+  let valid_input = validate_files(&input_files);
   // Match files to media file extensions
   let result: Vec<PathBuf> = valid_input
     .iter()
     .cloned()
-    .filter(|x| match_file_type(x.to_path_buf()))
+    .filter(|x| match_file_type(x))
     .collect();
 
   if result.is_empty() {

--- a/av1an-core/src/file_validation.rs
+++ b/av1an-core/src/file_validation.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 
 /// Returns file if it have suffix of media file
-fn match_file_type(input: &PathBuf) -> bool {
+fn match_file_type(input: &Path) -> bool {
   [
     "mkv", "mp4", "mov", "avi", "flv", "m2ts", "y4m", "py", "vpy",
   ]

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -181,7 +181,7 @@ pub fn determine_workers(encoder: Encoder) -> u64 {
 
 pub fn get_percentile(scores: Vec<f64>, percentile: f64) -> f64 {
   // Calculates percentile from vector of valuees
-  let mut sorted = scores.clone();
+  let mut sorted = scores;
   sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
   let k = (sorted.len() - 1) as f64 * percentile;

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -1,9 +1,11 @@
+#![warn(clippy::needless_pass_by_value)]
+
 #[macro_use]
 extern crate log;
 use serde::Deserialize;
 use std::fmt::Error;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use sysinfo::SystemExt;
@@ -213,12 +215,12 @@ struct Baz {
   frames: Vec<Bar>,
 }
 
-pub fn read_file_to_string(file: PathBuf) -> Result<String, Error> {
+pub fn read_file_to_string(file: &Path) -> Result<String, Error> {
   Ok(fs::read_to_string(&file).unwrap_or_else(|_| panic!("Can't open file {:?}", file)))
 }
 
 pub fn read_vmaf_file(file: PathBuf) -> Result<Vec<f64>, serde_json::Error> {
-  let json_str = read_file_to_string(file).unwrap();
+  let json_str = read_file_to_string(&file).unwrap();
   let bazs = serde_json::from_str::<Baz>(&json_str)?;
   let v = bazs
     .frames

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -166,8 +166,8 @@ pub fn determine_workers(encoder: Encoder) -> u64 {
   system.refresh_memory();
 
   let cpu = num_cpus::get() as u64;
-  // get_total_memory returns kb, convert to gb
-  let ram_gb = system.get_total_memory() / 10u64.pow(6);
+  // available_memory returns kb, convert to gb
+  let ram_gb = system.available_memory() / 10u64.pow(6);
 
   std::cmp::max(
     match encoder {

--- a/av1an-core/src/logger.rs
+++ b/av1an-core/src/logger.rs
@@ -8,7 +8,8 @@ use std::{
 static LOG_HANDLE: OnceCell<File> = OnceCell::new();
 
 pub fn set_log(file: &str) -> Result<(), Error> {
-  Ok(LOG_HANDLE.set(File::create(file).unwrap()).unwrap())
+  LOG_HANDLE.set(File::create(file).unwrap()).unwrap();
+  Ok(())
 }
 
 pub fn log(msg: &str) {

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -24,19 +24,17 @@ pub fn init_progress_bar(len: u64) -> Result<(), Box<dyn error::Error>> {
 }
 
 pub fn update_bar(inc: u64) -> Result<(), Box<dyn error::Error>> {
-  Ok(
-    PROGRESS_BAR
-      .get()
-      .expect("The progress bar was not initialized!")
-      .inc(inc),
-  )
+  PROGRESS_BAR
+    .get()
+    .expect("The progress bar was not initialized!")
+    .inc(inc);
+  Ok(())
 }
 
 pub fn finish_progress_bar() -> Result<(), Box<dyn error::Error>> {
-  Ok(
-    PROGRESS_BAR
-      .get()
-      .expect("The progress bar was not initialized!")
-      .finish(),
-  )
+  PROGRESS_BAR
+    .get()
+    .expect("The progress bar was not initialized!")
+    .finish();
+  Ok(())
 }

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -1,40 +1,47 @@
-use indicatif::ProgressBar;
-use indicatif::ProgressStyle;
-use once_cell::sync::OnceCell;
+// TODO move this functionality to av1an-cli (and without global variables) when
+// Python code is removed. This is only here (and implemented this way) for
+// interoperability with Python.
+
+use indicatif::{ProgressBar, ProgressStyle};
 use std::error;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
 
 const INDICATIF_PROGRESS_TEMPLATE: &str =
   "{spinner} [{elapsed_precise}] [{wide_bar}] {percent:>3}% {pos}/{len} ({fps}, eta {eta})";
 
-static PROGRESS_BAR: OnceCell<ProgressBar> = OnceCell::new();
+static PROGRESS_BAR: Lazy<Mutex<ProgressBar>> = Lazy::new(|| Mutex::new(ProgressBar::new(0)));
 
 pub fn init_progress_bar(len: u64) -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR.get_or_init(|| {
-    let bar = ProgressBar::new(len);
-    bar.set_style(
-      ProgressStyle::default_bar()
-        .template(INDICATIF_PROGRESS_TEMPLATE)
-        .progress_chars("#>-"),
-    );
-    bar.enable_steady_tick(100);
-    bar
-  });
+  let pb = PROGRESS_BAR.lock().unwrap();
+
+  pb.reset_elapsed();
+  pb.reset_eta();
+  pb.set_position(0);
+  pb.set_length(len);
+  pb.reset();
+  pb.set_style(
+    ProgressStyle::default_bar()
+      .template(INDICATIF_PROGRESS_TEMPLATE)
+      .progress_chars("#>-"),
+  );
+  pb.enable_steady_tick(100);
 
   Ok(())
 }
 
 pub fn update_bar(inc: u64) -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR
-    .get()
-    .expect("The progress bar was not initialized!")
-    .inc(inc);
+  PROGRESS_BAR.lock().unwrap().inc(inc);
+  Ok(())
+}
+
+pub fn set_pos(pos: u64) -> Result<(), Box<dyn error::Error>> {
+  PROGRESS_BAR.lock().unwrap().set_position(pos);
   Ok(())
 }
 
 pub fn finish_progress_bar() -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR
-    .get()
-    .expect("The progress bar was not initialized!")
-    .finish();
+  PROGRESS_BAR.lock().unwrap().finish();
   Ok(())
 }

--- a/av1an-core/src/split.rs
+++ b/av1an-core/src/split.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-pub fn segment(input: &Path, temp: &Path, segments: Vec<usize>) {
+pub fn segment(input: &Path, temp: &Path, segments: &[usize]) {
   let mut cmd = Command::new("ffmpeg");
 
   cmd.stdout(Stdio::piped());

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -37,7 +37,6 @@ pub fn interpolate_target_q(scores: Vec<(f64, u32)>, target: f64) -> Result<f64,
   sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
   let keys = sorted
-    .clone()
     .iter()
     .map(|f| Key::new(f.0 as f64, f.1 as f64, Interpolation::Linear))
     .collect();
@@ -52,7 +51,6 @@ pub fn interpolate_target_vmaf(scores: Vec<(f64, u32)>, q: f64) -> Result<f64, E
   sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
   let keys = sorted
-    .clone()
     .iter()
     .map(|f| Key::new(f.1 as f64, f.0 as f64, Interpolation::Linear))
     .collect();
@@ -77,7 +75,7 @@ pub fn log_probes(
     _ => "".to_string(),
   };
 
-  let mut scores_sorted = vmaf_cq_scores.clone();
+  let mut scores_sorted = vmaf_cq_scores;
   scores_sorted.sort_by_key(|x| x.1);
 
   log(format!("Chunk: {}, Rate: {}, Fr {}", name, probing_rate, frames).as_str());

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -64,12 +64,12 @@ pub fn log_probes(
   vmaf_cq_scores: Vec<(f64, u32)>,
   frames: u32,
   probing_rate: u32,
-  name: String,
+  name: &str,
   target_q: u32,
   target_vmaf: f64,
-  skip: String,
+  skip: &str,
 ) {
-  let skip_string = match skip.as_str() {
+  let skip_string = match skip {
     "high" => "Early Skip High Q".to_string(),
     "low" => "Early Skip Low Q".to_string(),
     _ => "".to_string(),

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, u32};
 
 pub fn plot_vmaf_score_file(
   scores_file: PathBuf,
-  plot_path: PathBuf,
+  plot_path: &PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
   let scores = read_vmaf_file(scores_file.clone()).unwrap();
 
@@ -95,7 +95,7 @@ pub fn validate_libvmaf() -> Result<(), Error> {
   Ok(())
 }
 
-pub fn validate_vmaf_test_run(model: String) -> Result<(), Error> {
+pub fn validate_vmaf_test_run(model: &str) -> Result<(), Error> {
   let mut cmd = Command::new("ffmpeg");
 
   cmd.args(["-hide_banner", "-filter_complex"]);
@@ -117,12 +117,12 @@ pub fn validate_vmaf_test_run(model: String) -> Result<(), Error> {
 
 pub fn validate_vmaf(vmaf_model: String) -> Result<(), Error> {
   validate_libvmaf()?;
-  validate_vmaf_test_run(vmaf_model)?;
+  validate_vmaf_test_run(&vmaf_model)?;
 
   Ok(())
 }
 
-pub fn run_vmaf_on_files(source: PathBuf, output: PathBuf) -> Result<PathBuf, Error> {
+pub fn run_vmaf_on_files(source: &PathBuf, output: PathBuf) -> Result<PathBuf, Error> {
   let mut cmd = Command::new("ffmpeg");
 
   cmd.args(["-y", "-hide_banner", "-loglevel", "error"]);
@@ -153,11 +153,11 @@ pub fn run_vmaf_on_files(source: PathBuf, output: PathBuf) -> Result<PathBuf, Er
   }
 }
 
-pub fn plot_vmaf(source: PathBuf, output: PathBuf) -> Result<(), Error> {
+pub fn plot_vmaf(source: PathBuf, output: &PathBuf) -> Result<(), Error> {
   println!("::VMAF Run..");
 
-  let json_file = run_vmaf_on_files(source, output.clone())?;
+  let json_file = run_vmaf_on_files(&source, output.clone())?;
   let plot_path = output.with_extension("png");
-  plot_vmaf_score_file(json_file, plot_path).unwrap();
+  plot_vmaf_score_file(json_file, &plot_path).unwrap();
   Ok(())
 }

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -17,7 +17,7 @@ pub fn plot_vmaf_score_file(
   let perc_1 = read_weighted_vmaf(scores_file.clone(), 0.01).unwrap();
   let perc_25 = read_weighted_vmaf(scores_file.clone(), 0.25).unwrap();
   let perc_75 = read_weighted_vmaf(scores_file.clone(), 0.75).unwrap();
-  let perc_mean = read_weighted_vmaf(scores_file.clone(), 0.50).unwrap();
+  let perc_mean = read_weighted_vmaf(scores_file, 0.50).unwrap();
 
   let root =
     BitMapBackend::new(plot_path.as_os_str(), (plot_width, plot_heigth)).into_drawing_area();
@@ -158,5 +158,6 @@ pub fn plot_vmaf(source: PathBuf, output: PathBuf) -> Result<(), Error> {
 
   let json_file = run_vmaf_on_files(source, output.clone())?;
   let plot_path = output.with_extension("png");
-  Ok(plot_vmaf_score_file(json_file, plot_path).unwrap())
+  plot_vmaf_score_file(json_file, plot_path).unwrap();
+  Ok(())
 }

--- a/av1an-pyo3/Cargo.toml
+++ b/av1an-pyo3/Cargo.toml
@@ -29,7 +29,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version="0.13.2" }
+pyo3 = { version = "0.14.1" }
 once_cell = "1.8.0"
 chrono = "0.4.19"
 av1an-core = { path="../av1an-core" }

--- a/av1an-pyo3/pyproject.toml
+++ b/av1an-pyo3/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "maturin"
-requires = ["setuptools", "maturin"]
+requires = ["setuptools", "maturin>=0.11,<0.12"]
 
 [tool.maturin]
 # cargo-extra-args = ["--release"]

--- a/av1an-pyo3/src/lib.rs
+++ b/av1an-pyo3/src/lib.rs
@@ -141,7 +141,7 @@ fn frame_probe_vspipe(source: &str) -> PyResult<usize> {
 fn extract_audio(input: String, temp: String, audio_params: Vec<String>) {
   let input_path = Path::new(&input);
   let temp_path = Path::new(&temp);
-  av1an_core::ffmpeg::extract_audio(input_path, temp_path, audio_params);
+  av1an_core::ffmpeg::extract_audio(input_path, temp_path, &audio_params);
 }
 
 #[pyfunction]
@@ -177,7 +177,7 @@ fn extra_splits(split_locations: Vec<usize>, total_frames: usize, split_size: us
 fn segment(input: String, temp: String, segments: Vec<usize>) -> PyResult<()> {
   let input = Path::new(&input);
   let temp = Path::new(&temp);
-  av1an_core::split::segment(input, temp, segments);
+  av1an_core::split::segment(input, temp, &segments);
   Ok(())
 }
 
@@ -188,7 +188,7 @@ fn process_inputs(input: Vec<String>) -> Vec<String> {
     .map(|x| PathBuf::from_str(x.as_str()).unwrap())
     .collect();
 
-  let processed = av1an_core::file_validation::process_inputs(path_bufs);
+  let processed = av1an_core::file_validation::process_inputs(&path_bufs);
 
   let out: Vec<String> = processed
     .iter()
@@ -423,7 +423,7 @@ pub fn finish_progress_bar() -> PyResult<()> {
 pub fn plot_vmaf_score_file(scores_file_string: String, plot_path_string: String) {
   let scores_file = PathBuf::from(scores_file_string);
   let plot_path = PathBuf::from(plot_path_string);
-  av1an_core::vmaf::plot_vmaf_score_file(scores_file, plot_path).unwrap()
+  av1an_core::vmaf::plot_vmaf_score_file(scores_file, &plot_path).unwrap()
 }
 
 #[pyfunction]
@@ -436,7 +436,7 @@ pub fn validate_vmaf(model: String) -> PyResult<()> {
 pub fn plot_vmaf(source: &str, output: &str) -> PyResult<()> {
   let input = PathBuf::from(source);
   let out = PathBuf::from(output);
-  av1an_core::vmaf::plot_vmaf(input, out).unwrap();
+  av1an_core::vmaf::plot_vmaf(input, &out).unwrap();
   Ok(())
 }
 
@@ -468,10 +468,10 @@ pub fn log_probes(
     vmaf_cq_scores,
     frames,
     probing_rate,
-    name,
+    &name,
     target_q,
     target_vmaf,
-    skip,
+    &skip,
   );
   Ok(())
 }

--- a/av1an-pyo3/src/lib.rs
+++ b/av1an-pyo3/src/lib.rs
@@ -37,7 +37,7 @@ fn construct_target_quality_command(
   threads: &str,
   q: &str,
 ) -> PyResult<Vec<String>> {
-  let encoder = av1an_encoder_constructor::Encoder::from_str(&encoder).map_err(|_| {
+  let encoder = av1an_encoder_constructor::Encoder::from_str(encoder).map_err(|_| {
     pyo3::exceptions::PyTypeError::new_err(format!("Unknown or unsupported encoder '{}'", encoder))
   })?;
 
@@ -234,12 +234,14 @@ fn vmaf_auto_threads(workers: usize) -> usize {
 
 #[pyfunction]
 fn set_log(file: &str) -> PyResult<()> {
-  Ok(av1an_core::logger::set_log(file).unwrap())
+  av1an_core::logger::set_log(file).unwrap();
+  Ok(())
 }
 
 #[pyfunction]
 fn log(msg: &str) -> PyResult<()> {
-  Ok(av1an_core::logger::log(msg))
+  av1an_core::logger::log(msg);
+  Ok(())
 }
 
 #[pyfunction]
@@ -350,7 +352,7 @@ fn man_command(encoder: String, params: Vec<String>, q: usize) -> Vec<String> {
 
 #[pyfunction]
 fn match_line(encoder: &str, line: &str) -> PyResult<usize> {
-  let enc = av1an_encoder_constructor::Encoder::from_str(&encoder).unwrap();
+  let enc = av1an_encoder_constructor::Encoder::from_str(encoder).unwrap();
 
   Ok(enc.match_line(line).unwrap())
 }
@@ -375,7 +377,16 @@ fn probe_cmd(
   probe_slow: bool,
 ) -> PyResult<(Vec<String>, Vec<String>)> {
   let encoder = av1an_encoder_constructor::Encoder::from_str(&encoder).unwrap();
-  Ok(encoder.probe_cmd(temp, name, q, ffmpeg_pipe, probing_rate, n_threads, video_params, probe_slow))
+  Ok(encoder.probe_cmd(
+    temp,
+    name,
+    q,
+    ffmpeg_pipe,
+    probing_rate,
+    n_threads,
+    video_params,
+    probe_slow,
+  ))
 }
 
 #[pyfunction]
@@ -392,17 +403,20 @@ pub fn read_weighted_vmaf(fl: String, percentile: f64) -> PyResult<f64> {
 
 #[pyfunction]
 pub fn init_progress_bar(len: u64) -> PyResult<()> {
-  Ok(av1an_core::progress_bar::init_progress_bar(len).unwrap())
+  av1an_core::progress_bar::init_progress_bar(len).unwrap();
+  Ok(())
 }
 
 #[pyfunction]
 pub fn update_bar(inc: u64) -> PyResult<()> {
-  Ok(av1an_core::progress_bar::update_bar(inc).unwrap())
+  av1an_core::progress_bar::update_bar(inc).unwrap();
+  Ok(())
 }
 
 #[pyfunction]
 pub fn finish_progress_bar() -> PyResult<()> {
-  Ok(av1an_core::progress_bar::finish_progress_bar().unwrap())
+  av1an_core::progress_bar::finish_progress_bar().unwrap();
+  Ok(())
 }
 
 #[pyfunction]
@@ -414,14 +428,16 @@ pub fn plot_vmaf_score_file(scores_file_string: String, plot_path_string: String
 
 #[pyfunction]
 pub fn validate_vmaf(model: String) -> PyResult<()> {
-  Ok(av1an_core::vmaf::validate_vmaf(model).unwrap())
+  av1an_core::vmaf::validate_vmaf(model).unwrap();
+  Ok(())
 }
 
 #[pyfunction]
 pub fn plot_vmaf(source: &str, output: &str) -> PyResult<()> {
   let input = PathBuf::from(source);
   let out = PathBuf::from(output);
-  Ok(av1an_core::vmaf::plot_vmaf(input, out).unwrap())
+  av1an_core::vmaf::plot_vmaf(input, out).unwrap();
+  Ok(())
 }
 
 #[pyfunction]
@@ -448,7 +464,7 @@ pub fn log_probes(
   target_vmaf: f64,
   skip: String,
 ) -> PyResult<()> {
-  Ok(av1an_core::target_quality::log_probes(
+  av1an_core::target_quality::log_probes(
     vmaf_cq_scores,
     frames,
     probing_rate,
@@ -456,7 +472,8 @@ pub fn log_probes(
     target_q,
     target_vmaf,
     skip,
-  ))
+  );
+  Ok(())
 }
 #[pymodule]
 fn av1an_pyo3(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/av1an-scene-detection/Cargo.toml
+++ b/av1an-scene-detection/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2018"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+av-scenechange = "0.5.0"
+anyhow = "1.0.42"
+y4m = "0.7.0"

--- a/av1an-scene-detection/src/av_scenechange.rs
+++ b/av1an-scene-detection/src/av_scenechange.rs
@@ -10,7 +10,7 @@ use std::{
 pub fn scene_detect(
   src: &Path,
   callback: Option<Box<dyn Fn(usize, usize)>>,
-  min: usize,
+  min_scene_len: usize,
   is_vs: bool,
 ) -> anyhow::Result<Vec<usize>> {
   Ok(
@@ -68,7 +68,7 @@ pub fn scene_detect(
       })?,
       DetectionOptions {
         ignore_flashes: true,
-        min_scenecut_distance: Some(12),
+        min_scenecut_distance: Some(min_scene_len),
         ..Default::default()
       },
       callback,

--- a/av1an-scene-detection/src/av_scenechange.rs
+++ b/av1an-scene-detection/src/av_scenechange.rs
@@ -1,0 +1,78 @@
+use av_scenechange::{detect_scene_changes, DetectionOptions};
+use std::{
+  path::Path,
+  process::{Command, Stdio},
+};
+
+/// Detect scene changes using rav1e scene detector.
+///
+/// src: Input to video.
+pub fn scene_detect(
+  src: &Path,
+  callback: Option<Box<dyn Fn(usize, usize)>>,
+  min: usize,
+  is_vs: bool,
+) -> anyhow::Result<Vec<usize>> {
+  Ok(
+    detect_scene_changes::<_, u8>(
+      &mut y4m::Decoder::new(if is_vs {
+        {
+          // vspipe -y .b8a0d8d/split/loadscript.vpy - | ffmpeg -i pipe: -f yuv4mpegpipe -pix_fmt yuv420p -vf scale=360:-2 - | mpv -
+          let vspipe = Command::new("vspipe")
+            .arg("-y")
+            .arg(src)
+            .arg("-")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?
+            .stdout
+            .unwrap();
+
+          Command::new("ffmpeg")
+            .stdin(vspipe)
+            .args(&[
+              "-i",
+              "pipe:",
+              "-f",
+              "yuv4mpegpipe",
+              "-pix_fmt",
+              "yuv420p",
+              "-vf",
+              "scale=360:-2",
+              "-",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?
+            .stdout
+            .unwrap()
+        }
+      } else {
+        Command::new("ffmpeg")
+          .arg("-i")
+          .arg(src)
+          .args(&[
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            "scale=360:-2",
+            "-f",
+            "yuv4mpegpipe",
+            "-",
+          ])
+          .stdout(Stdio::piped())
+          .stderr(Stdio::null())
+          .spawn()?
+          .stdout
+          .unwrap()
+      })?,
+      DetectionOptions {
+        ignore_flashes: true,
+        min_scenecut_distance: Some(12),
+        ..Default::default()
+      },
+      callback,
+    )
+    .scene_changes,
+  )
+}

--- a/av1an-scene-detection/src/av_scenechange.rs
+++ b/av1an-scene-detection/src/av_scenechange.rs
@@ -17,7 +17,6 @@ pub fn scene_detect(
     detect_scene_changes::<_, u8>(
       &mut y4m::Decoder::new(if is_vs {
         {
-          // vspipe -y .b8a0d8d/split/loadscript.vpy - | ffmpeg -i pipe: -f yuv4mpegpipe -pix_fmt yuv420p -vf scale=360:-2 - | mpv -
           let vspipe = Command::new("vspipe")
             .arg("-y")
             .arg(src)

--- a/av1an-scene-detection/src/lib.rs
+++ b/av1an-scene-detection/src/lib.rs
@@ -1,3 +1,4 @@
 #![allow(unused)]
 
 pub mod aom_kf;
+pub mod av_scenechange;

--- a/av1an/chunk/chunk_queue.py
+++ b/av1an/chunk/chunk_queue.py
@@ -138,7 +138,7 @@ def create_vs_chunk(
 
     vspipe_gen_cmd = [
         "vspipe",
-        vs_script,
+        str(vs_script),
         "-y",
         "-",
         "-s",

--- a/av1an/manager/Manager.py
+++ b/av1an/manager/Manager.py
@@ -1,12 +1,9 @@
 import json
 import shutil
 import sys
-import time
 from multiprocessing.managers import BaseManager
 from pathlib import Path
-from typing import List
 
-from av1an.chunk import Chunk
 from av1an.chunk.chunk_queue import load_or_gen_chunk_queue
 from av1an.concat import concatenate_mkvmerge
 from av1an.project.Project import Project
@@ -14,11 +11,9 @@ from av1an.split import split_routine
 from av1an_pyo3 import (
     concatenate_ffmpeg,
     concatenate_ivf,
-    create_vs_file,
     extract_audio,
     log,
     plot_vmaf,
-    process_inputs,
     set_log,
     determine_workers,
     hash_path,

--- a/av1an/manager/Pipes.py
+++ b/av1an/manager/Pipes.py
@@ -11,7 +11,6 @@ from av1an_pyo3 import (
     compose_1_2_pass,
     compose_2_2_pass,
     compose_ffmpeg_pipe,
-    encoder_bin,
     log,
     man_command,
     match_line,

--- a/av1an/project/Project.py
+++ b/av1an/project/Project.py
@@ -94,7 +94,7 @@ class Project(object):
                     self.chunk_method,
                 )
             )
-            fr = frame_probe_vspipe(vs)
+            fr = frame_probe_vspipe(str(vs))
             if fr > 0:
                 self.frames = fr
                 return fr

--- a/av1an/split.py
+++ b/av1an/split.py
@@ -4,7 +4,13 @@ import sys
 from pathlib import Path
 from typing import List
 
-from av1an_pyo3 import extra_splits, log, read_scenes_from_file, write_scenes_to_file
+from av1an_pyo3 import (
+    extra_splits,
+    log,
+    read_scenes_from_file,
+    write_scenes_to_file,
+    av_scenechange_detect,
+)
 
 from .project import Project
 from .scenedetection import ffmpeg, pyscene
@@ -45,7 +51,7 @@ def split_routine(project: Project, resuming: bool) -> List[int]:
         log("Applying extra splits")
         log(f"Split distance: {project.extra_split}")
         scenes = extra_splits(scenes, project.get_frames(), project.extra_split)
-        log(f"New splits:{len(scenes)}")
+        log(f"New splits: {len(scenes)}")
 
     # write scenes for resuming later if needed
     return scenes
@@ -72,7 +78,14 @@ def calc_split_locations(project: Project) -> List[int]:
             log(f"Error in PySceneDetect: {e}")
             print(f"Error in PySceneDetect: {e}")
             sys.exit(1)
-
+    elif project.split_method == "av-scenechange":
+        sc = av_scenechange_detect(
+            project.input.as_posix(),
+            project.get_frames(),
+            project.min_scene_len,
+            project.quiet,
+            project.is_vs,
+        )
     elif project.split_method == "ffmpeg":
         sc = ffmpeg(
             project.input,

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 from av1an.arg_parse import Args
-from av1an.manager import Manager
 from av1an.startup.setup import startup_check
 from pathlib import Path
 import sys
-from av1an_pyo3 import (
-    process_inputs,
-)
+from av1an_pyo3 import process_inputs, hash_path
 
 import time
 
@@ -49,6 +46,9 @@ def main():
 
             if len(queue) > 1:
                 print(f":: Encoding file {proj.input.name}")
+            if (project.temp is None) and project.keep:
+                print(f":: Temp dir: '.{str(hash_path(str(project.input[i])))}'")
+
             encode_file(proj)
 
             print(f"Finished: {round(time.time() - tm, 1)}s")


### PR DESCRIPTION
Also fixes some clippy warnings and adds `clippy::needless_pass_by_value` since that seems to be a common code smell here.

This new scene detector also works on vapoursynth input, and may be faster in many cases. On my laptop on 720p, av-scenechange is about 46% faster than pyscenedetect.

When compiling with `-C target-cpu=native` (which on my machine enables AVX2), the perf diff is up to 53% for the same clip. The performance can be further improved by compiling av1an with PGO.