### PR TITLE
Perform startup check before confirming output file overwrite

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -151,7 +151,7 @@ pub fn ivf(input: &Path, out: &Path) -> anyhow::Result<()> {
   Ok(())
 }
 
-pub fn mkvmerge(encode_folder: &Path, output: &Path) -> Result<(), anyhow::Error> {
+pub fn mkvmerge(encode_folder: &Path, output: &Path) -> anyhow::Result<()> {
   let mut encode_folder = PathBuf::from(encode_folder);
 
   let mut audio_file = PathBuf::from(&encode_folder);
@@ -192,7 +192,7 @@ pub fn mkvmerge(encode_folder: &Path, output: &Path) -> Result<(), anyhow::Error
       }
     }
     // The remainder is always *exactly* one element since we are using `chunks_exact(2)`, and we
-    // asserted that the length `files` is odd and nonzero in this branch.
+    // asserted that the length of `files` is odd and nonzero in this branch.
     cmd.arg(chunks.remainder()[0].path());
   } else {
     // The total number of elements at this point is even, and there are at *least* 2 elements,
@@ -221,7 +221,7 @@ pub fn mkvmerge(encode_folder: &Path, output: &Path) -> Result<(), anyhow::Error
 
   assert!(
     output.status.success(),
-    "mkvmerge failed with output: {:?}",
+    "mkvmerge failed with output: {:#?}",
     output
   );
 

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -43,7 +43,7 @@ pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
 }
 
 /// Returns vec of all keyframes
-pub fn get_keyframes<P: AsRef<Path>>(source: P) -> Vec<usize> {
+pub fn get_keyframes(source: &Path) -> Vec<usize> {
   let mut ictx = input(&source).unwrap();
   let input = ictx
     .streams()


### PR DESCRIPTION
Fixes slightly annoying issue where the startup check is performed after confirming output overwrite. Also small fixes/style changes as always.