### PR TITLE
Fix confirmation prompt

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -181,14 +181,12 @@ fn confirm(prompt: &str) -> io::Result<bool> {
     stdout.flush()?;
     stdin.read_line(&mut buf)?;
 
-    match buf.as_str() {
-      "y\n" | "Y\n" => break Ok(true),
-      "n\n" | "N\n" => break Ok(false),
+    match buf.as_str().trim() {
+      // allows enter to continue
+      "y" | "Y" | "" => break Ok(true),
+      "n" | "N" => break Ok(false),
       other => {
-        println!(
-          "Sorry, response {:?} is not understood.",
-          &other.get(..other.len().saturating_sub(1)).unwrap_or("")
-        );
+        println!("Sorry, response {:?} is not understood.", other);
         buf.clear();
         continue;
       }


### PR DESCRIPTION
Fixes #359 and also is more clear that pressing enter will not overwrite.