### PR TITLE
Add new scenechange method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "av-scenechange"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1710d6df78c912316637586ab68b794a158633954f12d22a47b8c90ce1255b95"
+checksum = "d42e2f96f7f4cc93b5043e8acaa6a83028b687c7b84c7f5a436a6dc4970ee0c9"
 dependencies = [
  "clap",
  "rav1e",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "rav1e"
-version = "0.5.0-beta"
+version = "0.5.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80b9488c1dca7379d29d43fac55038b5482cf3b29d1335b9d9b4bc2dbcca9c7"
+checksum = "819fe17f51d8eb13046a9602d00b56f2bb2da3c84d16e6d280afd87c5a815698"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
@@ -1835,9 +1835,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "v_frame"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b4c7125fe75942c6bca0fe93cd5a6018778791297cfb21283be47f1d52185b"
+checksum = "594718cad812ffd9e3784bdf272a233805b4b7a8d560b9ec30b1ae71d60eb23a"
 dependencies = [
  "cfg-if 1.0.0",
  "noop_proc_macro",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -41,7 +41,7 @@ crossbeam-utils = "0.8.5"
 flexi_logger = "0.18.0"
 textwrap = "0.14.2"
 path_abs = "0.5.1"
-av-scenechange = "0.6.0"
+av-scenechange = "0.7.0"
 y4m = "0.7.0"
 
 [dependencies.vapoursynth]

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -93,10 +93,18 @@ pub fn list_index_of_regex(params: &[String], re: &Regex) -> Option<usize> {
 pub enum SplitMethod {
   #[strum(serialize = "av-scenechange")]
   AvScenechange,
-  #[strum(serialize = "av-scenechange-fast")]
-  AvScenechangeFast,
   #[strum(serialize = "none")]
   None,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, strum::EnumString, strum::IntoStaticStr)]
+pub enum ScenecutMethod {
+  #[strum(serialize = "fast")]
+  Fast,
+  #[strum(serialize = "medium")]
+  Medium,
+  #[strum(serialize = "slow")]
+  Slow,
 }
 
 #[derive(

--- a/av1an-core/src/project.rs
+++ b/av1an-core/src/project.rs
@@ -15,7 +15,7 @@ use crate::{
   suggest_fix, vapoursynth,
   vapoursynth::{create_vs_file, is_vapoursynth},
   vmaf::plot_vmaf,
-  ChunkMethod, DashMap, DoneJson, Encoder, SplitMethod, TargetQuality, Verbosity,
+  ChunkMethod, DashMap, DoneJson, Encoder, ScenecutMethod, SplitMethod, TargetQuality, Verbosity,
 };
 use anyhow::{bail, ensure};
 use crossbeam_utils;
@@ -48,6 +48,8 @@ pub struct Project {
   pub chunk_method: ChunkMethod,
   pub scenes: Option<String>,
   pub split_method: SplitMethod,
+  pub sc_method: ScenecutMethod,
+  pub sc_downscale_height: Option<usize>,
   pub extra_splits_len: Option<usize>,
   pub min_scene_len: usize,
 
@@ -423,16 +425,8 @@ impl Project {
         self.min_scene_len,
         self.verbosity,
         self.is_vs,
-        false,
-      )
-      .unwrap(),
-      SplitMethod::AvScenechangeFast => av_scenechange_detect(
-        &self.input,
-        self.frames,
-        self.min_scene_len,
-        self.verbosity,
-        self.is_vs,
-        true,
+        self.sc_method,
+        self.sc_downscale_height,
       )
       .unwrap(),
       SplitMethod::None => Vec::with_capacity(0),


### PR DESCRIPTION
This leaves the default at medium, which is an improved version
of the current scenecut detection method.
The fast method has also been improved from its previous version.
The slow method is a completely new implementation, which has
been shown to be more accurate, but is also about 15% slower.

This also removes the av-scenechange-fast split method,
in favor of making a separate CLI option for --sc-method,
which can be set to "fast", "medium", or "slow".

This also adds a CLI option for scenecut downscaling,
which can be specified by providing a maximum height e.g.
--sc-downscale-height 720 to downscale any input which is
above 720p to 720p for scenecut detection.
This will avoid upscaling anything below 720p, because that
would just slow down scenecut detection for no benefit.