### PR TITLE
Refactor: fix chunk restarting, progress bar, and potential race condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
  "crossbeam-utils",
+ "dashmap",
  "failure",
  "flexi_logger",
  "indicatif",
@@ -484,6 +485,17 @@ checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
 dependencies = [
  "nix",
  "winapi",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+ "serde",
 ]
 
 [[package]]
@@ -1829,9 +1841,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-linebreak"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a31f45d18a3213b918019f78fe6a73a14ab896807f0aaf5622aa0684749455"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
 dependencies = [
  "regex",
 ]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -39,3 +39,7 @@ path_abs = "0.5.1"
 [dependencies.tokio]
 version = "1"
 features = ["rt", "process", "io-util"]
+
+[dependencies.dashmap]
+version = "4.0.2"
+features = ["serde"]

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -1,11 +1,6 @@
-// TODO move this functionality to av1an-cli (and without global variables) when
-// Python code is removed. This is only here (and implemented this way) for
-// interoperability with Python.
-
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
-use std::error;
 
-use once_cell::sync::Lazy;
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 
 const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(target_os = "windows") {
@@ -16,60 +11,58 @@ const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(target_os = "windows") {
   "{spinner} [{elapsed_precise}] [{wide_bar}] {percent:>3}% {pos}/{len} ({fps} fps, eta {eta})"
 };
 
-static PROGRESS_BAR: Lazy<ProgressBar> = Lazy::new(|| {
-  let pb = ProgressBar::hidden();
-  pb.set_style(
-    ProgressStyle::default_bar()
-      .template(INDICATIF_PROGRESS_TEMPLATE)
-      .with_key("fps", |state| format!("{:.2}", state.per_sec()))
-      .progress_chars("#>-"),
-  );
-  pb.set_draw_target(ProgressDrawTarget::stderr());
+static PROGRESS_BAR: OnceCell<ProgressBar> = OnceCell::new();
 
-  pb
-});
-
-pub fn init_progress_bar(len: u64) -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR.enable_steady_tick(100);
-  PROGRESS_BAR.reset_elapsed();
-  PROGRESS_BAR.reset_eta();
-  PROGRESS_BAR.set_position(0);
-  PROGRESS_BAR.set_length(len);
-  PROGRESS_BAR.reset();
-
-  Ok(())
+pub fn init_progress_bar(len: u64) {
+  let pb = PROGRESS_BAR.get_or_init(|| {
+    ProgressBar::new(len).with_style(
+      ProgressStyle::default_bar()
+        .template(INDICATIF_PROGRESS_TEMPLATE)
+        .with_key("fps", |state| format!("{:.2}", state.per_sec()))
+        .progress_chars("#>-"),
+    )
+  });
+  pb.enable_steady_tick(100);
+  pb.reset();
+  pb.reset_eta();
+  pb.reset_elapsed();
+  pb.set_position(0);
 }
 
-pub fn update_bar(inc: u64) -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR.inc(inc);
-  Ok(())
+pub fn update_bar(inc: u64) {
+  if let Some(pb) = PROGRESS_BAR.get() {
+    pb.inc(inc);
+  }
 }
 
-pub fn set_pos(pos: u64) -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR.set_position(pos);
-  Ok(())
+pub fn set_pos(pos: u64) {
+  if let Some(pb) = PROGRESS_BAR.get() {
+    pb.set_position(pos);
+  }
 }
 
-pub fn finish_progress_bar() -> Result<(), Box<dyn error::Error>> {
-  PROGRESS_BAR.finish();
-  Ok(())
+pub fn finish_progress_bar() {
+  if let Some(pb) = PROGRESS_BAR.get() {
+    pb.finish();
+  }
 }
 
-static MULTI_PROGRESS_BAR: Lazy<(MultiProgress, Mutex<Vec<ProgressBar>>)> = Lazy::new(|| {
-  let pb = MultiProgress::new();
-  pb.set_draw_target(ProgressDrawTarget::stderr());
+static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Mutex<Vec<ProgressBar>>)> = OnceCell::new();
 
-  (pb, Mutex::new(Vec::new()))
-});
+pub fn init_multi_progress_bar(len: u64, workers: usize) {
+  let multi_progress_bar = MULTI_PROGRESS_BAR.get_or_init(|| {
+    let pb = MultiProgress::new();
 
-pub fn init_multi_progress_bar(len: u64, workers: usize) -> Result<(), Box<dyn error::Error>> {
-  let mut pbs = MULTI_PROGRESS_BAR.1.lock();
+    (pb, Mutex::new(Vec::new()))
+  });
+
+  let mut pbs = multi_progress_bar.1.lock();
 
   for i in 0..workers {
     let pb = ProgressBar::hidden()
       .with_style(ProgressStyle::default_spinner().template("[{prefix}] {msg}"));
     pb.set_prefix(format!("Worker {:02}", i + 1));
-    pbs.push(MULTI_PROGRESS_BAR.0.add(pb));
+    pbs.push(multi_progress_bar.0.add(pb));
   }
 
   let pb = ProgressBar::hidden();
@@ -85,31 +78,29 @@ pub fn init_multi_progress_bar(len: u64, workers: usize) -> Result<(), Box<dyn e
   pb.set_position(0);
   pb.set_length(len);
   pb.reset();
-  pbs.push(MULTI_PROGRESS_BAR.0.add(pb));
+  pbs.push(multi_progress_bar.0.add(pb));
 
-  MULTI_PROGRESS_BAR
+  multi_progress_bar
     .0
     .set_draw_target(ProgressDrawTarget::stderr());
-
-  Ok(())
 }
 
-pub fn update_mp_msg(worker_idx: usize, msg: String) -> Result<(), Box<dyn error::Error>> {
-  let pbs = MULTI_PROGRESS_BAR.1.lock();
-  pbs[worker_idx].set_message(msg);
-  Ok(())
-}
-
-pub fn update_mp_bar(inc: u64) -> Result<(), Box<dyn error::Error>> {
-  let pbs = MULTI_PROGRESS_BAR.1.lock();
-  pbs.last().unwrap().inc(inc);
-  Ok(())
-}
-
-pub fn finish_multi_progress_bar() -> Result<(), Box<dyn error::Error>> {
-  let pbs = MULTI_PROGRESS_BAR.1.lock();
-  for pb in pbs.iter() {
-    pb.finish();
+pub fn update_mp_msg(worker_idx: usize, msg: String) {
+  if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
+    pbs.lock()[worker_idx].set_message(msg);
   }
-  Ok(())
+}
+
+pub fn update_mp_bar(inc: u64) {
+  if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
+    pbs.lock().last().unwrap().inc(inc);
+  }
+}
+
+pub fn finish_multi_progress_bar() {
+  if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
+    for pb in pbs.lock().iter() {
+      pb.finish();
+    }
+  }
 }


### PR DESCRIPTION
`DoneJson` is now a concurrent data structure, via `DashMap` and atomics
in the standard library. This should help avoid any potential race
conditions involved with one thread reading `done.json` while another
thread writes to it. Now, we only write to `done.json`, so any failure
from parsing the json while encoding is impossible.

The audio encoding is now done on a separate thread, and it is not
assumed that the audio encoding was finished if the `--resume` flag was
specified, which is now kept track of within `done.json`.

The initialization of the progress bar(s) now does not occur if the
corresponding initialization functions were not called, and the
functions to update the progress bar(s) are a NO-OP if it was not
initialized, rather than implicitly initializing it through the use of
the `Lazy` type from `once_cell`.

Additionally, all 3 concatenation functions now reside in the `concat` module.