### PR TITLE
Add kbps and final file size estimates to progress bar

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -6,6 +6,8 @@ use crate::{
   settings::EncodeArgs,
   Chunk, Instant, TargetQuality, Verbosity,
 };
+use std::sync::atomic::{self, AtomicU64};
+use std::sync::Arc;
 use std::{
   fmt::{Debug, Display},
   fs::File,
@@ -88,7 +90,12 @@ impl Display for EncoderCrash {
 impl<'a> Broker<'a> {
   /// Main encoding loop. set_thread_affinity may be ignored if the value is invalid.
   #[allow(clippy::needless_pass_by_value)]
-  pub fn encoding_loop(self, tx: Sender<()>, mut set_thread_affinity: Option<usize>) {
+  pub fn encoding_loop(
+    self,
+    tx: Sender<()>,
+    mut set_thread_affinity: Option<usize>,
+    audio_size_bytes: Arc<AtomicU64>,
+  ) {
     if !self.chunk_queue.is_empty() {
       let (sender, receiver) = crossbeam_channel::bounded(self.chunk_queue.len());
 
@@ -124,6 +131,7 @@ impl<'a> Broker<'a> {
           .map(|idx| (receiver.clone(), &self, idx))
           .map(|(rx, queue, worker_id)| {
             let tx = tx.clone();
+            let audio_size_ref = Arc::clone(&audio_size_bytes);
             s.spawn(move |_| {
               cfg_if! {
                 if #[cfg(any(target_os = "linux", target_os = "windows"))] {
@@ -141,7 +149,12 @@ impl<'a> Broker<'a> {
               }
 
               while let Ok(mut chunk) = rx.recv() {
-                if let Err(e) = queue.encode_chunk(&mut chunk, worker_id, frame_rate) {
+                if let Err(e) = queue.encode_chunk(
+                  &mut chunk,
+                  worker_id,
+                  frame_rate,
+                  Arc::clone(&audio_size_ref),
+                ) {
                   error!("[chunk {}] {}", chunk.index, e);
 
                   tx.send(()).unwrap();
@@ -171,6 +184,7 @@ impl<'a> Broker<'a> {
     chunk: &mut Chunk,
     worker_id: usize,
     frame_rate: f64,
+    audio_size_bytes: Arc<AtomicU64>,
   ) -> Result<(), EncoderCrash> {
     let st_time = Instant::now();
 
@@ -219,11 +233,10 @@ impl<'a> Broker<'a> {
         chunk.name(),
         DoneChunk {
           frames: encoded_frames,
-          size_kb: (Path::new(&chunk.output())
+          size_bytes: Path::new(&chunk.output())
             .metadata()
             .expect("Unable to get size of finished chunk")
-            .len()
-            / 1000) as u32,
+            .len(),
         },
       );
 
@@ -232,7 +245,12 @@ impl<'a> Broker<'a> {
         .write_all(serde_json::to_string(get_done()).unwrap().as_bytes())
         .unwrap();
 
-      update_progress_bar_estimates(frame_rate, self.project.frames, self.project.verbosity);
+      update_progress_bar_estimates(
+        frame_rate,
+        self.project.frames,
+        self.project.verbosity,
+        audio_size_bytes.load(atomic::Ordering::SeqCst),
+      );
 
       debug!(
         "finished chunk {:05}: {} frames, {:.2} fps, took {:.2?}",

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -55,6 +55,16 @@ pub fn num_frames(source: &Path) -> Result<usize, ffmpeg_next::Error> {
   )
 }
 
+pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg_next::Error> {
+  let ictx = input(&source)?;
+  let input = ictx
+    .streams()
+    .best(MediaType::Video)
+    .ok_or(StreamNotFound)?;
+  let rate = input.avg_frame_rate();
+  Ok(rate.numerator() as f64 / rate.denominator() as f64)
+}
+
 pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg_next::Error> {
   let ictx = ffmpeg_next::format::input(&source)?;
 

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -3,6 +3,7 @@ use ffmpeg_next::format::{input, Pixel};
 use ffmpeg_next::media::Type as MediaType;
 use ffmpeg_next::Error::StreamNotFound;
 use path_abs::{PathAbs, PathInfo};
+use std::path::PathBuf;
 use std::{
   ffi::OsStr,
   path::Path,
@@ -111,14 +112,14 @@ pub fn has_audio(file: &Path) -> bool {
 
 /// Encodes the audio using FFmpeg, blocking the current thread.
 ///
-/// This function returns `true` if the audio exists and the audio
-/// successfully encoded, or `false` otherwise.
+/// This function returns `Some(output)` if the audio exists and the audio
+/// successfully encoded, or `None` otherwise.
 #[must_use]
 pub fn encode_audio<S: AsRef<OsStr>>(
   input: impl AsRef<Path>,
   temp: impl AsRef<Path>,
   audio_params: &[S],
-) -> bool {
+) -> Option<PathBuf> {
   let input = input.as_ref();
   let temp = temp.as_ref();
 
@@ -147,7 +148,7 @@ pub fn encode_audio<S: AsRef<OsStr>>(
     ]);
 
     encode_audio.args(audio_params);
-    encode_audio.arg(audio_file);
+    encode_audio.arg(&audio_file);
 
     let output = encode_audio.output().unwrap();
 
@@ -156,12 +157,12 @@ pub fn encode_audio<S: AsRef<OsStr>>(
         "FFmpeg failed to encode audio!\n{:#?}\nParams: {:?}",
         output, encode_audio
       );
-      return false;
+      return None;
     }
 
-    true
+    Some(audio_file)
   } else {
-    false
+    None
   }
 }
 

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -112,6 +112,14 @@ impl Input {
       Input::VapourSynth(path) => vapoursynth::num_frames(path.as_path()).expect(FAIL_MSG),
     }
   }
+
+  pub fn frame_rate(&self) -> f64 {
+    const FAIL_MSG: &str = "Failed to get frame rate for input video";
+    match &self {
+      Input::Video(path) => ffmpeg::frame_rate(path.as_path()).expect(FAIL_MSG),
+      Input::VapourSynth(path) => vapoursynth::frame_rate(path.as_path()).expect(FAIL_MSG),
+    }
+  }
 }
 
 impl<P: AsRef<Path> + Into<PathBuf>> From<P> for Input {
@@ -129,11 +137,19 @@ impl<P: AsRef<Path> + Into<PathBuf>> From<P> for Input {
   }
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
+struct DoneChunk {
+  frames: usize,
+  // Currently an Option for backwards compatibility,
+  // since this field was added recently.
+  size_kb: u32,
+}
+
 /// Concurrent data structure for keeping track of the finished chunks in an encode
 #[derive(Debug, Deserialize, Serialize)]
 struct DoneJson {
   frames: AtomicUsize,
-  done: DashMap<String, usize>,
+  done: DashMap<String, DoneChunk>,
   audio_done: AtomicBool,
 }
 

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -140,9 +140,7 @@ impl<P: AsRef<Path> + Into<PathBuf>> From<P> for Input {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 struct DoneChunk {
   frames: usize,
-  // Currently an Option for backwards compatibility,
-  // since this field was added recently.
-  size_kb: u32,
+  size_bytes: u64,
 }
 
 /// Concurrent data structure for keeping track of the finished chunks in an encode

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1,3 +1,4 @@
+use crate::progress_bar::update_progress_bar_estimates;
 use crate::progress_bar::{reset_bar_at, reset_mp_bar_at};
 use crate::vapoursynth::{is_ffms2_installed, is_lsmash_installed};
 use crate::{
@@ -862,12 +863,11 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       let done = fs::read_to_string(done_path)?;
       let done: DoneJson = serde_json::from_str(&done)?;
       self.frames = done.frames.load(atomic::Ordering::Relaxed);
-      init_done(done);
 
-      get_done()
+      init_done(done)
         .done
         .iter()
-        .map(|ref_multi| *ref_multi.value())
+        .map(|ref_multi| ref_multi.frames)
         .sum()
     } else {
       self.frames = self.input.frames();
@@ -947,6 +947,11 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       } else if self.verbosity == Verbosity::Verbose {
         init_multi_progress_bar(self.frames as u64, self.workers);
         reset_mp_bar_at(initial_frames as u64);
+      }
+
+      if !get_done().done.is_empty() {
+        let frame_rate = self.input.frame_rate();
+        update_progress_bar_estimates(frame_rate, self.frames, self.verbosity);
       }
 
       let broker = Broker {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -25,6 +25,7 @@ use crossbeam_utils;
 use ffmpeg_next::format::Pixel;
 use itertools::Itertools;
 use std::cmp::Ordering;
+use std::sync::atomic::AtomicUsize;
 use std::{
   borrow::Cow,
   cmp,
@@ -38,7 +39,7 @@ use std::{
   iter,
   path::{Path, PathBuf},
   process::{exit, Command, Stdio},
-  sync::atomic::{self, AtomicBool, AtomicUsize},
+  sync::atomic::{self, AtomicBool, AtomicU64},
   sync::{mpsc, Arc},
 };
 
@@ -899,14 +900,16 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
     crossbeam_utils::thread::scope(|s| -> anyhow::Result<()> {
       // vapoursynth audio is currently unsupported
+      let audio_size_bytes = Arc::new(AtomicU64::new(0));
       let audio_thread = if self.input.is_video()
         && (!self.resume || !get_done().audio_done.load(atomic::Ordering::SeqCst))
       {
         let input = self.input.as_video_path();
         let temp = self.temp.as_str();
         let audio_params = self.audio_params.as_slice();
+        let audio_size_ref = Arc::clone(&audio_size_bytes);
         Some(s.spawn(move |_| {
-          let audio_output_exists = ffmpeg::encode_audio(input, temp, audio_params);
+          let audio_output = ffmpeg::encode_audio(input, temp, audio_params);
           get_done().audio_done.store(true, atomic::Ordering::SeqCst);
 
           let progress_file = Path::new(temp).join("done.json");
@@ -915,7 +918,14 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
             .write_all(serde_json::to_string(get_done()).unwrap().as_bytes())
             .unwrap();
 
-          audio_output_exists
+          if let Some(ref audio_output) = audio_output {
+            audio_size_ref.store(
+              audio_output.metadata().unwrap().len(),
+              atomic::Ordering::SeqCst,
+            );
+          }
+
+          audio_output.is_some()
         }))
       } else {
         None
@@ -951,7 +961,12 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
       if !get_done().done.is_empty() {
         let frame_rate = self.input.frame_rate();
-        update_progress_bar_estimates(frame_rate, self.frames, self.verbosity);
+        update_progress_bar_estimates(
+          frame_rate,
+          self.frames,
+          self.verbosity,
+          audio_size_bytes.load(atomic::Ordering::SeqCst),
+        );
       }
 
       let broker = Broker {
@@ -965,9 +980,10 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
         max_tries: self.max_tries,
       };
 
+      let audio_size_ref = Arc::clone(&audio_size_bytes);
       let (tx, rx) = mpsc::channel();
       let handle = s.spawn(|_| {
-        broker.encoding_loop(tx, self.set_thread_affinity);
+        broker.encoding_loop(tx, self.set_thread_affinity, audio_size_ref);
       });
 
       // Queue::encoding_loop only sends a message if there was an error (meaning a chunk crashed)

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -102,6 +102,15 @@ fn get_num_frames(env: &mut Environment) -> anyhow::Result<usize> {
   Ok(num_frames)
 }
 
+fn get_frame_rate(env: &mut Environment) -> anyhow::Result<f64> {
+  let info = get_clip_info(env);
+
+  match info.framerate {
+    Property::Variable => bail!("Cannot output clips with varying framerate"),
+    Property::Constant(fps) => Ok(fps.numerator as f64 / fps.denominator as f64),
+  }
+}
+
 /// Get the bit depth from an environment that has already been
 /// evaluated on a script.
 fn get_bit_depth(env: &mut Environment) -> anyhow::Result<usize> {
@@ -195,4 +204,16 @@ pub fn bit_depth(source: &Path) -> anyhow::Result<usize> {
     .unwrap();
 
   get_bit_depth(&mut environment)
+}
+
+pub fn frame_rate(source: &Path) -> anyhow::Result<f64> {
+  // Create a new VSScript environment.
+  let mut environment = Environment::new().unwrap();
+
+  // Evaluate the script.
+  environment
+    .eval_file(source, EvalFlags::SetWorkingDir)
+    .unwrap();
+
+  get_frame_rate(&mut environment)
 }


### PR DESCRIPTION
This looks at the size of each chunk when it completes and saves that
size in kilobytes into the done.json file. For backwards compatibility
for encodes resumed from an earlier version of av1an, if the done.json
does not contain the chunk size, then on resume, av1an will lookup the
size of that chunk. The estimates on the progress bar also handle
resumes and chunk crashes gracefully.