### PR TITLE
Min chunk size to 24 and faster more accurate aomenc target-quality

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -173,7 +173,7 @@ pub struct CliOpts {
   pub extra_split: usize,
 
   /// Minimum number of frames for a scenecut
-  #[structopt(long, default_value = "60")]
+  #[structopt(long, default_value = "24")]
   pub min_scene_len: usize,
 
   /// Specify number encoding passes

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -422,6 +422,8 @@ impl Encoder {
         "--enable-global-motion=0",
         "--enable-cdef=0",
         "--max-reference-frames=3",
+        "--arnr-strength=0",
+        "--arnr-maxframes=1",
         "--cdf-update-mode=2",
         "--deltaq-mode=0",
         "--enable-tpl-model=0",


### PR DESCRIPTION
With this PR, we'd change the minimum scene length to 24 frames as to make it more psycho-visually accurate if there are rapid scene-changes.

As for the 2nd part, disabling all kinds of temporal filtering and denoising in aomenc is a good idea for target-quality in itself, since we need the highest image possible out of a certain Q to evaluate quality properly, even if it creates more artifacts.