### PR TITLE
Fix some clippy warnings, use enums instead of strings

### DIFF
--- a/av1an-cli/src/main.rs
+++ b/av1an-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use av1an_cli::Args;
+use av1an_core::vapoursynth;
 use av1an_pyo3::{hash_path, is_vapoursynth, Project};
 use clap::Clap;
 
@@ -31,7 +32,7 @@ pub fn main() {
         .to_owned()
     },
     ffmpeg: if let Some(s) = args.ffmpeg {
-      shlex::split(&s).unwrap_or_else(|| Vec::new())
+      shlex::split(&s).unwrap_or_else(Vec::new)
     } else {
       Vec::new()
     },
@@ -44,7 +45,7 @@ pub fn main() {
       args.encoder.get_default_pass()
     },
     video_params: if let Some(params) = args.video_params {
-      shlex::split(&params).unwrap_or_else(|| Vec::new())
+      shlex::split(&params).unwrap_or_else(Vec::new)
     } else {
       Vec::new()
     },
@@ -59,16 +60,16 @@ pub fn main() {
       )
     },
     audio_params: if let Some(params) = args.audio_params {
-      shlex::split(&params).unwrap_or_else(|| Vec::new())
+      shlex::split(&params).unwrap_or_else(|| vec!["-c:a".into(), "copy".into()])
     } else {
       vec!["-c:a".into(), "copy".into()]
     },
     ffmpeg_pipe: Vec::new(),
     chunk_method: args
       .chunk_method
-      .map(|cm| <&'static str>::from(cm).to_owned()),
+      .unwrap_or_else(|| vapoursynth::select_chunk_method().unwrap()),
     concat: <&'static str>::from(args.concat).to_owned(),
-    encoder: <&'static str>::from(args.encoder).to_owned(),
+    encoder: args.encoder,
     extra_splits_len: Some(args.extra_split),
     input: args.input.to_str().unwrap().to_owned(),
     keep: args.keep,
@@ -85,7 +86,7 @@ pub fn main() {
     scenes: args
       .scenes
       .map(|scenes| scenes.to_str().unwrap().to_owned()),
-    split_method: <&'static str>::from(args.split_method).to_owned(),
+    split_method: args.split_method,
     target_quality: args.target_quality,
     target_quality_method: Some(args.target_quality_method),
     vmaf: args.vmaf,

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -870,9 +870,7 @@ fn run(args: &[&str]) -> Result<(), Error> {
 pub fn select_chunk_method() -> Result<ChunkMethod, Error> {
   // Create a new VSScript environment.
   let environment = Environment::new().context("Couldn't create the VSScript environment")?;
-  let core = environment
-    .get_core()
-    .context("Couldn't get the VapourSynth core")?;
+  let core = environment.get_core()?;
 
   let plugins = core.plugins();
   let plugins: HashSet<&str> = plugins

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -173,13 +173,13 @@ pub fn plot_vmaf(source: &Path, output: &Path) -> Result<(), Error> {
 }
 
 pub fn run_vmaf_on_chunk(
-  encoded: PathBuf,
-  pipe_cmd: Vec<String>,
-  stat_file: PathBuf,
-  model: String,
-  res: String,
+  encoded: &Path,
+  pipe_cmd: &[String],
+  stat_file: &Path,
+  model: &str,
+  res: &str,
   sample_rate: usize,
-  vmaf_filter: String,
+  vmaf_filter: &str,
   threads: usize,
 ) -> Result<(), Error> {
   // Select filter for sampling from the source


### PR DESCRIPTION
The `Project` struct now uses enums for `Encoder`, `SplitMethod`, and `ChunkMethod`, which is much faster than comparing up strings at runtime. This also removes many now useless functions that were wrappers around methods in `Encoder` itself which took a string as an argument.