### PR TITLE
Fix target quality and VMAF plotting on Windows

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -87,7 +87,11 @@ impl Encoder {
         into_vec![
           format!("--fpf={}.log", fpf),
           "-o",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
           "-"
         ],
       )
@@ -99,7 +103,11 @@ impl Encoder {
           "--first-pass",
           format!("{}.stat", fpf),
           "--output",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
         ]
       )
       .collect(),
@@ -109,7 +117,11 @@ impl Encoder {
         into_vec![
           format!("--fpf={}.log", fpf),
           "-o",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
           "-"
         ],
       )
@@ -131,7 +143,11 @@ impl Encoder {
           "--stats",
           format!("{}.stat", fpf),
           "-b",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
         ],
       )
       .collect(),
@@ -152,7 +168,11 @@ impl Encoder {
           format!("{}.log", fpf),
           "-",
           "-o",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
         ]
       )
       .collect(),
@@ -173,7 +193,11 @@ impl Encoder {
           format!("{}.log", fpf),
           "-",
           "-o",
-          if cfg!(windows) { "nul" } else { "/dev/null" },
+          if cfg!(target_os = "windows") {
+            "nul"
+          } else {
+            "/dev/null"
+          },
         ]
       )
       .collect(),

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -1,3 +1,4 @@
+use path_abs::{PathAbs, PathInfo};
 use regex::Regex;
 use std::ffi::OsStr;
 use std::path::Path;
@@ -167,4 +168,23 @@ pub fn get_frame_types(file: &Path) -> Vec<String> {
   let string_vec: Vec<String> = str_vec.iter().map(|s| (*s).to_string()).collect();
 
   string_vec
+}
+
+pub fn escape_path_in_filter(path: impl AsRef<Path>) -> String {
+  if cfg!(target_os = "windows") {
+    PathAbs::new(path.as_ref())
+      .unwrap()
+      .to_str()
+      .unwrap()
+      // This is needed because of how FFmpeg handles absolute file paths on Windows.
+      // https://stackoverflow.com/questions/60440793/how-can-i-use-windows-absolute-paths-with-the-movie-filter-on-ffmpeg
+      .replace(r"\", "/")
+      .replace(":", r"\\:")
+  } else {
+    PathAbs::new(path.as_ref())
+      .unwrap()
+      .to_str()
+      .unwrap()
+      .to_string()
+  }
 }


### PR DESCRIPTION
FFmpeg requires a very specific syntax to escape the file path in
Windows when using a filter, so this has been implemented with
conditional compilation. The behavior is the same on Windows, except
that the path is converted to an absolute path. Also, the only usage of
`std::env::current_dir` has been removed, since it was being used as an
ad-hoc way to convert a relative path to an absolute one, which doesn't
work if the temporary directory is in a different directory than the
current one.

We no longer kill the child processes from `process_pipe`,
since calling `wait` or `wait_with_output` closes the stdin handle
anyway.

Also, all usages of `cfg!(windows)` have been changed to `cfg!(target_os
= "windows")` to keep a consistent style.