### PR TITLE
Fix a case where the log file could fail to be created

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -101,6 +101,17 @@ impl EncodeArgs {
     ffmpeg_next::init()?;
     ffmpeg_next::util::log::set_level(ffmpeg_next::util::log::level::Level::Fatal);
 
+    if !self.resume && Path::new(&self.temp).is_dir() {
+      fs::remove_dir_all(&self.temp)
+        .with_context(|| format!("Failed to remove temporary directory {:?}", &self.temp))?;
+    }
+
+    create_dir!(Path::new(&self.temp))?;
+    create_dir!(Path::new(&self.temp).join("split"))?;
+    create_dir!(Path::new(&self.temp).join("encode"))?;
+
+    info!("temporary directory: {}", &self.temp);
+
     let done_json_exists = Path::new(&self.temp).join("done.json").exists();
     let chunks_json_exists = Path::new(&self.temp).join("chunks.json").exists();
 
@@ -131,17 +142,6 @@ impl EncodeArgs {
         }
       }
     }
-
-    if !self.resume && Path::new(&self.temp).is_dir() {
-      fs::remove_dir_all(&self.temp)
-        .with_context(|| format!("Failed to remove temporary directory {:?}", &self.temp))?;
-    }
-
-    create_dir!(Path::new(&self.temp))?;
-    create_dir!(Path::new(&self.temp).join("split"))?;
-    create_dir!(Path::new(&self.temp).join("encode"))?;
-
-    info!("temporary directory: {}", &self.temp);
 
     Ok(())
   }


### PR DESCRIPTION
Previously, these warn statements came before we create
the temp directory. I'm assuming when the first log
statement is run, flexi_logger then attempts to create
the log file. If it fails, it doesn't try again.

Ensuring we create the temp directory before attempting
to log should resolve this issue.