### PR TITLE
Use a different method for ffmpeg frame count

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --no-default-features
 
       - name: Build Av1an
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - "*.md"
 
 env:
-  deps: tree
+  deps: tree llvm clang
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
@@ -82,14 +82,14 @@ jobs:
             default: true
             components: rustfmt, clippy
 
+      - name: Install requirements
+        run: |
+          apt-get update && apt-get install -y ${{ env.deps }}
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
           command: check
-
-      - name: Install requirements
-        run: |
-          apt-get update && apt-get install -y ${{ env.deps }}
 
       - name: Build Av1an
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "av-data",
  "av-format",
  "log",
- "nom",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ dependencies = [
  "path_abs",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 1.1.0",
  "structopt",
 ]
 
@@ -187,7 +187,7 @@ dependencies = [
  "ctrlc",
  "path_abs",
  "serde",
- "shlex",
+ "shlex 1.1.0",
  "structopt",
 ]
 
@@ -203,6 +203,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
+ "ffmpeg-next",
  "flexi_logger",
  "indicatif",
  "itertools",
@@ -238,6 +239,26 @@ dependencies = [
  "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if 0.1.10",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 0.1.1",
 ]
 
 [[package]]
@@ -304,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom 5.1.2",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +365,17 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -615,6 +656,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ffmpeg-next"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676cda947a87a1e8a42e154059c567e75de64860252cce52c684acd8c074fa0"
+dependencies = [
+ "bitflags",
+ "ffmpeg-sys-next",
+ "libc",
+]
+
+[[package]]
+name = "ffmpeg-sys-next"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de57234f2c49c6e093fe67bbbaa9142c228f6e2d5533ef27980993d5b6adef2a"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "num_cpus",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "flexi_logger"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +938,16 @@ checksum = "fcf184a4b6b274f82a5df6b357da6055d3e82272327bba281c28bbba6f1664ef"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi",
 ]
 
 [[package]]
@@ -953,6 +1035,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1114,6 +1206,12 @@ checksum = "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff"
 dependencies = [
  "rustc_version 0.3.3",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pest"
@@ -1413,6 +1511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1636,12 @@ dependencies = [
  "freetype-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shlex"
@@ -1878,6 +1988,12 @@ checksum = "c5ad7879f2893d1574b128d26e65aedf38c3c01ac3af1c7d09cc6bc4c5148b87"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ structopt = "0.3.22"
 av1an-cli = { path = "av1an-cli", version = "0.1.1" }
 av1an-core = { path = "av1an-core", version = "0.1.0" }
 
+[features]
+default = ["ffmpeg_static"]
+ffmpeg_static = ["av1an-core/ffmpeg_static"]
 
 [workspace]
 members = ["av1an-core", "av1an-cli"]
+
+[profile.dev.package.av-scenechange]
+opt-level = 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM luigi311/encoders-docker:latest
 
 ENV MPLCONFIGDIR="/home/app_user/"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DEPENDENCIES="mkvtoolnix curl"
+ARG DEPENDENCIES="mkvtoolnix curl llvm clang"
 
 # Install dependencies
 RUN apt-get update && \

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -44,6 +44,10 @@ path_abs = "0.5.1"
 av-scenechange = "0.7.0"
 y4m = "0.7.0"
 
+[dependencies.ffmpeg-next]
+version = "4.4.0"
+features = ["static"]
+
 [dependencies.vapoursynth]
 version = "0.3.0"
 features = ["vsscript-functions", "vapoursynth-functions"]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -46,7 +46,6 @@ y4m = "0.7.0"
 
 [dependencies.ffmpeg-next]
 version = "4.4.0"
-features = ["static"]
 
 [dependencies.vapoursynth]
 version = "0.3.0"
@@ -59,3 +58,6 @@ features = ["rt", "process", "io-util"]
 [dependencies.dashmap]
 version = "4.0.2"
 features = ["serde"]
+
+[features]
+ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -11,7 +11,9 @@ const NULL: &str = if cfg!(target_os = "windows") {
 };
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, strum::EnumString, strum::IntoStaticStr)]
+#[derive(
+  Clone, Copy, PartialEq, Serialize, Deserialize, Debug, strum::EnumString, strum::IntoStaticStr,
+)]
 pub enum Encoder {
   aom,
   rav1e,

--- a/av1an-core/src/project.rs
+++ b/av1an-core/src/project.rs
@@ -91,6 +91,8 @@ pub struct Project {
 impl Project {
   /// Initialize logging routines and create temporary directories
   pub fn initialize(&mut self) -> anyhow::Result<()> {
+    ffmpeg_next::init()?;
+
     info!("File hash: {}", hash_path(&self.input));
 
     self.resume = self.resume && Path::new(&self.temp).join("done.json").exists();

--- a/av1an-core/src/project.rs
+++ b/av1an-core/src/project.rs
@@ -387,6 +387,18 @@ impl Project {
       self.video_params = self.encoder.get_default_arguments();
     }
 
+    if self.encoder == Encoder::aom
+      && self.concat != ConcatMethod::MKVMerge
+      && self
+        .video_params
+        .iter()
+        .any(|param| param == "--enable-keyframe-filtering=2")
+    {
+      bail!(
+        "keyframe filtering mode 2 currently only works when using mkvmerge as the concat method"
+      );
+    }
+
     self.validate_input();
     self.initialize().unwrap();
 


### PR DESCRIPTION
This method uses ffprobe to count the number of packets
(which is identical to the number of frames, but faster)
in a video stream. This works with more video formats,
including with --enable-keyframe-filtering=2 in aomenc.
Performance should be similar or better than ffmpeg -copy.

Fixes #367