### PR TITLE
Refactor: Better ffmpeg pipe handling + more info in --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -183,6 +183,8 @@ dependencies = [
  "path_abs",
  "shlex 1.1.0",
  "structopt",
+ "thiserror",
+ "vergen 5.1.16",
 ]
 
 [[package]]
@@ -204,6 +206,7 @@ dependencies = [
  "log",
  "num_cpus",
  "once_cell",
+ "paste",
  "path_abs",
  "plotters",
  "regex",
@@ -214,6 +217,7 @@ dependencies = [
  "strum 0.22.0",
  "sysinfo",
  "textwrap 0.14.2",
+ "thiserror",
  "tokio",
  "vapoursynth",
  "which",
@@ -472,6 +476,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "err-derive"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,10 +601,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "git2"
+version = "0.13.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -594,6 +653,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -694,6 +764,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.24+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +786,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +805,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -928,6 +1028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -1064,11 +1170,11 @@ dependencies = [
 [[package]]
 name = "rav1e"
 version = "0.5.0-beta.2"
-source = "git+https://github.com/xiph/rav1e#9099940c25a7f30f78ecec2439d0d5224dbb895c"
+source = "git+https://github.com/xiph/rav1e#9417a4df1069cc066d499e04b9130ffd32019ed1"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "bitstream-io",
  "cc",
  "cfg-if 1.0.0",
@@ -1092,7 +1198,7 @@ dependencies = [
  "system-deps",
  "thiserror",
  "v_frame",
- "vergen",
+ "vergen 3.0.4",
 ]
 
 [[package]]
@@ -1382,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1504,10 +1610,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.12.0"
+name = "tinyvec"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1530,12 +1651,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
 name = "unicode-linebreak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1557,9 +1693,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.2.4"
-source = "git+https://github.com/xiph/rav1e#9099940c25a7f30f78ecec2439d0d5224dbb895c"
+source = "git+https://github.com/xiph/rav1e#9417a4df1069cc066d499e04b9130ffd32019ed1"
 dependencies = [
  "cfg-if 1.0.0",
  "noop_proc_macro",
@@ -1606,10 +1754,27 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vergen"
 version = "3.0.4"
-source = "git+https://github.com/xiph/rav1e#9099940c25a7f30f78ecec2439d0d5224dbb895c"
+source = "git+https://github.com/xiph/rav1e#9417a4df1069cc066d499e04b9130ffd32019ed1"
 dependencies = [
  "bitflags",
  "chrono",
+]
+
+[[package]]
+name = "vergen"
+version = "5.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b62d4fc8fc9c81d139c8106b9f4e583e7c1eb36e320dc28d5c03aab86729495"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "chrono",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version",
+ "rustversion",
+ "thiserror",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ Example with default parameters:
 
 With your own parameters:
 
-    av1an -i input -v " --cpu-used=3 --end-usage=q --cq-level=30 --threads=8 " -w 10
-    --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -log my_log -o output
-
-
+    av1an -i input -v " --cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
+    --target-quality 95 -a " -c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 
 <h2 align="center">Usage</h2>
 
-    -i  --input             Input file(s), or Vapoursynth (.py,.vpy) script
+    -i  --input             Input file, or Vapoursynth (.py,.vpy) script
                             (relative or absolute path)
 
     -o  --output-file       Name/Path for output file (Default: (input file name)_(encoder).mkv)

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -18,6 +18,10 @@ ctrlc = "3.1.9"
 path_abs = "0.5.1"
 anyhow = "1.0.42"
 av1an-core = { path = "../av1an-core", version = "0.1.0" }
+thiserror = "1.0.30"
+
+[build-dependencies]
+vergen = { version = "5", default-features = false, features = ["git", "build", "rustc", "cargo"] }
 
 [dependencies.ffmpeg-next]
 version = "4.4.0"

--- a/av1an-cli/build.rs
+++ b/av1an-cli/build.rs
@@ -1,0 +1,11 @@
+use vergen::{vergen, Config, ShaKind, TimestampKind};
+
+fn main() {
+  let mut config = Config::default();
+
+  *config.git_mut().sha_kind_mut() = ShaKind::Short;
+  *config.git_mut().commit_timestamp_kind_mut() = TimestampKind::All;
+  *config.build_mut().kind_mut() = TimestampKind::All;
+
+  vergen(config).unwrap();
+}

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -1,12 +1,14 @@
 use anyhow::anyhow;
 use anyhow::{bail, ensure};
 use av1an_core::into_vec;
+use av1an_core::settings::PixelFormat;
 use av1an_core::Input;
 use av1an_core::ScenecutMethod;
 use ffmpeg_next::format::Pixel;
 use path_abs::{PathAbs, PathInfo};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::process::exit;
 use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
 
 use av1an_core::{
@@ -17,10 +19,34 @@ use av1an_core::{
   {concat::ConcatMethod, ChunkMethod, SplitMethod},
 };
 
-/// Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding
+pub fn version() -> &'static str {
+  // This string has to be constructed at compile-time,
+  // since structopt requires a &'static str
+  concat!(
+    env!("VERGEN_BUILD_SEMVER"),
+    " (rev ",
+    env!("VERGEN_GIT_SHA_SHORT"),
+    ") (",
+    env!("VERGEN_CARGO_PROFILE"),
+    ")",
+    "\n\n* Compiler\n  rustc ",
+    env!("VERGEN_RUSTC_SEMVER"),
+    " (LLVM ",
+    env!("VERGEN_RUSTC_LLVM_VERSION"),
+    ")\n\n* Target Triple\n  ",
+    env!("VERGEN_CARGO_TARGET_TRIPLE"),
+    "\n\n* Date Info",
+    "\n   Build Date:  ",
+    env!("VERGEN_BUILD_DATE"),
+    "\n  Commit Date:  ",
+    env!("VERGEN_GIT_COMMIT_DATE"),
+  )
+}
+
+/// Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per-scene quality encoding
 #[derive(StructOpt, Debug)]
-#[structopt(name = "av1an", setting = ColoredHelp)]
-pub struct Args {
+#[structopt(name = "av1an", setting = ColoredHelp, version = version())]
+pub struct CliOpts {
   /// Input file or vapoursynth (.py, .vpy) script
   #[structopt(short, parse(from_os_str))]
   pub input: PathBuf,
@@ -33,11 +59,11 @@ pub struct Args {
   #[structopt(short, parse(from_os_str))]
   pub output_file: Option<PathBuf>,
 
-  /// Concatenation method to use for splits
+  /// Method to use for concatenating encoded chunks
   #[structopt(short, long, possible_values = &["ffmpeg", "mkvmerge", "ivf"], default_value = "ffmpeg")]
   pub concat: ConcatMethod,
 
-  /// Disable printing progress to terminal
+  /// Disable printing progress to the terminal
   #[structopt(short, long)]
   pub quiet: bool,
 
@@ -45,7 +71,7 @@ pub struct Args {
   #[structopt(long)]
   pub verbose: bool,
 
-  /// Enable logging
+  /// Specify this option to log to a non-default file
   #[structopt(short, long)]
   pub logging: Option<String>,
 
@@ -53,8 +79,8 @@ pub struct Args {
   #[structopt(short, long)]
   pub resume: bool,
 
-  /// Keep temporary folder after encode
-  #[structopt(long)]
+  /// Do not delete the temporary folder after encoding has finished
+  #[structopt(short, long)]
   pub keep: bool,
 
   /// Method for creating chunks
@@ -65,58 +91,68 @@ pub struct Args {
   #[structopt(short, long, parse(from_os_str))]
   pub scenes: Option<PathBuf>,
 
-  /// Specify splitting method
+  /// Method used to detect scenecuts. `av-scenechange` uses an algorithm to analyze which frames of
+  /// the video are the start of new scenes, while `none` disable scene detection entirely (and only
+  /// rely on `-x`/`--extra-split` to add extra scenecuts).
   #[structopt(long, possible_values=&["av-scenechange", "none"], default_value = "av-scenechange")]
   pub split_method: SplitMethod,
 
   /// Specify scenecut method
   ///
-  /// Standard: Most accurate, still reasonably fast
-  /// Fast: Very fast, but less accurate
+  /// Standard: Most accurate, still reasonably fast.
+  /// Fast: Very fast, but less accurate.
   #[structopt(long, possible_values=&["standard", "fast"], default_value = "standard")]
   pub sc_method: ScenecutMethod,
 
-  /// Optional downscaling for scenecut detection,
-  /// specify as the desired maximum height to scale to
+  /// Optional downscaling for scenecut detection.
+  /// Specify as the desired maximum height to scale to
   /// (e.g. "720" to downscale to 720p--this will leave lower resolution content untouched).
   /// Downscaling will improve speed but lower scenecut accuracy,
   /// especially when scaling to very low resolutions.
   #[structopt(long)]
   pub sc_downscale_height: Option<usize>,
 
-  /// Number of frames after which make split
-  /// Set to 0 to disable
+  /// Maximum scene length
+  ///
+  /// When a scenecut is found whose distance to the previous scenecut is greater than the value
+  /// specified by this option, one or more extra splits (scenecuts) are added. Set this option
+  /// to 0 to disable adding extra splits.
   #[structopt(short = "x", long, default_value = "240")]
   pub extra_split: usize,
 
-  /// Minimum number of frames in a split
+  /// Minimum number of frames for a scenecut
   #[structopt(long, default_value = "60")]
   pub min_scene_len: usize,
 
-  /// Specify encoding passes
+  /// Specify number encoding passes
+  ///
+  /// When using vpx or aom with RT, set this option to 1.
   #[structopt(short, long)]
   pub passes: Option<u8>,
 
-  /// Parameters passed to the encoder
+  /// Video encoder parameters
   #[structopt(short, long)]
   pub video_params: Option<String>,
 
+  /// Video encoder to use
   #[structopt(short, long, default_value = "aom", possible_values=&["aom", "rav1e", "vpx", "svt-av1", "x264", "x265"])]
   pub encoder: Encoder,
 
-  /// Number of workers
+  /// Number of workers. 0 = automatic
   #[structopt(short, long, default_value = "0")]
   pub workers: usize,
 
-  /// Force encoding if input args seen as invalid
+  /// Do not check if the encoder arguments specified by `--video-params` are valid
   #[structopt(long)]
   pub force: bool,
 
-  /// FFmpeg commands
-  #[structopt(short = "f", long)]
-  pub ffmpeg: Option<String>,
+  /// FFmpeg filter options
+  #[structopt(short = "f", long = "ffmpeg")]
+  pub ffmpeg_filter_args: Option<String>,
 
-  /// FFmpeg commands
+  /// Audio encoding parameters. If not specified, "-c:a copy" is used
+  ///
+  /// Example to encode the audio with libopus: -a="-c:a libopus -b:a 128k -ac 2"
   #[structopt(short, long)]
   pub audio_params: Option<String>,
 
@@ -124,15 +160,15 @@ pub struct Args {
   #[structopt(long, default_value = "yuv420p10le")]
   pub pix_format: Pixel,
 
-  /// Calculate VMAF after encode
+  /// Calculate and plot the VMAF of the encode
   #[structopt(long)]
   pub vmaf: bool,
 
-  /// Path to VMAF models
+  /// Path to VMAF model
   #[structopt(long, parse(from_os_str))]
   pub vmaf_path: Option<PathBuf>,
 
-  /// Resolution used in VMAF calculation
+  /// Resolution used for VMAF calculation
   #[structopt(long, default_value = "1920x1080")]
   pub vmaf_res: String,
 
@@ -140,11 +176,11 @@ pub struct Args {
   #[structopt(long)]
   pub vmaf_threads: Option<usize>,
 
-  /// Value to target
+  /// VMAF score to target
   #[structopt(long)]
   pub target_quality: Option<f64>,
 
-  /// Number of probes to make for target_quality
+  /// Maximum number of probes allowed for target quality
   #[structopt(long, default_value = "4")]
   pub probes: u32,
 
@@ -156,15 +192,16 @@ pub struct Args {
   #[structopt(long)]
   pub probe_slow: bool,
 
-  /// Min q for target_quality
+  /// Min q for target quality
   #[structopt(long)]
   pub min_q: Option<u32>,
 
-  /// Max q for target_quality
+  /// Max q for target quality
   #[structopt(long)]
   pub max_q: Option<u32>,
 
-  /// Filter applied to source at vmaf calcualation, use if you crop source
+  /// Filter applied to source at VMAF calcualation. This option should
+  /// be specified if the source is cropped.
   #[structopt(long)]
   pub vmaf_filter: Option<String>,
 }
@@ -191,8 +228,8 @@ fn confirm(prompt: &str) -> io::Result<bool> {
   }
 }
 
-pub fn cli() -> anyhow::Result<()> {
-  let args = Args::from_args();
+pub fn parse_cli() -> anyhow::Result<EncodeArgs> {
+  let args = CliOpts::from_args();
 
   let temp = if let Some(path) = args.temp {
     path.to_str().unwrap().to_owned()
@@ -200,16 +237,16 @@ pub fn cli() -> anyhow::Result<()> {
     format!(".{}", hash_path(args.input.as_path()))
   };
 
-  // TODO parse with normal (non proc-macro) clap methods to simplify this
-  // Unify Project/Args
-  let mut encode = EncodeArgs {
-    frames: 0,
+  let input = Input::from(args.input.as_path());
+
+  let mut encode_args = EncodeArgs {
+    frames: input.frames(),
     logging: if let Some(log_file) = args.logging {
       Path::new(&format!("{}.log", log_file)).to_owned()
     } else {
       Path::new(&temp).join("log.log")
     },
-    ffmpeg: if let Some(args) = args.ffmpeg {
+    ffmpeg_filter_args: if let Some(args) = args.ffmpeg_filter_args {
       shlex::split(&args).ok_or_else(|| anyhow!("Failed to split ffmpeg filter arguments"))?
     } else {
       Vec::new()
@@ -253,7 +290,6 @@ pub fn cli() -> anyhow::Result<()> {
     } else {
       into_vec!["-c:a", "copy"]
     },
-    ffmpeg_pipe: Vec::new(),
     chunk_method: args
       .chunk_method
       .unwrap_or_else(vapoursynth::best_available_chunk_method),
@@ -264,13 +300,16 @@ pub fn cli() -> anyhow::Result<()> {
     } else {
       None
     },
-    input: Input::from(args.input.as_path()),
+    input,
     keep: args.keep,
     min_q: args.min_q,
     max_q: args.max_q,
     min_scene_len: args.min_scene_len,
     vmaf_threads: args.vmaf_threads,
-    pix_format: args.pix_format,
+    pix_format: PixelFormat {
+      format: args.pix_format,
+      bit_depth: args.encoder.get_format_bit_depth(args.pix_format)?,
+    },
     probe_slow: args.probe_slow,
     probes: args.probes,
     probing_rate: args.probing_rate,
@@ -294,13 +333,7 @@ pub fn cli() -> anyhow::Result<()> {
     workers: args.workers,
   };
 
-  ctrlc::set_handler(|| {
-    println!("Stopped");
-    std::process::exit(0);
-  })
-  .unwrap();
-
-  encode.startup_check()?;
+  encode_args.startup_check()?;
 
   if let Some(path) = args.output_file.as_deref() {
     if path.exists()
@@ -310,10 +343,10 @@ pub fn cli() -> anyhow::Result<()> {
       ))?
     {
       println!("Not overwriting, aborting.");
-      return Ok(());
+      exit(0);
     }
   } else {
-    let path: &Path = encode.output_file.as_ref();
+    let path: &Path = encode_args.output_file.as_ref();
 
     if path.exists()
       && !confirm(&format!(
@@ -322,12 +355,23 @@ pub fn cli() -> anyhow::Result<()> {
       ))?
     {
       println!("Not overwriting, aborting.");
-      return Ok(());
+      exit(0);
     }
   }
 
-  encode.initialize()?;
-  encode.encode_file()?;
+  Ok(encode_args)
+}
+
+pub fn run() -> anyhow::Result<()> {
+  let mut args = parse_cli()?;
+
+  ctrlc::set_handler(|| {
+    println!("Stopped");
+    exit(0);
+  })?;
+
+  args.initialize()?;
+  args.encode_file()?;
 
   Ok(())
 }

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -38,6 +38,8 @@ textwrap = "0.14.2"
 path_abs = "0.5.1"
 av-scenechange = "0.7.0"
 y4m = "0.7.0"
+thiserror = "1.0.30"
+paste = "1.0.5"
 
 [dependencies.ffmpeg-next]
 version = "4.4.0"

--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -243,7 +243,7 @@ pub fn ffmpeg(temp: &Path, output: &Path, encoder: Encoder) {
     let mut contents = String::new();
 
     for i in files {
-      if cfg!(target_os = "windows") {
+      if cfg!(windows) {
         contents.push_str(&format!("file {}\n", i.path().display()).replace(r"\", r"\\"));
       } else {
         contents.push_str(&format!("file {}\n", i.path().display()));

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -1,7 +1,7 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use once_cell::sync::OnceCell;
 
-const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(target_os = "windows") {
+const INDICATIF_PROGRESS_TEMPLATE: &str = if cfg!(windows) {
   // Do not use a spinner on Windows since the default console cannot display
   // the characters used for the spinner
   "[{elapsed_precise}] [{wide_bar}] {percent:>3}% {pos}/{len} ({fps} fps, eta {eta})"

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 
 pub fn av_scenechange_detect(
   input: &Input,
-  encoder: &Encoder,
+  encoder: Encoder,
   total_frames: usize,
   min_scene_len: usize,
   verbosity: Verbosity,
@@ -47,7 +47,7 @@ pub fn av_scenechange_detect(
 /// Detect scene changes using rav1e scene detector.
 pub fn scene_detect(
   input: &Input,
-  encoder: &Encoder,
+  encoder: Encoder,
   callback: Option<Box<dyn Fn(usize, usize)>>,
   min_scene_len: usize,
   sc_method: ScenecutMethod,
@@ -87,11 +87,11 @@ pub fn scene_detect(
     Input::Video(path) => {
       let input_pix_format = ffmpeg::get_pixel_format(path.as_ref())
         .unwrap_or_else(|e| panic!("FFmpeg failed to get pixel format for input video: {:?}", e));
-      bit_depth = encoder.get_format_bit_depth(input_pix_format);
+      bit_depth = encoder.get_format_bit_depth(input_pix_format)?;
       Command::new("ffmpeg")
         .args(["-r", "1", "-i"])
         .arg(path)
-        .args(&filters)
+        .args(filters)
         .args(["-f", "yuv4mpegpipe", "-strict", "-1", "-"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -153,11 +153,11 @@ impl EncodeArgs {
     } else if current_pass == 1 {
       self
         .encoder
-        .compose_1_2_pass(self.video_params.clone(), &fpf_file.to_str().unwrap())
+        .compose_1_2_pass(self.video_params.clone(), fpf_file.to_str().unwrap())
     } else {
       self.encoder.compose_2_2_pass(
         self.video_params.clone(),
-        &fpf_file.to_str().unwrap(),
+        fpf_file.to_str().unwrap(),
         chunk.output(),
       )
     };

--- a/av1an-core/src/split.rs
+++ b/av1an-core/src/split.rs
@@ -19,7 +19,7 @@ pub fn segment(input: impl AsRef<Path>, temp: impl AsRef<Path>, segments: &[usiz
   cmd.stdout(Stdio::piped());
   cmd.stderr(Stdio::piped());
 
-  cmd.args(&[
+  cmd.args([
     "-hide_banner",
     "-y",
     "-i",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use av1an_cli::cli;
+use av1an_cli::run;
 
 fn main() -> anyhow::Result<()> {
-  cli()
+  run()
 }


### PR DESCRIPTION
- Update dependencies
- Better documentation in `--help`
- Include git commit hash and more info in `--version`
- Add `-k` as shorthand for `--keep`
- Do not pass `ffmpeg_pipe` around everywhere
- Use macro to generate encoder bit depth functions
- Fix documentation in README