### PR TITLE
Perform input pixel format check only once

### DIFF
--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -49,7 +49,7 @@ impl<'a> TargetQuality<'a> {
       min_q: args.min_q.unwrap(),
       max_q: args.max_q.unwrap(),
       encoder: args.encoder,
-      pix_format: args.pix_format.format,
+      pix_format: args.output_pix_format.format,
       temp: args.temp.clone(),
       workers: args.workers,
       video_params: args.video_params.clone(),


### PR DESCRIPTION
Previously, the pixel format of the input file was checked every time
a chunk was started. Now, we just get the pixel format once at the
beginning and reuse it for all chunks.