### PR TITLE
Fix scene detection in some very specific scenarios

### DIFF
--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -87,7 +87,7 @@ pub fn scene_detect(
             .unwrap()
         }
         Input::Video(path) => Command::new("ffmpeg")
-          .arg("-i")
+          .args(["-r", "1", "-i"])
           .arg(path)
           .args(filters)
           .args(["-f", "yuv4mpegpipe", "-"])


### PR DESCRIPTION
FFmpeg misbehaves with some sources (even if they are CFR) and seems to keep piping frames, even past the total frame count of the source. The `-r` flag is needed to fix this issue. It can be set to any arbitrary number and it will not affect the result for the purposes of scene detection, so a value of 1 was chosen.