### PR TITLE
Improve error handling for concatenation

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -964,7 +964,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
           concat::mkvmerge(self.temp.as_ref(), self.output_file.as_ref())?;
         }
         ConcatMethod::FFmpeg => {
-          concat::ffmpeg(self.temp.as_ref(), self.output_file.as_ref());
+          concat::ffmpeg(self.temp.as_ref(), self.output_file.as_ref())?;
         }
       }
 


### PR DESCRIPTION
* Log the command used for concat (activated with log level `debug`)
  (the command along with process output is logged again at log level
  `error` if the command failed, regardless of `--log-level`)
* Replace some unwraps with `Result`s
* Add more `with_context()`s