### PR TITLE
Fix default audio parameters

### DIFF
--- a/av1an-cli/src/main.rs
+++ b/av1an-cli/src/main.rs
@@ -61,7 +61,7 @@ pub fn main() {
     audio_params: if let Some(params) = args.audio_params {
       shlex::split(&params).unwrap_or_else(|| Vec::new())
     } else {
-      Vec::new()
+      vec!["-c:a".into(), "copy".into()]
     },
     ffmpeg_pipe: Vec::new(),
     chunk_method: args


### PR DESCRIPTION
By default, ffmpeg re-encodes the audio to vorbis if no parameters are specified.