### PR TITLE
Use dimmed colors instead of fixed xterm 256 colors

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -438,7 +438,7 @@ impl LogWriter for StderrLogger {
     let style = match record.level() {
       Level::Error => Style::default().fg(Color::Fixed(196)).bold(),
       Level::Warn => Style::default().fg(Color::Fixed(208)).bold(),
-      Level::Info => Style::default().fg(Color::Fixed(8)),
+      Level::Info => Style::default().dimmed(),
       _ => Style::default(),
     };
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -903,7 +903,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
         Color::Purple.paint("asses"),
         Color::Purple.bold().paint(self.passes.to_string()),
         Style::default().bold().paint("Params"),
-        Color::Fixed(239).paint(self.video_params.join(" "))
+        Style::default().dimmed().paint(self.video_params.join(" "))
       );
 
       if self.verbosity == Verbosity::Normal {


### PR DESCRIPTION
Using fixed xterm 256 colors for grays can cause problems on some terminals with color schemes where the background is very close to the text, so we switch to using dimmed colors which should be much easier to read on a broader range of terminals.