### PR TITLE
Fix many clippy warnings, many small code style changes

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -10,7 +10,7 @@ use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
 use av1an_core::{
   encoder::Encoder,
   hash_path,
-  project::Project,
+  settings::EncodeArgs,
   vapoursynth, Verbosity,
   {concat::ConcatMethod, ChunkMethod, SplitMethod},
 };
@@ -141,7 +141,7 @@ pub struct Args {
 
   /// Value to target
   #[structopt(long)]
-  pub target_quality: Option<f32>,
+  pub target_quality: Option<f64>,
 
   /// Number of probes to make for target_quality
   #[structopt(long, default_value = "4")]
@@ -201,7 +201,7 @@ pub fn cli() -> anyhow::Result<()> {
 
   // TODO parse with normal (non proc-macro) clap methods to simplify this
   // Unify Project/Args
-  let mut project = Project {
+  let mut project = EncodeArgs {
     frames: 0,
     logging: if let Some(log_file) = args.logging {
       Path::new(&format!("{}.log", log_file)).to_owned()
@@ -226,14 +226,14 @@ pub fn cli() -> anyhow::Result<()> {
       Vec::new()
     },
     output_file: if let Some(output) = args.output_file {
-      if output.exists() {
-        if !confirm(&format!(
+      if output.exists()
+        && !confirm(&format!(
           "Output file {:?} exists. Do you want to overwrite it? [Y/n]: ",
           output
-        ))? {
-          println!("Not overwriting, aborting.");
-          return Ok(());
-        }
+        ))?
+      {
+        println!("Not overwriting, aborting.");
+        return Ok(());
       }
 
       let output = PathAbs::new(output).context(
@@ -257,14 +257,14 @@ pub fn cli() -> anyhow::Result<()> {
         args.encoder
       );
 
-      if Path::new(&*default_path).exists() {
-        if !confirm(&format!(
+      if Path::new(&*default_path).exists()
+        && !confirm(&format!(
           "Default output file {:?} exists. Do you want to overwrite it? [Y/n]: ",
           &default_path
-        ))? {
-          println!("Not overwriting, aborting.");
-          return Ok(());
-        }
+        ))?
+      {
+        println!("Not overwriting, aborting.");
+        return Ok(());
       }
 
       default_path
@@ -297,9 +297,7 @@ pub fn cli() -> anyhow::Result<()> {
     probes: args.probes,
     probing_rate: args.probing_rate,
     resume: args.resume,
-    scenes: args
-      .scenes
-      .map(|scenes| scenes.to_str().unwrap().to_owned()),
+    scenes: args.scenes,
     split_method: args.split_method,
     sc_method: args.sc_method,
     sc_downscale_height: args.sc_downscale_height,
@@ -314,7 +312,7 @@ pub fn cli() -> anyhow::Result<()> {
     vmaf: args.vmaf,
     vmaf_filter: args.vmaf_filter,
     vmaf_path: args.vmaf_path,
-    vmaf_res: Some(args.vmaf_res),
+    vmaf_res: args.vmaf_res,
     workers: args.workers,
   };
 

--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -264,7 +264,7 @@ pub fn ffmpeg(temp: &Path, output: &Path, encoder: Encoder) {
 
   let audio_file = temp.join("audio.mkv");
 
-  let audio_cmd = if audio_file.exists() && audio_file.metadata().unwrap().len() > 1000 {
+  let audio_args = if audio_file.exists() && audio_file.metadata().unwrap().len() > 1000 {
     vec!["-i", audio_file.to_str().unwrap(), "-c", "copy"]
   } else {
     Vec::with_capacity(0)
@@ -291,7 +291,7 @@ pub fn ffmpeg(temp: &Path, output: &Path, encoder: Encoder) {
         "-i",
         concat_file,
       ])
-      .args(audio_cmd)
+      .args(audio_args)
       .args(&[
         "-c",
         "copy",
@@ -301,8 +301,8 @@ pub fn ffmpeg(temp: &Path, output: &Path, encoder: Encoder) {
         "0",
         "-f",
         "mp4",
-        output.to_str().unwrap(),
-      ]),
+      ])
+      .arg(output),
     _ => cmd
       .args([
         "-y",
@@ -316,8 +316,9 @@ pub fn ffmpeg(temp: &Path, output: &Path, encoder: Encoder) {
         "-i",
         concat_file,
       ])
-      .args(audio_cmd)
-      .args(["-c", "copy", output.to_str().unwrap()]),
+      .args(audio_args)
+      .args(["-c", "copy"])
+      .arg(output),
   };
   let out = cmd.output().unwrap();
 

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -594,11 +594,11 @@ impl Encoder {
   pub fn probe_cmd(
     self,
     temp: String,
-    name: String,
+    name: &str,
     q: usize,
     ffmpeg_pipe: Vec<String>,
     probing_rate: usize,
-    n_threads: usize,
+    vmaf_threads: usize,
     mut video_params: Vec<String>,
     probe_slow: bool,
   ) -> (Vec<String>, Vec<Cow<'static, str>>) {
@@ -644,7 +644,7 @@ impl Encoder {
 
       ps
     } else {
-      self.construct_target_quality_command(n_threads, q)
+      self.construct_target_quality_command(vmaf_threads, q)
     };
 
     let output: Vec<Cow<str>> = match self {

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -24,7 +24,8 @@ pub fn compose_ffmpeg_pipe(params: Vec<String>) -> Vec<String> {
 
   p
 }
-/// Get frame count. Direct counting of frame count using ffmpeg
+
+/// Get frame count using FFmpeg
 pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
   let mut ictx = input(&source)?;
   let input = ictx
@@ -134,11 +135,4 @@ pub fn escape_path_in_filter(path: impl AsRef<Path>) -> String {
       .unwrap()
       .to_string()
   }
-}
-
-/// Check for `FFmpeg`
-pub fn get_ffmpeg_info() -> String {
-  let mut cmd = Command::new("ffmpeg");
-  cmd.stderr(Stdio::piped());
-  String::from_utf8(cmd.output().unwrap().stderr).unwrap()
 }

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -16,7 +16,7 @@ pub fn av_scenechange_detect(
     progress_bar::init_progress_bar(total_frames as u64);
   }
 
-  let mut frames = crate::scene_detect::scene_detect(
+  let mut frames = scene_detect(
     input,
     if verbosity == Verbosity::Quiet {
       None
@@ -42,10 +42,8 @@ pub fn av_scenechange_detect(
 }
 
 /// Detect scene changes using rav1e scene detector.
-///
-/// src: Input to video.
 pub fn scene_detect(
-  src: &Input,
+  input: &Input,
   callback: Option<Box<dyn Fn(usize, usize)>>,
   min_scene_len: usize,
   sc_method: ScenecutMethod,
@@ -64,7 +62,7 @@ pub fn scene_detect(
 
   Ok(
     detect_scene_changes::<_, u8>(
-      &mut y4m::Decoder::new(match src {
+      &mut y4m::Decoder::new(match input {
         Input::VapourSynth(path) => {
           let vspipe = Command::new("vspipe")
             .arg("-y")
@@ -107,7 +105,7 @@ pub fn scene_detect(
           ScenecutMethod::Medium => SceneDetectionSpeed::Medium,
           ScenecutMethod::Slow => SceneDetectionSpeed::Slow,
         },
-        ..Default::default()
+        ..DetectionOptions::default()
       },
       callback,
     )


### PR DESCRIPTION
Mostly just stylistic changes/cleanups, but some notable changes:

- Validating encoder params now operates over string views of the original help text output rather than allocating new strings for everything
- The `Project` struct has been renamed to `EncodeArgs`, and the `project` module has been renamed to `settings`