### PR TITLE
Enable thin-LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ members = ["av1an-core", "av1an-cli"]
 
 [profile.dev.package.av-scenechange]
 opt-level = 3
+
+[profile.release]
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
Although the majority of av1an's time is spent
in third-party binaries, compiling with thin-LTO
does show up to a 10% improvement on scene detection
time. This will cause compilation to be slower.
However, thin-LTO has far less of a compilation time
impact than full LTO, while providing almost the same
speedups.