### PR TITLE
Delegate chunk starts/finishes to debug log level, other logging changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,6 @@ dependencies = [
  "glob",
  "lazy_static",
  "log",
- "regex",
  "rustversion",
  "thiserror",
  "time 0.3.5",

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -20,8 +20,12 @@ anyhow = "1.0.42"
 av1an-core = { path = "../av1an-core", version = "0.2.0" }
 thiserror = "1.0.30"
 once_cell = "1.8.0"
-flexi_logger = "0.19.6"
 ansi_term = "0.12.1"
+
+[dependencies.flexi_logger]
+version = "0.19.6"
+default-features = false
+features = ["colors"]
 
 [build-dependencies.vergen]
 version = "5"

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -174,7 +174,7 @@ impl<'a> Broker<'a> {
     let st_time = Instant::now();
 
     // space padding at the beginning to align with "finished chunk"
-    info!(" started chunk {:05}: {} frames", chunk.index, chunk.frames);
+    debug!(" started chunk {:05}: {} frames", chunk.index, chunk.frames);
 
     if let Some(ref tq) = self.target_quality {
       tq.per_shot_target_quality_routine(chunk)?;
@@ -216,7 +216,7 @@ impl<'a> Broker<'a> {
         .write_all(serde_json::to_string(get_done()).unwrap().as_bytes())
         .unwrap();
 
-      info!(
+      debug!(
         "finished chunk {:05}: {} frames, {:.2} fps, took {:.2?}",
         chunk.index, chunk.frames, fps, enc_time
       )

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -75,7 +75,7 @@ pub struct EncodeArgs {
   pub pix_format: PixelFormat,
 
   pub verbosity: Verbosity,
-  pub logging: PathBuf,
+  pub log_file: PathBuf,
   pub resume: bool,
   pub keep: bool,
   pub force: bool,


### PR DESCRIPTION
* Rename `--logging` to `--log-file` (`-l` shorthand still works)
* Introduce new `--log-level` option to set the log level filter

This change makes `--verbose` not log chunk starts and finishes, and
that information is not logged in the log file either unless
`--log-level=debug` is set. By default, `--log-level` is set to `info`.

The `debug` log level also logs the rav1e scenechange decision info
for each frame.