### PR TITLE
Allow setting thread affinity for each worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "affinity"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763e484feceb7dd021b21c5c6f81aee06b1594a743455ec7efbf72e6355e447b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "errno",
+ "libc",
+ "num_cpus",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +205,7 @@ dependencies = [
 name = "av1an-core"
 version = "0.2.0"
 dependencies = [
+ "affinity",
  "anyhow",
  "av-format",
  "av-ivf",
@@ -216,6 +229,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simdutf8",
+ "smallvec",
  "splines",
  "strsim 0.10.0",
  "strum 0.22.0",
@@ -514,6 +528,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,7 +609,7 @@ dependencies = [
  "regex",
  "rustversion",
  "thiserror",
- "time 0.3.4",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -1389,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1674,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -171,6 +171,10 @@ pub struct CliOpts {
   #[structopt(short, long, default_value = "0")]
   pub workers: usize,
 
+  /// Optionally pin each worker to this many threads
+  #[structopt(long)]
+  pub set_thread_affinity: Option<usize>,
+
   /// Do not check if the encoder arguments specified by `--video-params` are valid
   #[structopt(long)]
   pub force: bool,
@@ -372,6 +376,7 @@ pub fn parse_cli() -> anyhow::Result<EncodeArgs> {
     vmaf_path: args.vmaf_path,
     vmaf_res: args.vmaf_res,
     workers: args.workers,
+    set_thread_affinity: args.set_thread_affinity,
   };
 
   encode_args.startup_check()?;

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -40,8 +40,14 @@ av-scenechange = "0.7.2"
 y4m = "0.7.0"
 thiserror = "1.0.30"
 paste = "1.0.5"
-simdutf8 = { version = "0.1.3" }
+simdutf8 = "0.1.3"
 parking_lot = "0.11.2"
+affinity = "0.1.2"
+
+[dependencies.smallvec]
+version = "1.7.0"
+default-features = false
+features = ["const_generics", "const_new", "union"]
 
 [dependencies.ffmpeg-next]
 version = "4.4.0"

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -67,6 +67,7 @@ pub struct EncodeArgs {
   pub video_params: Vec<String>,
   pub encoder: Encoder,
   pub workers: usize,
+  pub set_thread_affinity: Option<usize>,
 
   // FFmpeg params
   pub ffmpeg_filter_args: Vec<String>,
@@ -888,7 +889,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
       let (tx, rx) = mpsc::channel();
       let handle = s.spawn(|_| {
-        broker.encoding_loop(tx);
+        broker.encoding_loop(tx, self.set_thread_affinity);
       });
 
       // Queue::encoding_loop only sends a message if there was an error (meaning a chunk crashed)


### PR DESCRIPTION
Introduces a new command line option called `--set-thread-affinity=n`,
where `n` specifies the number of threads to assign to each worker.

We use the `affinity` crate instead of the `nix` crate directly to
get abstractions for Windows and Linux.