### PR TITLE
Replace some panics with Err returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
 name = "av1an-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "av1an-core",
  "clap 3.0.0-beta.4",
  "ctrlc",

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -8,6 +8,7 @@ name = "av1an"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.42"
 clap = "3.0.0-beta.2"
 serde_json = "1.0.64"
 serde = { version = "1.0.126", features = ["serde_derive"] }

--- a/av1an-cli/src/main.rs
+++ b/av1an-cli/src/main.rs
@@ -6,7 +6,7 @@ use av1an_core::{hash_path, is_vapoursynth, Project, Verbosity};
 use clap::Clap;
 use path_abs::{PathAbs, PathInfo};
 
-pub fn main() {
+pub fn main() -> anyhow::Result<()> {
   let args = Args::parse();
 
   let temp = if let Some(path) = args.temp {
@@ -113,6 +113,8 @@ pub fn main() {
   })
   .unwrap();
 
-  project.startup_check().unwrap();
+  project.startup_check()?;
   project.encode_file();
+
+  Ok(())
 }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -19,7 +19,7 @@ use path_abs::{PathAbs, PathInfo};
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::cmp::Ordering;
-use std::fmt::{Display, Error};
+use std::fmt::Display;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -28,7 +28,7 @@ use std::sync::mpsc::Sender;
 use std::sync::{atomic, mpsc};
 use sysinfo::SystemExt;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail, ensure, Context};
 use once_cell::sync::{Lazy, OnceCell};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -226,8 +226,8 @@ struct Baz {
   frames: Vec<Bar>,
 }
 
-pub fn read_file_to_string(file: impl AsRef<Path>) -> Result<String, Error> {
-  Ok(fs::read_to_string(&file).unwrap_or_else(|_| panic!("Can't open file {:?}", file.as_ref())))
+pub fn read_file_to_string(file: impl AsRef<Path>) -> anyhow::Result<String> {
+  fs::read_to_string(&file).with_context(|| format!("Can't open file {:?}", file.as_ref()))
 }
 
 pub fn read_vmaf_file(file: impl AsRef<Path>) -> Result<Vec<f64>, serde_json::Error> {
@@ -894,10 +894,10 @@ impl Project {
       Encoder::rav1e | Encoder::aom | Encoder::svt_av1 | Encoder::vpx
     ) && self.concat == ConcatMethod::Ivf
     {
-      panic!(".ivf only supports VP8, VP9, and AV1");
+      bail!(".ivf only supports VP8, VP9, and AV1");
     }
 
-    assert!(
+    ensure!(
       Path::new(&self.input).exists(),
       "Input file {:?} does not exist!",
       self.input
@@ -906,11 +906,11 @@ impl Project {
     self.is_vs = is_vapoursynth(&self.input);
 
     if which::which("ffmpeg").is_err() {
-      panic!("No FFmpeg");
+      bail!("No FFmpeg");
     }
 
     if let Some(ref vmaf_path) = self.vmaf_path {
-      assert!(Path::new(vmaf_path).exists());
+      ensure!(Path::new(vmaf_path).exists());
     }
 
     if self.probes < 4 {
@@ -933,7 +933,7 @@ impl Project {
     let settings_valid = which::which(&encoder_bin).is_ok();
 
     if !settings_valid {
-      panic!(
+      bail!(
         "Encoder {} not found. Is it installed in the system path?",
         encoder_bin
       );


### PR DESCRIPTION
Errors now look like this:

```
Error: Input file "foo" does not exist!
```

instead of this:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Input file "foo" does not exist!', av1an-cli/src/main.rs:116:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```