### PR TITLE
Remove other unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,13 +173,8 @@ dependencies = [
 name = "av1an-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "av1an-core",
- "ctrlc",
- "path_abs",
  "serde",
- "serde_json",
- "shlex",
  "structopt",
 ]
 

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -4,11 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.42"
 structopt = "0.3.22"
-serde_json = "1.0.64"
 serde = { version = "1.0.126", features = ["serde_derive"] }
 av1an-core = { path = "../av1an-core" }
-shlex = "1.0.0"
-ctrlc = "3.1.9"
-path_abs = "0.5.1"


### PR DESCRIPTION
It seems like these dependencies don't need to be specified to compile, as they are already specified in the root Cargo.toml.