### PR TITLE
Reduce piping overhead to encoder in certain situations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,8 +179,8 @@ dependencies = [
  "anyhow",
  "av1an-core",
  "ctrlc",
+ "ffmpeg-next",
  "path_abs",
- "serde",
  "shlex 1.1.0",
  "structopt",
 ]
@@ -211,7 +211,7 @@ dependencies = [
  "serde_json",
  "splines",
  "strsim 0.10.0",
- "strum",
+ "strum 0.22.0",
  "sysinfo",
  "textwrap 0.14.2",
  "tokio",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crossbeam-channel"
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
@@ -1347,8 +1347,14 @@ name = "strum"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+
+[[package]]
+name = "strum"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.22.0",
 ]
 
 [[package]]
@@ -1356,6 +1362,18 @@ name = "strum_macros"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1376,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1388,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffff4a02fa61eee51f95210fc9c98ea6eeb46bb071adeafd61e1a0b9b22c6a6d"
+checksum = "e223c65cd36b485a34c2ce6e38efa40777d31c4166d9076030c74cdcf971679f"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -1412,8 +1430,8 @@ dependencies = [
  "heck",
  "itertools",
  "pkg-config",
- "strum",
- "strum_macros",
+ "strum 0.21.0",
+ "strum_macros 0.21.1",
  "thiserror",
  "toml",
  "version-compare",
@@ -1457,18 +1475,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ av1an-core = { path = "av1an-core", version = "0.1.0" }
 
 [features]
 default = ["ffmpeg_static"]
-ffmpeg_static = ["av1an-core/ffmpeg_static"]
+ffmpeg_static = ["av1an-core/ffmpeg_static", "av1an-cli/ffmpeg_static"]
 
 [workspace]
 members = ["av1an-core", "av1an-cli"]

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -17,5 +17,10 @@ shlex = "1.0.0"
 ctrlc = "3.1.9"
 path_abs = "0.5.1"
 anyhow = "1.0.42"
-serde = { version = "1.0.126", features = ["serde_derive"] }
 av1an-core = { path = "../av1an-core", version = "0.1.0" }
+
+[dependencies.ffmpeg-next]
+version = "4.4.0"
+
+[features]
+ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -3,8 +3,8 @@ use anyhow::{bail, ensure};
 use av1an_core::into_vec;
 use av1an_core::Input;
 use av1an_core::ScenecutMethod;
+use ffmpeg_next::format::Pixel;
 use path_abs::{PathAbs, PathInfo};
-use serde::{Deserialize, Serialize};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
@@ -18,7 +18,7 @@ use av1an_core::{
 };
 
 /// Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding
-#[derive(StructOpt, Debug, Serialize, Deserialize)]
+#[derive(StructOpt, Debug)]
 #[structopt(name = "av1an", setting = ColoredHelp)]
 pub struct Args {
   /// Input file or vapoursynth (.py, .vpy) script
@@ -123,7 +123,7 @@ pub struct Args {
 
   /// FFmpeg pixel format
   #[structopt(long, default_value = "yuv420p10le")]
-  pub pix_format: String,
+  pub pix_format: Pixel,
 
   /// Calculate VMAF after encode
   #[structopt(long)]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -27,7 +27,7 @@ splines = "4.0.0"
 indicatif = "0.17.0-beta.1"
 once_cell = "1.8.0"
 chrono = "0.4.19"
-strum = { version = "0.21", features = ["derive"] }
+strum = { version = "0.22.0", features = ["derive"] }
 itertools = "0.10.1"
 which = "4.1.0"
 strsim = "0.10.0"

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -1,5 +1,5 @@
 use crate::into_vec;
-use ffmpeg_next::format::input;
+use ffmpeg_next::format::{input, Pixel};
 use ffmpeg_next::media::Type as MediaType;
 use ffmpeg_next::Error::StreamNotFound;
 use path_abs::{PathAbs, PathInfo};
@@ -40,6 +40,19 @@ pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
       .filter(|(stream, _)| stream.index() == video_stream_index)
       .count(),
   )
+}
+
+pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg_next::Error> {
+  let ictx = ffmpeg_next::format::input(&source)?;
+
+  let input = ictx
+    .streams()
+    .best(MediaType::Video)
+    .ok_or(StreamNotFound)?;
+
+  let decoder = input.codec().decoder().video()?;
+
+  Ok(decoder.format())
 }
 
 /// Returns vec of all keyframes


### PR DESCRIPTION
Previously, we always piped the chunk method into FFmpeg
to apply filters and convert the pixel format, but this
just adds unnecessary overhead if there is no FFmpeg filter
specified and if the pixel format of the source and encode
are the same. So, in that situation, we now pipe the chunk
method directly into the encoder instead. This should
nicely speed things up a bit (and possibly reduce memory
consumption).

Additionally, `--pix-format` is now verified using the FFmpeg
API when the CLI args are parsed, making it impossible to
accidentally specify an incorrect format. Previously, there
were no checks at all, so if you specified the wrong format it
would just fail during the encoding process with no obvious
indication of the root cause.

This does not apply to vapoursynth input for now, as that
would be slightly more complicated since it has a different
API for getting the pixel format.