### PR TITLE
Refactor: Remove `parking_lot::Mutex` from multi progress bar, rework…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,6 @@ dependencies = [
  "log",
  "num_cpus",
  "once_cell",
- "parking_lot",
  "path_abs",
  "plotters",
  "regex",
@@ -775,15 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,15 +856,6 @@ checksum = "fcf184a4b6b274f82a5df6b357da6055d3e82272327bba281c28bbba6f1664ef"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1086,31 +1067,6 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
 
 [[package]]
 name = "paste"

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -267,7 +267,7 @@ pub fn cli() -> anyhow::Result<()> {
     ffmpeg_pipe: Vec::new(),
     chunk_method: args
       .chunk_method
-      .unwrap_or_else(|| vapoursynth::select_chunk_method().unwrap()),
+      .unwrap_or_else(vapoursynth::best_available_chunk_method),
     concat: args.concat,
     encoder: args.encoder,
     extra_splits_len: Some(args.extra_split),

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -34,7 +34,6 @@ once_cell = "1.8.0"
 chrono = "0.4.19"
 strum = { version = "0.21", features = ["derive"] }
 itertools = "0.10.1"
-parking_lot = "0.11.1"
 which = "4.1.0"
 strsim = "0.10.0"
 crossbeam-channel = "0.5.1"

--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -8,6 +8,7 @@ use path_abs::PathAbs;
 use serde::{Deserialize, Serialize};
 use std::{
   fmt::Display,
+  fs,
   fs::{read_dir, DirEntry, File},
   io::Write,
   path::{Path, PathBuf},
@@ -49,7 +50,7 @@ pub fn sort_files_by_filename(files: &mut [PathBuf]) {
 }
 
 pub fn ivf(input: &Path, out: &Path) -> anyhow::Result<()> {
-  let mut files: Vec<PathBuf> = std::fs::read_dir(input)?
+  let mut files: Vec<PathBuf> = fs::read_dir(input)?
     .into_iter()
     .filter_map(Result::ok)
     .filter_map(|d| {
@@ -153,7 +154,7 @@ pub fn ivf(input: &Path, out: &Path) -> anyhow::Result<()> {
 pub fn mkvmerge(encode_folder: String, output: String) -> Result<(), anyhow::Error> {
   let mut encode_folder = PathBuf::from(encode_folder);
 
-  let mut audio_file = PathBuf::from(encode_folder.as_os_str());
+  let mut audio_file = PathBuf::from(&encode_folder);
   audio_file.push("audio.mkv");
 
   encode_folder.push("encode");
@@ -164,29 +165,66 @@ pub fn mkvmerge(encode_folder: String, output: String) -> Result<(), anyhow::Err
     .map(Result::unwrap)
     .collect();
 
+  assert!(!files.is_empty());
+
   files.sort_by_key(DirEntry::path);
 
   let mut cmd = Command::new("mkvmerge");
-  cmd.args([
-    "-o",
-    output.as_os_str().to_str().unwrap(),
-    "--append-mode",
-    "file",
-  ]);
+  cmd.arg("-o");
+  cmd.arg(output);
+  cmd.args(["--append-mode", "file"]);
 
   if audio_file.exists() {
-    cmd.arg(audio_file.as_os_str().to_str().unwrap());
-  };
-
-  let mut append_args = Vec::new();
-  for fl in files {
-    append_args.push(fl.path().as_os_str().to_str().unwrap().to_string());
-    append_args.push("+".to_string());
+    cmd.arg(audio_file);
   }
-  append_args.pop().unwrap();
 
-  cmd.args(append_args);
-  cmd.output().unwrap();
+  // `std::process::Command` does not support removing arguments after they have been added,
+  // so we have to add all elements without adding any extra that are later removed. This
+  // complicates the logic slightly, but in turn does not perform any unnecessary allocations
+  // or copy from a temporary data structure.
+  if files.len() % 2 != 0 {
+    let mut chunks = files.chunks_exact(2);
+    for files in &mut chunks {
+      // Each chunk always has exactly 2 elements.
+      for file in files {
+        cmd.arg(file.path());
+        cmd.arg("+");
+      }
+    }
+    // The remainder is always *exactly* one element since are using `chunks_exact(2)`, and we
+    // asserted that the length `files` is odd and nonzero in this branch.
+    cmd.arg(chunks.remainder()[0].path());
+  } else {
+    // The total number of elements at this point is even, and there are at *least* 2 elements,
+    // since `files` is not empty and the case of exactly one element would have been handled by
+    // the previous `if`, so we get the last 2 to handle them separately from the other pairs of 2,
+    // so as to not add a trailing "+" at the end.
+
+    // `files.len() - 2` cannot overflow, as `files.len()` is at least 2 here.
+    let (start, end) = files.split_at(files.len() - 2);
+
+    // `start` will be empty if there are exactly 2 elements in `files`, in which case
+    // this loop will not run.
+    for file in start {
+      cmd.arg(file.path());
+      cmd.arg("+");
+    }
+
+    // There are always *exactly* 2 elements in `end`, since we used `split_at(files.len() - 2)`,
+    // which will always succeed given that `files` has at least 2 elements at this point.
+    cmd.arg(end[0].path());
+    cmd.arg("+");
+    cmd.arg(end[1].path());
+  }
+
+  let output = cmd.output()?;
+
+  assert!(
+    output.status.success(),
+    "mkvmerge failed with output: {:?}",
+    output
+  );
+
   Ok(())
 }
 

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cmp, fmt::Display, path::PathBuf};
 
-const NULL: &'static str = if cfg!(target_os = "windows") {
+const NULL: &str = if cfg!(target_os = "windows") {
   "nul"
 } else {
   "/dev/null"
@@ -318,7 +318,7 @@ impl Encoder {
   }
 
   /// Returns regex used for matching q/crf arguments in command line
-  fn q_regex(&self) -> &'static Regex {
+  fn q_regex(self) -> &'static Regex {
     match &self {
       Self::aom | Self::vpx => regex!(r"--cq-level=.+"),
       Self::rav1e => regex!(r"--quantizer"),
@@ -346,8 +346,8 @@ impl Encoder {
   }
 
   /// Retuns regex for matching encoder progress in cli
-  fn pipe_match(&self) -> &'static Regex {
-    match &self {
+  fn pipe_match(self) -> &'static Regex {
+    match self {
       Self::aom | Self::vpx => regex!(r".*Pass (?:1/1|2/2) .*frame.*?/([^ ]+?) "),
       Self::rav1e => regex!(r"encoded.*? ([^ ]+?) "),
       Self::svt_av1 => regex!(r"Encoding frame\s+(\d+)"),
@@ -572,7 +572,7 @@ impl Encoder {
     }
   }
 
-  /// Function remove_patterns that takes in args and patterns and removes all instances of the patterns from the args.
+  /// Function `remove_patterns` that takes in args and patterns and removes all instances of the patterns from the args.
   pub fn remove_patterns(args: &mut Vec<String>, patterns: &[&str]) {
     for pattern in patterns {
       if let Some(index) = args.iter().position(|value| value.contains(pattern)) {

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::if_not_else)]
 
 #[macro_use]
 extern crate log;
@@ -172,10 +173,9 @@ pub fn hash_path(path: &str) -> String {
 
 fn frame_probe(source: &str) -> usize {
   if is_vapoursynth(source) {
-    crate::vapoursynth::num_frames(Path::new(source)).unwrap()
+    vapoursynth::num_frames(source.as_ref()).unwrap()
   } else {
-    // TODO evaluate vapoursynth script in-memory if ffms2 or lsmash exists
-    ffmpeg::get_frame_count(source)
+    ffmpeg::num_frames(source.as_ref()).unwrap()
   }
 }
 

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -1,6 +1,5 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use once_cell::sync::OnceCell;
-use parking_lot::Mutex;
 
 const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(target_os = "windows") {
   // Do not use a spinner on Windows since the default console cannot display
@@ -48,59 +47,57 @@ pub fn finish_progress_bar() {
   }
 }
 
-static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Mutex<Vec<ProgressBar>>)> = OnceCell::new();
+static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Vec<ProgressBar>)> = OnceCell::new();
 
 pub fn init_multi_progress_bar(len: u64, workers: usize) {
-  let multi_progress_bar = MULTI_PROGRESS_BAR.get_or_init(|| {
-    let pb = MultiProgress::new();
+  MULTI_PROGRESS_BAR.get_or_init(|| {
+    let mpb = MultiProgress::new();
 
-    (pb, Mutex::new(Vec::new()))
+    let mut pbs = Vec::new();
+
+    for i in 0..workers {
+      let pb = ProgressBar::hidden()
+        .with_style(ProgressStyle::default_spinner().template("[{prefix}] {msg}"));
+      pb.set_prefix(format!("Worker {:02}", i + 1));
+      pbs.push(mpb.add(pb));
+    }
+
+    let pb = ProgressBar::hidden();
+    pb.set_style(
+      ProgressStyle::default_bar()
+        .template(INDICATIF_PROGRESS_TEMPLATE)
+        .with_key("fps", |state| format!("{:.2}", state.per_sec()))
+        .progress_chars("#>-"),
+    );
+    pb.enable_steady_tick(100);
+    pb.reset_elapsed();
+    pb.reset_eta();
+    pb.set_position(0);
+    pb.set_length(len);
+    pb.reset();
+    pbs.push(mpb.add(pb));
+
+    mpb.set_draw_target(ProgressDrawTarget::stderr());
+
+    (mpb, pbs)
   });
-
-  let mut pbs = multi_progress_bar.1.lock();
-
-  for i in 0..workers {
-    let pb = ProgressBar::hidden()
-      .with_style(ProgressStyle::default_spinner().template("[{prefix}] {msg}"));
-    pb.set_prefix(format!("Worker {:02}", i + 1));
-    pbs.push(multi_progress_bar.0.add(pb));
-  }
-
-  let pb = ProgressBar::hidden();
-  pb.set_style(
-    ProgressStyle::default_bar()
-      .template(INDICATIF_PROGRESS_TEMPLATE)
-      .with_key("fps", |state| format!("{:.2}", state.per_sec()))
-      .progress_chars("#>-"),
-  );
-  pb.enable_steady_tick(100);
-  pb.reset_elapsed();
-  pb.reset_eta();
-  pb.set_position(0);
-  pb.set_length(len);
-  pb.reset();
-  pbs.push(multi_progress_bar.0.add(pb));
-
-  multi_progress_bar
-    .0
-    .set_draw_target(ProgressDrawTarget::stderr());
 }
 
 pub fn update_mp_msg(worker_idx: usize, msg: String) {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    pbs.lock()[worker_idx].set_message(msg);
+    pbs[worker_idx].set_message(msg);
   }
 }
 
 pub fn update_mp_bar(inc: u64) {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    pbs.lock().last().unwrap().inc(inc);
+    pbs.last().unwrap().inc(inc);
   }
 }
 
 pub fn finish_multi_progress_bar() {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    for pb in pbs.lock().iter() {
+    for pb in pbs.iter() {
       pb.finish();
     }
   }

--- a/av1an-core/src/project.rs
+++ b/av1an-core/src/project.rs
@@ -255,11 +255,11 @@ impl Project {
       } else {
         create_vs_file(&self.temp, &self.input, self.chunk_method).unwrap()
       };
-      let fr = vapoursynth::num_frames(Path::new(&vs)).unwrap();
+      let fr = vapoursynth::num_frames(vs.as_ref()).unwrap();
       assert!(fr != 0, "vapoursynth reported 0 frames");
       fr
     } else {
-      ffmpeg::get_frame_count(&self.input)
+      ffmpeg::num_frames(self.input.as_ref()).unwrap()
     };
 
     self.frames

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -303,6 +303,7 @@ pub fn interpolate_target_vmaf(scores: Vec<(f64, u32)>, q: f64) -> Result<f64, E
   Ok(spline.sample(q).unwrap())
 }
 
+#[derive(Copy, Clone)]
 pub enum Skip {
   High,
   Low,
@@ -328,7 +329,7 @@ pub fn log_probes(
     match skip {
       Skip::High => " Early Skip High Q",
       Skip::Low => " Early Skip Low Q",
-      _ => "",
+      Skip::None => "",
     }
   );
   info!("Target Q: {:.0} VMAF: {:.2}", target_q, target_vmaf);

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -189,7 +189,7 @@ pub fn plot_vmaf(
 ) -> Result<(), Error> {
   let source = source.as_ref();
   let output = output.as_ref();
-  let model = model.as_ref().map(|path| path.as_ref());
+  let model = model.as_ref().map(AsRef::as_ref);
 
   println!(":: VMAF Run");
 


### PR DESCRIPTION
… mkvmerge concatenation implementation

- This removes the `parking_lot::Mutex` wrapping the multi progress bar, as it was not actually necessary. This also removes `parking_lot` as a dependency, as it is unused now.

- Rework the implementation of `mkvmerge` concatenation to not perform any unnecessary UTF-8 validation or allocations. This requires an algorithm to specify chunks with a '+' in between, but without a trailing '+', without later removing arguments (as the API of `std::process:Command` does not support this). This does not change the behavior of `-c mkvmerge` in any way, however.

- Also fix some miscellaneous clippy warnings.