### PR TITLE
Bump av-scenechange to 0.6 (includes rav1e 0.5-beta)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "av-scenechange"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4108b3bcac79b51af5dc0c79383ac5e9bc1ecf49ce9d90f360db5685feed24ef"
+checksum = "1710d6df78c912316637586ab68b794a158633954f12d22a47b8c90ce1255b95"
 dependencies = [
  "clap 2.33.3",
  "rav1e",
@@ -269,6 +275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30aa9e2ffbb838c6b451db14f3cd8e63ed622bf859f9956bc93845a10fafc26a"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -853,7 +868,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -1353,13 +1368,13 @@ dependencies = [
 
 [[package]]
 name = "rav1e"
-version = "0.4.1"
+version = "0.5.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0938e7e19a9e1624e7fec541ee57c3e93e507b8bdb274c21ec8ee7850d8d3203"
+checksum = "a80b9488c1dca7379d29d43fac55038b5482cf3b29d1335b9d9b4bc2dbcca9c7"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.1",
  "bitstream-io",
  "cc",
  "cfg-if 1.0.0",
@@ -1378,8 +1393,9 @@ dependencies = [
  "rayon",
  "regex",
  "rust_hawktracer",
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "simd_helpers",
+ "system-deps",
  "thiserror",
  "v_frame",
  "vergen",
@@ -1732,6 +1748,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab7dbd121ce66af2176147a48c7e01aaf1f001837a18a7cf4317858606bbdf8"
+dependencies = [
+ "anyhow",
+ "cfg-expr",
+ "heck",
+ "itertools",
+ "pkg-config",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1961,12 @@ dependencies = [
  "chrono",
  "rustc_version 0.4.0",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version_check"

--- a/av1an-scene-detection/Cargo.toml
+++ b/av1an-scene-detection/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-av-scenechange = "0.5.0"
+av-scenechange = "0.6.0"
 anyhow = "1.0.42"
 y4m = "0.7.0"


### PR DESCRIPTION
This pulls in the scenechange improvements that were merged into rav1e some time ago.