### PR TITLE
Print scenechange info to stderr when in verbose mode

### DIFF
--- a/av1an-core/src/project.rs
+++ b/av1an-core/src/project.rs
@@ -463,6 +463,14 @@ impl Project {
       scenes = extra_splits(scenes, self.frames, split_len);
       info!("SC: Now at {} scenes", scenes.len() + 1);
     }
+    if self.verbosity == Verbosity::Verbose {
+      // Also print this info to stderr in verbose mode
+      eprintln!("Found {} scenes", scenes.len() + 1);
+      if let Some(split_len) = self.extra_splits_len {
+        eprintln!("Applying extra splits every {} frames", split_len);
+        eprintln!("Now at {} scenes", scenes.len() + 1);
+      }
+    }
 
     self.write_scenes_to_file(&scenes, scene_file.as_path().to_str().unwrap());
 


### PR DESCRIPTION
I found myself frequently having to look in the log file to see this,
and felt it would be more convenient to have it printed to the terminal.
This only affects verbose mode--normal mode will continue to print
this info to only the log file.