### PR TITLE
Simplify target quality probe names

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -608,7 +608,7 @@ impl Encoder {
   pub fn probe_cmd(
     self,
     temp: String,
-    name: &str,
+    chunk_index: usize,
     q: usize,
     pix_fmt: Pixel,
     probing_rate: usize,
@@ -626,7 +626,7 @@ impl Encoder {
       pix_fmt,
     );
 
-    let probe_name = format!("v_{}{}.ivf", q, name);
+    let probe_name = format!("v_{}_{}.ivf", q, chunk_index);
     let mut probe = PathBuf::from(temp);
     probe.push("split");
     probe.push(&probe_name);

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -175,7 +175,7 @@ impl<'a> TargetQuality<'a> {
 
     let cmd = self.encoder.probe_cmd(
       self.temp.clone(),
-      &chunk.name(),
+      chunk.index,
       q,
       self.pix_format,
       self.probing_rate,
@@ -251,13 +251,12 @@ impl<'a> TargetQuality<'a> {
 
     rt.block_on(future)?;
 
-    let probe_name =
-      Path::new(&chunk.temp)
-        .join("split")
-        .join(format!("v_{}{}.ivf", q, chunk.name()));
+    let probe_name = Path::new(&chunk.temp)
+      .join("split")
+      .join(format!("v_{}_{}.ivf", q, chunk.index));
     let fl_path = Path::new(&chunk.temp)
       .join("split")
-      .join(format!("{}.json", chunk.name()));
+      .join(format!("{}.json", chunk.index));
 
     vmaf::run_vmaf(
       &probe_name,


### PR DESCRIPTION
This shouldn't cause any breaking changes since it doesn't affect (de)serialization and when resuming we don't read the probes again.