### PR TITLE
Initial round of improvements for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,12 +208,14 @@ dependencies = [
  "log",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "paste",
  "path_abs",
  "plotters",
  "regex",
  "serde",
  "serde_json",
+ "simdutf8",
  "splines",
  "strsim 0.10.0",
  "strum 0.22.0",
@@ -305,9 +307,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -681,6 +683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -797,6 +808,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -1006,10 +1026,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "paste"
-version = "1.0.5"
+name = "parking_lot"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "path_abs"
@@ -1230,6 +1275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559"
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.20.5"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223c65cd36b485a34c2ce6e38efa40777d31c4166d9076030c74cdcf971679f"
+checksum = "fb6c2c4a6ca462f07ca89841a2618dca6e405304d19ae238997e64915d89f513"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -1624,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -21,7 +21,7 @@ num_cpus = "1.13.0"
 anyhow = "1.0.42"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sysinfo = "0.20.0"
+sysinfo = "0.21.0"
 regex = "1.5.4"
 splines = "4.0.0"
 indicatif = "0.17.0-beta.1"
@@ -40,6 +40,8 @@ av-scenechange = "0.7.2"
 y4m = "0.7.0"
 thiserror = "1.0.30"
 paste = "1.0.5"
+simdutf8 = { version = "0.1.3" }
+parking_lot = "0.11.2"
 
 [dependencies.ffmpeg-next]
 version = "4.4.0"

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -8,7 +8,10 @@ pub struct Chunk {
   pub source: Vec<OsString>,
   pub output_ext: String,
   pub frames: usize,
-  pub per_shot_target_quality_cq: Option<u32>,
+  // do not break compatibility with output produced by older versions of av1an
+  /// Optional target quality CQ level
+  #[serde(rename = "per_shot_target_quality_cq")]
+  pub tq_cq: Option<u32>,
 }
 
 impl Chunk {
@@ -26,7 +29,7 @@ impl Chunk {
       source,
       output_ext: output_ext.to_owned(),
       frames,
-      per_shot_target_quality_cq,
+      tq_cq: per_shot_target_quality_cq,
     })
   }
 
@@ -58,7 +61,7 @@ mod tests {
       source: vec!["".into()],
       output_ext: "ivf".to_owned(),
       frames: 5,
-      per_shot_target_quality_cq: None,
+      tq_cq: None,
     };
     assert_eq!("00001", ch.name());
   }
@@ -70,7 +73,7 @@ mod tests {
       source: vec!["".into()],
       output_ext: "ivf".to_owned(),
       frames: 5,
-      per_shot_target_quality_cq: None,
+      tq_cq: None,
     };
     assert_eq!("10000", ch.name());
   }
@@ -83,7 +86,7 @@ mod tests {
       source: vec!["".into()],
       output_ext: "ivf".to_owned(),
       frames: 5,
-      per_shot_target_quality_cq: None,
+      tq_cq: None,
     };
     assert_eq!("d/encode/00001.ivf", ch.output());
   }

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -370,9 +370,6 @@ impl Encoder {
   /// Returs option of q/crf value from cli encoder output
   pub fn match_line(self, line: &str) -> Option<usize> {
     let encoder_regex = self.pipe_match();
-    if !encoder_regex.is_match(line) {
-      return Some(0);
-    }
     let captures = encoder_regex.captures(line)?.get(1)?.as_str();
     captures.parse::<usize>().ok()
   }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -100,9 +100,10 @@ impl Input {
   }
 
   pub fn frames(&self) -> usize {
+    const FAIL_MSG: &str = "failed to get number of frames for input video";
     match &self {
-      Input::Video(path) => ffmpeg::num_frames(path.as_path()).unwrap(),
-      Input::VapourSynth(path) => vapoursynth::num_frames(path.as_path()).unwrap(),
+      Input::Video(path) => ffmpeg::num_frames(path.as_path()).expect(FAIL_MSG),
+      Input::VapourSynth(path) => vapoursynth::num_frames(path.as_path()).expect(FAIL_MSG),
     }
   }
 }
@@ -215,19 +216,6 @@ pub fn hash_path(path: &Path) -> String {
   let mut s = DefaultHasher::new();
   path.hash(&mut s);
   format!("{:x}", s.finish())[..7].to_string()
-}
-
-pub async fn process_pipe(pipe: tokio::process::Child, chunk_index: usize) -> Result<(), String> {
-  let status = pipe.wait_with_output().await.unwrap();
-
-  if !status.status.success() {
-    return Err(format!(
-      "Encoder encountered an error on chunk {}: {:?}",
-      chunk_index, status
-    ));
-  }
-
-  Ok(())
 }
 
 fn save_chunk_queue(temp: &str, chunk_queue: &[Chunk]) {

--- a/av1an-core/src/split.rs
+++ b/av1an-core/src/split.rs
@@ -48,8 +48,7 @@ pub fn segment(input: impl AsRef<Path>, temp: impl AsRef<Path>, segments: &[usiz
 
     cmd.args(&["-f", "segment", "-segment_frames", &segments_joined]);
     let split_path = Path::new(temp).join("split").join("%05d.mkv");
-    let split_str = split_path.to_str().unwrap();
-    cmd.arg(split_str);
+    cmd.arg(split_path);
   }
   let out = cmd.output().unwrap();
   assert!(out.status.success(), "FFmpeg failed to segment: {:#?}", out);

--- a/av1an-core/src/util.rs
+++ b/av1an-core/src/util.rs
@@ -1,6 +1,3 @@
-use anyhow::Context;
-use std::{fs, path::Path};
-
 #[macro_export]
 macro_rules! regex {
   ($re:literal $(,)?) => {{
@@ -58,8 +55,4 @@ macro_rules! create_dir {
       },
     }
   };
-}
-
-pub fn read_file_to_string(file: impl AsRef<Path>) -> anyhow::Result<String> {
-  fs::read_to_string(&file).with_context(|| format!("Can't open file {:?}", file.as_ref()))
 }

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -133,8 +133,7 @@ pub fn create_vs_file(
       ChunkMethod::LSMASH => "lwi",
       _ => return Err(anyhow!("invalid chunk method")),
     }
-  )))
-  .unwrap();
+  )))?;
 
   load_script.write_all(
     // TODO should probably check if the syntax for rust strings and escaping utf and stuff like that is the same as in python


### PR DESCRIPTION
The main change that this commit introduces is an `EncoderCrash` type
for errors, which also reports the stderr of the process piping to
the encoder so that it is easier to tell what the actual error is.

Target quality probe crashes are now properly logged with the
`EncoderCrash` type, replacing the old panicking code and making the
error significantly easier to read.

An "optimization" has been implemented which does not wait for the child
process piping to the encoder to exit, and instead collects its stderr
output asynchronously and immediately exits upon an encoder crash. This
does not yet apply to target quality probes, as there is not yet a
single interface for running an encoder (it is done manually for now).
This will change in the future, but this patch is getting too big for
everything so for now we just capture stderr synchronously for target
quality probes.

- Also update `get_percentile` to use an O(N) algorithm from the
  standard library instead of O(N*log N).