### PR TITLE
Update indicatif branch name

### DIFF
--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -21,7 +21,7 @@ failure = "0.1.8"
 regex = "1.5.4"
 plotters = "0.3.1"
 splines = "4.0.0"
-indicatif = { git = "https://github.com/mitsuhiko/indicatif" }
+indicatif = { git = "https://github.com/mitsuhiko/indicatif", branch = "main" }
 once_cell = "1.8.0"
 chrono = "0.4.19"
 strum = { version = "0.21", features = ["derive"] }


### PR DESCRIPTION
They changed the name of their master branch to "main",
so this fails to build if you don't have an existing Cargo.lock file.