### PR TITLE
Fix skipping of ffmpeg pipe step

### DIFF
--- a/av1an-core/src/util.rs
+++ b/av1an-core/src/util.rs
@@ -31,6 +31,17 @@ macro_rules! ref_vec {
   };
 }
 
+#[macro_export]
+macro_rules! into_array {
+  ($($x:expr),* $(,)?) => {
+    [
+      $(
+        $x.into(),
+      )*
+    ]
+  };
+}
+
 /// Attempts to create the directory if it does not exist, logging and returning
 /// and error if creating the directory failed.
 #[macro_export]


### PR DESCRIPTION
This optimization added in #379 was never triggered.
Because the `initialize()` method always added a set
of default params to `self.ffmpeg_params`, the clause
to skip the ffmpeg pipe, `self.ffmpeg_params.is_empty()`,
was unreachable.