### PR TITLE
Fix all clippy warnings as of latest stable rustc

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -12,6 +12,9 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::items_after_statements)]
+#![allow(clippy::wildcard_imports)]
+#![allow(clippy::drop_ref)]
+#![allow(clippy::unsafe_derive_deserialize)]
 
 #[macro_use]
 extern crate log;

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -95,11 +95,11 @@ pub fn scene_detect(
       Command::new("ffmpeg")
         .args(["-r", "1", "-i"])
         .arg(path)
-        .args(if let Some(filters) = &filters {
-          &filters[..]
-        } else {
-          &[]
-        })
+        .args(
+          filters
+            .as_ref()
+            .map_or(&[] as &[String], |filters| &filters[..]),
+        )
         .args(["-f", "yuv4mpegpipe", "-strict", "-1", "-"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -54,6 +54,7 @@ pub enum InputPixelFormat {
   FFmpeg { format: Pixel },
 }
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct EncodeArgs {
   pub frames: usize,
 


### PR DESCRIPTION
I kind of wish that we wouldn't use clippy::pedantic and
clippy::nursery, as the number of `allow` lints at the top of src/lib.rs
is becoming quite absurd. However, I at least wanted to clear out the
large set of warnings being issued, regardless of that discussion.