### PR TITLE
Add a fast scenecut method option

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Args {
   pub scenes: Option<PathBuf>,
 
   /// Specify splitting method
-  #[clap(long, possible_values=&["av-scenechange", "none"], default_value = "av-scenechange")]
+  #[clap(long, possible_values=&["av-scenechange", "av-scenechange-fast", "none"], default_value = "av-scenechange")]
   pub split_method: SplitMethod,
 
   /// Number of frames after which make split

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -110,6 +110,8 @@ impl Display for ConcatMethod {
 pub enum SplitMethod {
   #[strum(serialize = "av-scenechange")]
   AvScenechange,
+  #[strum(serialize = "av-scenechange-fast")]
+  AvScenechangeFast,
   #[strum(serialize = "none")]
   None,
 }
@@ -318,6 +320,7 @@ pub fn av_scenechange_detect(
   min_scene_len: usize,
   verbosity: Verbosity,
   is_vs: bool,
+  fast_analysis: bool,
 ) -> anyhow::Result<Vec<usize>> {
   if verbosity != Verbosity::Quiet {
     println!("Scene detection");
@@ -335,6 +338,7 @@ pub fn av_scenechange_detect(
     },
     min_scene_len,
     is_vs,
+    fast_analysis,
   )?;
 
   progress_bar::finish_progress_bar();
@@ -974,6 +978,16 @@ impl Project {
         self.min_scene_len,
         self.verbosity,
         self.is_vs,
+        false,
+      )
+      .unwrap(),
+      SplitMethod::AvScenechangeFast => av_scenechange_detect(
+        &self.input,
+        self.frames,
+        self.min_scene_len,
+        self.verbosity,
+        self.is_vs,
+        true,
       )
       .unwrap(),
       SplitMethod::None => Vec::with_capacity(0),


### PR DESCRIPTION
Selectable with `--split-method av-scenechange-fast`.
The fast method enables downscaling the video before scene detection,
and uses av-scenechange's fast mode, which is similar to pyscenedetect.
This also removes the downscaling from the normal scenecut mode,
since downscaling does affect accuracy of the scene detection.