### PR TITLE
Do not split encoder args for non-vpx-based CLIs

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -333,9 +333,13 @@ impl EncodeArgs {
       .as_slice()
       .iter()
       .filter_map(|param| {
-        if param.starts_with('-') {
+        if param.starts_with('-') && [Encoder::aom, Encoder::vpx].contains(&self.encoder) {
+          // These encoders require args to be passed using an equal sign,
+          // e.g. `--cq-level=30`
           param.split('=').next()
         } else {
+          // The other encoders use a space, so we don't need to do extra splitting,
+          // e.g. `--crf 30`
           None
         }
       })


### PR DESCRIPTION
This fixes an issue with encoders such as x264
where parsing would fail if you passed a negative
argument, such as `--deblock -1:-1`.