### PR TITLE
Lazily compile all regexes, move macros to util module

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -354,7 +354,7 @@ impl Encoder {
     new_params
   }
 
-  /// Retuns string for regex to matching encoder progress in cli
+  /// Retuns regex for matching encoder progress in cli
   fn pipe_match(&self) -> &'static Regex {
     match &self {
       Self::aom | Self::vpx => regex!(r".*Pass (?:1/1|2/2) .*frame.*?/([^ ]+?) "),

--- a/av1an-core/src/util.rs
+++ b/av1an-core/src/util.rs
@@ -1,0 +1,36 @@
+#[macro_export]
+macro_rules! regex {
+  ($re:literal $(,)?) => {{
+    static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+    RE.get_or_init(|| regex::Regex::new($re).unwrap())
+  }};
+}
+
+#[macro_export]
+macro_rules! into_vec {
+  ($($x:expr),* $(,)?) => {
+    vec![
+      $(
+        $x.into(),
+      )*
+    ]
+  };
+}
+
+/// Attempts to create the directory if it does not exist, logging and returning
+/// and error if creating the directory failed.
+#[macro_export]
+macro_rules! create_dir {
+  ($loc:expr) => {
+    match std::fs::create_dir(&$loc) {
+      Ok(_) => Ok(()),
+      Err(e) => match e.kind() {
+        std::io::ErrorKind::AlreadyExists => Ok(()),
+        _ => {
+          error!("Error while creating directory {:?}: {}", &$loc, e);
+          Err(e)
+        }
+      },
+    }
+  };
+}


### PR DESCRIPTION
This should avoid some unnecessary overhead where regexes were being recompiled every time their respective function was called.