### PR TITLE
Prevent data loss if concatenation failed

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -1273,7 +1273,9 @@ impl Project {
         plot_vmaf(&input, &output_file, model).unwrap();
       }
 
-      if !keep {
+      if !Path::new(&output_file).exists() {
+          warn!("Concatenating failed for unknown reasons! Temp folder will not be deleted: {}", temp);
+      } else if !keep {
         if let Err(e) = fs::remove_dir_all(temp) {
           warn!("Failed to delete temp directory: {}", e);
         }


### PR DESCRIPTION
I had multiple cases in which concatenation using `mkvmerge` silently failed and av1an deleted the temp folder afterwards. I saw the `mkvmerge` process running in the background but it never wrote to the output file.

Of course the real fix should include further debugging and location of the problem with mkvmerge, but this patch at least prevents data loss. People can either join the files manually or simply run av1an with `--resume` without losing possible hundreds of hours of encoding time.