### PR TITLE
Refactoring, allow compiling with Rust 1.53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1710d6df78c912316637586ab68b794a158633954f12d22a47b8c90ce1255b95"
 dependencies = [
- "clap 2.33.3",
+ "clap",
  "rav1e",
  "serde",
  "serde_json",
@@ -160,12 +160,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "av1an-core",
- "clap 3.0.0-beta.4",
  "ctrlc",
  "path_abs",
  "serde",
  "serde_json",
  "shlex",
+ "structopt",
 ]
 
 [[package]]
@@ -177,7 +177,6 @@ dependencies = [
  "av-ivf",
  "av-scenechange",
  "chrono",
- "clap 2.33.3",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -269,9 +268,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
@@ -329,37 +328,6 @@ dependencies = [
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.0.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.14.2",
- "vec_map",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -549,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dwrote"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba2265890613939b533fa11c3728651531419ac549ccf527896201581f23991"
+checksum = "081e9563bb9600593f0f5d38c24f0e3dc550cd301b4872b986e20f1874104791"
 dependencies = [
  "atty",
  "chrono",
@@ -741,12 +715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,16 +746,6 @@ dependencies = [
  "num-rational",
  "num-traits",
  "png",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -833,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
@@ -882,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -898,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1102,9 +1060,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -1116,16 +1074,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "os_str_bytes"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
-
-[[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -1134,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1476,9 +1428,9 @@ checksum = "cb626abdbed5e93f031baae60d72032f56bc964e11ac2ff65f2ba3ed98d6d3e1"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -1551,18 +1503,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -1603,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1678,6 +1630,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structopt"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1723,12 +1699,13 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.20.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af066e6272f2175c1783cfc2ebf3e2d8dfe2c182b00677fdeccbf8291af83fb"
+checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
+ "doc-comment",
  "libc",
  "ntapi",
  "once_cell",
@@ -1759,15 +1736,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "terminal_size"
@@ -1801,18 +1769,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1832,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes",

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.42"
-clap = "3.0.0-beta.2"
+structopt = "0.3.22"
 serde_json = "1.0.64"
 serde = { version = "1.0.126", features = ["serde_derive"] }
 av1an-core = { path="../av1an-core" }

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -1,147 +1,147 @@
-use clap::AppSettings::ColoredHelp;
-use clap::Clap;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use structopt::clap::AppSettings::ColoredHelp;
+use structopt::StructOpt;
 
 use av1an_core::encoder::Encoder;
 use av1an_core::{ChunkMethod, ConcatMethod, SplitMethod};
 
 /// Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding
-#[derive(Clap, Debug, Serialize, Deserialize)]
-#[clap(name = "av1an", setting = ColoredHelp, version)]
+#[derive(StructOpt, Debug, Serialize, Deserialize)]
+#[structopt(name = "av1an", setting = ColoredHelp)]
 pub struct Args {
   /// Input file or vapoursynth (.py, .vpy) script
-  #[clap(short, parse(from_os_str))]
+  #[structopt(short, parse(from_os_str))]
   pub input: PathBuf,
 
   /// Temporary directory to use
-  #[clap(long, parse(from_os_str))]
+  #[structopt(long, parse(from_os_str))]
   pub temp: Option<PathBuf>,
 
   /// Specify output file
-  #[clap(short, parse(from_os_str))]
+  #[structopt(short, parse(from_os_str))]
   pub output_file: Option<PathBuf>,
 
   /// Concatenation method to use for splits
-  #[clap(short, long, possible_values = &["ffmpeg", "mkvmerge", "ivf"], default_value = "ffmpeg")]
+  #[structopt(short, long, possible_values = &["ffmpeg", "mkvmerge", "ivf"], default_value = "ffmpeg")]
   pub concat: ConcatMethod,
 
   /// Disable printing progress to terminal
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub quiet: bool,
 
   /// Print extra progress info and stats to terminal
-  #[clap(long)]
+  #[structopt(long)]
   pub verbose: bool,
 
   /// Enable logging
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub logging: Option<String>,
 
   /// Resume previous session
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub resume: bool,
 
   /// Keep temporary folder after encode
-  #[clap(long)]
+  #[structopt(long)]
   pub keep: bool,
 
   /// Method for creating chunks
-  #[clap(short = 'm', long, possible_values=&["segment", "select", "ffms2", "lsmash", "hybrid"])]
+  #[structopt(short = "m", long, possible_values=&["segment", "select", "ffms2", "lsmash", "hybrid"])]
   pub chunk_method: Option<ChunkMethod>,
 
   /// File location for scenes
-  #[clap(short, long, parse(from_os_str))]
+  #[structopt(short, long, parse(from_os_str))]
   pub scenes: Option<PathBuf>,
 
   /// Specify splitting method
-  #[clap(long, possible_values=&["av-scenechange", "av-scenechange-fast", "none"], default_value = "av-scenechange")]
+  #[structopt(long, possible_values=&["av-scenechange", "av-scenechange-fast", "none"], default_value = "av-scenechange")]
   pub split_method: SplitMethod,
 
   /// Number of frames after which make split
-  #[clap(short = 'x', long, default_value = "240")]
+  #[structopt(short = "x", long, default_value = "240")]
   pub extra_split: usize,
 
   /// Minimum number of frames in a split
-  #[clap(long, default_value = "60")]
+  #[structopt(long, default_value = "60")]
   pub min_scene_len: usize,
 
   /// Specify encoding passes
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub passes: Option<u8>,
 
   /// Parameters passed to the encoder
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub video_params: Option<String>,
 
-  #[clap(short, long, default_value = "aom", possible_values=&["aom", "rav1e", "vpx", "svt-av1", "x264", "x265"])]
+  #[structopt(short, long, default_value = "aom", possible_values=&["aom", "rav1e", "vpx", "svt-av1", "x264", "x265"])]
   pub encoder: Encoder,
 
   /// Number of workers
-  #[clap(short, long, default_value = "0")]
+  #[structopt(short, long, default_value = "0")]
   pub workers: usize,
 
   /// Force encoding if input args seen as invalid
-  #[clap(long)]
+  #[structopt(long)]
   pub force: bool,
 
   /// FFmpeg commands
-  #[clap(short = 'f', long)]
+  #[structopt(short = "f", long)]
   pub ffmpeg: Option<String>,
 
   /// FFmpeg commands
-  #[clap(short, long)]
+  #[structopt(short, long)]
   pub audio_params: Option<String>,
 
   /// FFmpeg pixel format
-  #[clap(long, default_value = "yuv420p10le")]
+  #[structopt(long, default_value = "yuv420p10le")]
   pub pix_format: String,
 
   /// Calculate VMAF after encode
-  #[clap(long)]
+  #[structopt(long)]
   pub vmaf: bool,
 
   /// Path to VMAF models
-  #[clap(long, parse(from_os_str))]
+  #[structopt(long, parse(from_os_str))]
   pub vmaf_path: Option<PathBuf>,
 
   /// Resolution used in VMAF calculation
-  #[clap(long, default_value = "1920x1080")]
+  #[structopt(long, default_value = "1920x1080")]
   pub vmaf_res: String,
 
   /// Number of threads to use for VMAF calculation
-  #[clap(long)]
+  #[structopt(long)]
   pub vmaf_threads: Option<u32>,
 
   /// Value to target
-  #[clap(long)]
+  #[structopt(long)]
   pub target_quality: Option<f32>,
 
   /// Method selection for target quality
-  #[clap(long, possible_values = &["per_shot"], default_value = "per_shot")]
+  #[structopt(long, possible_values = &["per_shot"], default_value = "per_shot")]
   pub target_quality_method: String,
 
   /// Number of probes to make for target_quality
-  #[clap(long, default_value = "4")]
+  #[structopt(long, default_value = "4")]
   pub probes: u32,
 
   /// Framerate for probes, 1 - original
-  #[clap(long, default_value = "4")]
+  #[structopt(long, default_value = "4")]
   pub probing_rate: u32,
 
   /// Use encoding settings for probes
-  #[clap(long)]
+  #[structopt(long)]
   pub probe_slow: bool,
 
   /// Min q for target_quality
-  #[clap(long)]
+  #[structopt(long)]
   pub min_q: Option<u32>,
 
   /// Max q for target_quality
-  #[clap(long)]
+  #[structopt(long)]
   pub max_q: Option<u32>,
 
   /// Filter applied to source at vmaf calcualation, use if you crop source
-  #[clap(long)]
+  #[structopt(long)]
   pub vmaf_filter: Option<String>,
 }

--- a/av1an-cli/src/main.rs
+++ b/av1an-cli/src/main.rs
@@ -3,11 +3,12 @@ use std::path::Path;
 use av1an_cli::Args;
 use av1an_core::vapoursynth;
 use av1an_core::{hash_path, is_vapoursynth, Project, Verbosity};
-use clap::Clap;
 use path_abs::{PathAbs, PathInfo};
 
+use structopt::StructOpt;
+
 pub fn main() -> anyhow::Result<()> {
-  let args = Args::parse();
+  let args = Args::from_args();
 
   let temp = if let Some(path) = args.temp {
     path.to_str().unwrap().to_owned()

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -11,10 +11,13 @@ av-format = "0.3.1"
 av-ivf = "0.2.2"
 num_cpus = "1.13.0"
 anyhow = "1.0.42"
-serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-sysinfo = "0.20.0"
-clap = "2.33.3"
+serde_json = "1.0"
+
+# do not upgrade sysinfo for now, as 0.20 requires rust 1.54 which is too new for MSYS2,
+# which currently only has 1.53
+sysinfo = "0.19.0"
+
 regex = "1.5.4"
 plotters = "0.3.1"
 splines = "4.0.0"

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -73,15 +73,9 @@ impl<'a> Broker<'a> {
 
     info!("Enc: {}, {} fr", chunk.index, chunk.frames);
 
-    // Target Quality mode
-    if self.project.target_quality.is_some() {
-      if let Some(ref method) = self.project.target_quality_method {
-        if method == "per_shot" {
-          if let Some(ref tq) = self.target_quality {
-            tq.per_shot_target_quality_routine(chunk);
-          }
-        }
-      }
+    // TODO change logic if other target quality methods are added in the future
+    if let Some(ref tq) = self.target_quality {
+      tq.per_shot_target_quality_routine(chunk);
     }
 
     // Run all passes for this chunk
@@ -140,8 +134,8 @@ impl<'a> Broker<'a> {
     let actual_frames = frame_probe(&chunk.output_path());
 
     if actual_frames != expected_frames {
-      info!(
-        "Chunk #{}: {}/{} fr",
+      warn!(
+        "FRAME MISMATCH: Chunk #{}: {}/{} fr",
         chunk.index, actual_frames, expected_frames
       );
     }

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -1,16 +1,8 @@
-#![allow(clippy::mutex_atomic)]
-// This is a mostly drop-in reimplementation of vspipe.
-// The main difference is what the errors look like.
-
-// Modified from vspipe example in vapoursynth crate
-// https://github.com/YaLTeR/vapoursynth-rs/blob/master/vapoursynth/examples/vspipe.rs
-extern crate vapoursynth;
-
 use std::collections::HashSet;
 use std::path::Path;
 
-use self::vapoursynth::prelude::*;
 use super::ChunkMethod;
+use vapoursynth::prelude::*;
 
 use anyhow::anyhow;
 

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -150,7 +150,7 @@ pub fn run_vmaf_on_files(
   cmd.arg(
     format!(
       "[0:v]scale={}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];[1:v]{}scale={}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}{}{}",
-      res, 
+      res,
       vmaf_filter,
       res,
       file_path.as_os_str().to_str().unwrap(),
@@ -226,7 +226,10 @@ pub fn run_vmaf_on_chunk(
   };
 
   let distorted = format!("[0:v]scale={}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[distorted];", &res);
-  let reference = format!("[1:v]{}scale={}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];", filter, &res);
+  let reference = format!(
+    "[1:v]{}scale={}:flags=bicubic:force_original_aspect_ratio=decrease,setpts=PTS-STARTPTS[ref];",
+    filter, &res
+  );
 
   let vmaf = if let Some(model) = model {
     format!(


### PR DESCRIPTION
Switch back to an old version of sysinfo, as 0.20 requires 1.54 to compile it, which is too new for MSYS2. Many minor simplifications.

We also switch to structopt for now instead of the beta release of clap, as clap officially recommends to not use the beta yet, and it caused some problems when compiling on Windows or with an older compiler.

Some minor changes:

- The `decow_strings` function has been removed, and we deal with `Cow<str>` properly now.
- The `remove_patterns` function now takes a mutable reference to a `Vec<String>` instead of copying one and modifing it to reduce complexity and overhead.
- The structs used to serialize the VMAF json result have been renamed to `VmafResult`, `Metrics`, and `VmafScore` (they were previously `Foo`, `Bar`, and `Baz`)
- Using an enum instead of a string as the argument to `log_probes` for better type safety and less overhead
- `frame_check_output` now warns if there is a mismatch, and the message has been updated to be more clear that a frame mismatch has occurred
- Several other small changes