### PR TITLE
Refactoring, use ffms2 or lsmash for frame counting on chunks if avai…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,6 @@ dependencies = [
  "log",
  "num_cpus",
  "once_cell",
- "parking_lot",
  "path_abs",
  "plotters",
  "regex",
@@ -288,9 +287,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 dependencies = [
  "jobserver",
 ]
@@ -775,15 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,15 +856,6 @@ checksum = "fcf184a4b6b274f82a5df6b357da6055d3e82272327bba281c28bbba6f1664ef"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1088,31 +1069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1645,9 +1601,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1656,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1814,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "bytes",

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -263,7 +263,7 @@ pub fn cli() -> anyhow::Result<()> {
     ffmpeg_pipe: Vec::new(),
     chunk_method: args
       .chunk_method
-      .unwrap_or_else(|| vapoursynth::select_chunk_method().unwrap()),
+      .unwrap_or_else(|| vapoursynth::best_available_chunk_method()),
     concat: args.concat,
     encoder: args.encoder,
     extra_splits_len: Some(args.extra_split),

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -34,7 +34,6 @@ once_cell = "1.8.0"
 chrono = "0.4.19"
 strum = { version = "0.21", features = ["derive"] }
 itertools = "0.10.1"
-parking_lot = "0.11.1"
 which = "4.1.0"
 strsim = "0.10.0"
 crossbeam-channel = "0.5.1"

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use regex::Regex;
 
-const NULL: &'static str = if cfg!(target_os = "windows") {
+const NULL: &str = if cfg!(target_os = "windows") {
   "nul"
 } else {
   "/dev/null"
@@ -327,7 +327,7 @@ impl Encoder {
   }
 
   /// Returns regex used for matching q/crf arguments in command line
-  fn q_regex(&self) -> &'static Regex {
+  fn q_regex(self) -> &'static Regex {
     match &self {
       Self::aom | Self::vpx => regex!(r"--cq-level=.+"),
       Self::rav1e => regex!(r"--quantizer"),
@@ -355,8 +355,8 @@ impl Encoder {
   }
 
   /// Retuns regex for matching encoder progress in cli
-  fn pipe_match(&self) -> &'static Regex {
-    match &self {
+  fn pipe_match(self) -> &'static Regex {
+    match self {
       Self::aom | Self::vpx => regex!(r".*Pass (?:1/1|2/2) .*frame.*?/([^ ]+?) "),
       Self::rav1e => regex!(r"encoded.*? ([^ ]+?) "),
       Self::svt_av1 => regex!(r"Encoding frame\s+(\d+)"),

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -6,9 +6,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 /// Get frame count. Direct counting of frame count using ffmpeg
-pub fn get_frame_count(source: impl AsRef<Path>) -> usize {
-  let source = source.as_ref();
-
+pub fn get_frame_count(source: &Path) -> anyhow::Result<usize> {
   let mut cmd = Command::new("ffmpeg");
   cmd.args(&[
     "-hide_banner",
@@ -26,17 +24,18 @@ pub fn get_frame_count(source: impl AsRef<Path>) -> usize {
   cmd.stdout(Stdio::piped());
   cmd.stderr(Stdio::piped());
 
-  let out = cmd.output().unwrap();
+  let out = cmd.output()?;
 
   assert!(out.status.success());
 
-  let output = String::from_utf8(out.stderr).unwrap();
+  let output = String::from_utf8(out.stderr)?;
 
   let cap = regex!(r".*frame=\s*([0-9]+)\s")
     .captures_iter(&output)
     .last()
     .unwrap();
-  cap[1].parse::<usize>().unwrap()
+
+  Ok(cap[1].parse::<usize>()?)
 }
 
 /// Returns vec of all keyframes

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -1,7 +1,6 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 
 use once_cell::sync::OnceCell;
-use parking_lot::Mutex;
 
 const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(target_os = "windows") {
   // Do not use a spinner on Windows since the default console cannot display
@@ -49,59 +48,57 @@ pub fn finish_progress_bar() {
   }
 }
 
-static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Mutex<Vec<ProgressBar>>)> = OnceCell::new();
+static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Vec<ProgressBar>)> = OnceCell::new();
 
 pub fn init_multi_progress_bar(len: u64, workers: usize) {
-  let multi_progress_bar = MULTI_PROGRESS_BAR.get_or_init(|| {
-    let pb = MultiProgress::new();
+  MULTI_PROGRESS_BAR.get_or_init(|| {
+    let mpb = MultiProgress::new();
 
-    (pb, Mutex::new(Vec::new()))
+    let mut pbs = Vec::new();
+
+    for i in 0..workers {
+      let pb = ProgressBar::hidden()
+        .with_style(ProgressStyle::default_spinner().template("[{prefix}] {msg}"));
+      pb.set_prefix(format!("Worker {:02}", i + 1));
+      pbs.push(mpb.add(pb));
+    }
+
+    let pb = ProgressBar::hidden();
+    pb.set_style(
+      ProgressStyle::default_bar()
+        .template(INDICATIF_PROGRESS_TEMPLATE)
+        .with_key("fps", |state| format!("{:.2}", state.per_sec()))
+        .progress_chars("#>-"),
+    );
+    pb.enable_steady_tick(100);
+    pb.reset_elapsed();
+    pb.reset_eta();
+    pb.set_position(0);
+    pb.set_length(len);
+    pb.reset();
+    pbs.push(mpb.add(pb));
+
+    mpb.set_draw_target(ProgressDrawTarget::stderr());
+
+    (mpb, pbs)
   });
-
-  let mut pbs = multi_progress_bar.1.lock();
-
-  for i in 0..workers {
-    let pb = ProgressBar::hidden()
-      .with_style(ProgressStyle::default_spinner().template("[{prefix}] {msg}"));
-    pb.set_prefix(format!("Worker {:02}", i + 1));
-    pbs.push(multi_progress_bar.0.add(pb));
-  }
-
-  let pb = ProgressBar::hidden();
-  pb.set_style(
-    ProgressStyle::default_bar()
-      .template(INDICATIF_PROGRESS_TEMPLATE)
-      .with_key("fps", |state| format!("{:.2}", state.per_sec()))
-      .progress_chars("#>-"),
-  );
-  pb.enable_steady_tick(100);
-  pb.reset_elapsed();
-  pb.reset_eta();
-  pb.set_position(0);
-  pb.set_length(len);
-  pb.reset();
-  pbs.push(multi_progress_bar.0.add(pb));
-
-  multi_progress_bar
-    .0
-    .set_draw_target(ProgressDrawTarget::stderr());
 }
 
 pub fn update_mp_msg(worker_idx: usize, msg: String) {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    pbs.lock()[worker_idx].set_message(msg);
+    pbs[worker_idx].set_message(msg);
   }
 }
 
 pub fn update_mp_bar(inc: u64) {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    pbs.lock().last().unwrap().inc(inc);
+    pbs.last().unwrap().inc(inc);
   }
 }
 
 pub fn finish_multi_progress_bar() {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    for pb in pbs.lock().iter() {
+    for pb in pbs.iter() {
       pb.finish();
     }
   }

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -9,6 +9,7 @@ use std::convert::TryInto;
 use std::fmt::Error;
 use std::path::Path;
 use std::process::Stdio;
+
 pub struct TargetQuality<'a> {
   vmaf_res: String,
   vmaf_filter: String,
@@ -310,6 +311,7 @@ pub fn interpolate_target_vmaf(scores: Vec<(f64, u32)>, q: f64) -> Result<f64, E
   Ok(spline.sample(q).unwrap())
 }
 
+#[derive(Copy, Clone)]
 pub enum Skip {
   High,
   Low,
@@ -335,7 +337,7 @@ pub fn log_probes(
     match skip {
       Skip::High => " Early Skip High Q",
       Skip::Low => " Early Skip Low Q",
-      _ => "",
+      Skip::None => "",
     }
   );
   info!("Target Q: {:.0} VMAF: {:.2}", target_q, target_vmaf);

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -1,18 +1,28 @@
 use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
 use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+
+use crate::ffmpeg;
 
 use super::ChunkMethod;
+
+use once_cell::sync::Lazy;
+use path_abs::PathAbs;
 use vapoursynth::prelude::*;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 
-pub fn select_chunk_method() -> anyhow::Result<ChunkMethod> {
-  // Create a new VSScript environment.
-  let environment = Environment::new().map_err(|e| anyhow!("{}", e))?;
-  let core = environment.get_core().map_err(|e| anyhow!("{}", e))?;
+static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
+  let environment = Environment::new().expect("Failed to initialize VapourSynth environment");
+  let core = environment
+    .get_core()
+    .expect("Failed to get VapourSynth core");
 
   let plugins = core.plugins();
-  let plugins: HashSet<&str> = plugins
+  plugins
     .keys()
     .filter_map(|plugin| {
       plugins
@@ -20,27 +30,24 @@ pub fn select_chunk_method() -> anyhow::Result<ChunkMethod> {
         .ok()
         .and_then(|slice| std::str::from_utf8(slice).ok())
         .and_then(|s| s.split(';').nth(1))
+        .map(ToOwned::to_owned)
     })
-    .collect();
+    .collect()
+});
 
-  if plugins.contains("systems.innocent.lsmas") {
-    Ok(ChunkMethod::LSMASH)
-  } else if plugins.contains("com.vapoursynth.ffms2") {
-    Ok(ChunkMethod::FFMS2)
+pub fn best_available_chunk_method() -> ChunkMethod {
+  if VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas") {
+    ChunkMethod::LSMASH
+  } else if VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2") {
+    ChunkMethod::FFMS2
   } else {
-    Ok(ChunkMethod::Hybrid)
+    ChunkMethod::Hybrid
   }
 }
 
-pub fn num_frames(path: &Path) -> anyhow::Result<usize> {
-  // Create a new VSScript environment.
-  let mut environment = Environment::new().unwrap();
-
-  // Evaluate the script.
-  environment
-    .eval_file(path, EvalFlags::SetWorkingDir)
-    .unwrap();
-
+/// Get the number of frames from an environment that has already been
+/// evaluated on a script.
+fn get_num_frames(env: &mut Environment) -> anyhow::Result<usize> {
   // Get the output node.
   let output_index = 0;
 
@@ -50,19 +57,19 @@ pub fn num_frames(path: &Path) -> anyhow::Result<usize> {
     output_index
   ))?;
   #[cfg(not(feature = "gte-vsscript-api-31"))]
-  let (node, _) = (environment.get_output(output_index).unwrap(), None::<Node>);
+  let (node, _) = (env.get_output(output_index).unwrap(), None::<Node>);
 
   let num_frames = {
     let info = node.info();
 
     if let Property::Variable = info.format {
-      panic!("Cannot output clips with varying format");
+      bail!("Cannot output clips with varying format");
     }
     if let Property::Variable = info.resolution {
-      panic!("Cannot output clips with varying dimensions");
+      bail!("Cannot output clips with varying dimensions");
     }
     if let Property::Variable = info.framerate {
-      panic!("Cannot output clips with varying framerate");
+      bail!("Cannot output clips with varying framerate");
     }
 
     #[cfg(feature = "gte-vapoursynth-api-32")]
@@ -72,8 +79,7 @@ pub fn num_frames(path: &Path) -> anyhow::Result<usize> {
     let num_frames = {
       match info.num_frames {
         Property::Variable => {
-          // TODO: make it possible?
-          panic!("Cannot output clips with unknown length");
+          bail!("Cannot output clips with unknown length");
         }
         Property::Constant(x) => x,
       }
@@ -83,4 +89,111 @@ pub fn num_frames(path: &Path) -> anyhow::Result<usize> {
   };
 
   Ok(num_frames)
+}
+
+pub static FRAME_COUNT_FN: Lazy<fn(&Path) -> anyhow::Result<usize>> = Lazy::new(|| {
+  macro_rules! create_eval_fn {
+    ($filter:expr) => {
+      |source| {
+        let mut environment =
+          Environment::new().expect("Failed to initialize VapourSynth environment");
+
+        environment
+          .eval_script(&format!(
+            concat!(
+              "from vapoursynth import core\n",
+              "core.",
+              $filter,
+              "({:?}, cache=False).set_output()"
+            ),
+            source
+          ))
+          .unwrap();
+
+        get_num_frames(&mut environment)
+      }
+    };
+  }
+
+  // FFMS2 is preferred over L-SMASH for getting the number of frames of a clip
+  // since it correctly handles clips encoded with `--enable-keyframe-filtering=2`,
+  // while L-SMASH seems to crash
+  if VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2") {
+    create_eval_fn!("ffms2.Source")
+  } else if VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas") {
+    create_eval_fn!("lsmas.LWLibavSource")
+  } else {
+    ffmpeg::get_frame_count
+  }
+});
+
+/// Generates vapoursynth script for either FFMS2 or L-SMASH
+fn generate_script(source: &Path, cache_file: &Path, chunk_method: ChunkMethod) -> String {
+  format!(
+    "from vapoursynth import core
+core.{}({:?}, cachefile={:?}).set_output()",
+    match chunk_method {
+      ChunkMethod::FFMS2 => "ffms2.Source",
+      ChunkMethod::LSMASH => "lsmas.LWLibavSource",
+      _ => panic!(
+        "Chunk method {:?} is not a vapoursynth filter!",
+        chunk_method
+      ),
+    },
+    source,
+    cache_file
+  )
+}
+
+pub fn create_vs_file(
+  temp: &str,
+  source: &str,
+  chunk_method: ChunkMethod,
+) -> anyhow::Result<String> {
+  let temp: &Path = temp.as_ref();
+  let source = Path::new(source).canonicalize()?;
+
+  let load_script_path = temp.join("split").join("loadscript.vpy");
+
+  if load_script_path.exists() {
+    return Ok(load_script_path.to_string_lossy().to_string());
+  }
+  let mut load_script = File::create(&load_script_path)?;
+
+  let cache_file = PathAbs::new(temp.join("split").join(format!(
+    "cache.{}",
+    match chunk_method {
+      ChunkMethod::FFMS2 => "ffindex",
+      ChunkMethod::LSMASH => "lwi",
+      _ => return Err(anyhow!("invalid chunk method")),
+    }
+  )))
+  .unwrap();
+
+  load_script
+    .write_all(generate_script(&source, &cache_file.as_path(), chunk_method).as_bytes())?;
+
+  // TODO use vapoursynth crate instead
+  Command::new("vspipe")
+    .arg("-i")
+    .arg(&load_script_path)
+    .args(&["-i", "-"])
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()?
+    .wait()?;
+
+  Ok(load_script_path.to_string_lossy().to_string())
+}
+
+pub fn num_frames_script(source: &Path) -> anyhow::Result<usize> {
+  // Create a new VSScript environment.
+  let mut environment = Environment::new().unwrap();
+
+  // Evaluate the script.
+  environment
+    .eval_file(source, EvalFlags::SetWorkingDir)
+    .unwrap();
+
+  get_num_frames(&mut environment)
 }

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -115,13 +115,10 @@ pub static FRAME_COUNT_FN: Lazy<fn(&Path) -> anyhow::Result<usize>> = Lazy::new(
     };
   }
 
-  // FFMS2 is preferred over L-SMASH for getting the number of frames of a clip
-  // since it correctly handles clips encoded with `--enable-keyframe-filtering=2`,
-  // while L-SMASH seems to crash
-  if VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2") {
-    create_eval_fn!("ffms2.Source")
-  } else if VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas") {
+  if VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas") {
     create_eval_fn!("lsmas.LWLibavSource")
+  } else if VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2") {
+    create_eval_fn!("ffms2.Source")
   } else {
     ffmpeg::get_frame_count
   }


### PR DESCRIPTION
…lable

- This removes the `parking_lot::Mutex` wrapping the multi progress bar, as it was not actually necessary. This also removes `parking_lot` as a dependency, as it is unused now.

- We now evaluate a vapoursynth script in-memory (i.e. without creating any temporary files) to get the frame count for chunks if available. Note that ffms2 is preferred over lsmash for getting the frame count, as ffms2 works with `--enable-keyframe-filtering=2` in aomenc, but lsmash does not.

- Rework the implementation of `mkvmerge` concatenation to not perform any unnecessary UTF-8 validation or allocations. This requires an algorithm to specify chunks with a '+' in between, but without a trailing '+', without later removing arguments (as the API of `std::process:Command` does not support this).

- Also fix some miscellaneous clippy warnings.