### PR TITLE
ffmpeg: fix frame count parsing

### DIFF
--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -32,9 +32,8 @@ pub fn get_frame_count(source: impl AsRef<Path>) -> usize {
   let re = Regex::new(r".*frame=\s*([0-9]+)\s").unwrap();
   let output = String::from_utf8(out.stderr).unwrap();
 
-  let cap = re.captures(&output).unwrap();
-
-  cap[cap.len() - 1].parse::<usize>().unwrap()
+  let cap = re.captures_iter(&output).last().unwrap();
+  cap[1].parse::<usize>().unwrap()
 }
 
 /// Returns vec of all keyframes


### PR DESCRIPTION
The old code used to search for the first match that looked like a frame
count. When ffmpeg emits a warning, it would also emit the frame count at
the point of warning, therefore the previous implementation gave wrong
frame count when it happened.

Fix this by modifying the code to take the last match. Also replace the
index of cap by an explicit one since this is the index of capture group
(which is constant given the regex), not matches.