### PR TITLE
Changes for rav1e's hybrid scene detection update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,8 +147,7 @@ dependencies = [
 [[package]]
 name = "av-scenechange"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6862bce3788390cfa690dca7f4392646773cbfaef2154ab0059d32b60ff74bf"
+source = "git+https://github.com/rust-av/av-scenechange?branch=hybrid-sc#951d57a042a2ec2fffc9951fa72279ad4e01eaeb"
 dependencies = [
  "clap",
  "rav1e",
@@ -1064,8 +1063,7 @@ dependencies = [
 [[package]]
 name = "rav1e"
 version = "0.5.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819fe17f51d8eb13046a9602d00b56f2bb2da3c84d16e6d280afd87c5a815698"
+source = "git+https://github.com/xiph/rav1e#beb1839fcd0ef31e94a966e4ed47387712094704"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
@@ -1560,8 +1558,7 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 [[package]]
 name = "v_frame"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594718cad812ffd9e3784bdf272a233805b4b7a8d560b9ec30b1ae71d60eb23a"
+source = "git+https://github.com/xiph/rav1e#beb1839fcd0ef31e94a966e4ed47387712094704"
 dependencies = [
  "cfg-if 1.0.0",
  "noop_proc_macro",
@@ -1607,13 +1604,11 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
+version = "3.0.4"
+source = "git+https://github.com/xiph/rav1e#beb1839fcd0ef31e94a966e4ed47387712094704"
 dependencies = [
  "bitflags",
  "chrono",
- "rustc_version",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ members = ["av1an-core", "av1an-cli"]
 
 [profile.dev.package.av-scenechange]
 opt-level = 3
+
+[patch.crates-io]
+av-scenechange = { git = "https://github.com/rust-av/av-scenechange", branch = "hybrid-sc" }
+rav1e = { git = "https://github.com/xiph/rav1e" }

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -71,10 +71,9 @@ pub struct Args {
 
   /// Specify scenecut method
   ///
-  /// Slow: Most accurate, but 5 times slower than medium
-  /// Medium: Gives a reasonable amount of accuracy at a fairly quick speed
+  /// Standard: Most accurate, still reasonably fast
   /// Fast: Very fast, but less accurate
-  #[structopt(long, possible_values=&["slow", "medium", "fast"], default_value = "medium")]
+  #[structopt(long, possible_values=&["standard", "fast"], default_value = "standard")]
   pub sc_method: ScenecutMethod,
 
   /// Optional downscaling for scenecut detection,

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -168,10 +168,8 @@ pub enum SplitMethod {
 pub enum ScenecutMethod {
   #[strum(serialize = "fast")]
   Fast,
-  #[strum(serialize = "medium")]
-  Medium,
-  #[strum(serialize = "slow")]
-  Slow,
+  #[strum(serialize = "standard")]
+  Standard,
 }
 
 #[derive(

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -98,12 +98,10 @@ pub fn scene_detect(
           .unwrap(),
       })?,
       DetectionOptions {
-        ignore_flashes: true,
         min_scenecut_distance: Some(min_scene_len),
-        fast_analysis: match sc_method {
+        analysis_speed: match sc_method {
           ScenecutMethod::Fast => SceneDetectionSpeed::Fast,
-          ScenecutMethod::Medium => SceneDetectionSpeed::Medium,
-          ScenecutMethod::Slow => SceneDetectionSpeed::Slow,
+          ScenecutMethod::Standard => SceneDetectionSpeed::Standard,
         },
         ..DetectionOptions::default()
       },


### PR DESCRIPTION
This pulls in the changes from https://github.com/xiph/rav1e/pull/2813 into av1an. Combined with https://github.com/xiph/rav1e/pull/2827, the new method should be as fast as or faster than the previous slow method, while being more accurate.

Currently this is pointed at rav1e's git master awaiting a new release from them. We can either leave this PR open until a release is made, or merge it and take out the reference to rav1e's git when they perform a release. Up to the maintainers here.