### PR TITLE
Retry chunk without TPL if a TPL-related crash occurs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "av-data",
  "av-format",
  "log",
- "nom 6.2.1",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -213,6 +213,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "log",
+ "memchr",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -863,9 +864,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -942,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec",
  "funty",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -17,6 +17,7 @@ license = "GPL-3.0"
 log = "0.4.14"
 av-format = "0.3.1"
 av-ivf = "0.2.2"
+memchr = "2.4.1"
 num_cpus = "1.13.0"
 anyhow = "1.0.42"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
aomenc has had a history of crashes related to TPL on certain
chunks, particularly in videos with less motion, such as animated
content. This commit enables a workaround to retry a chunk with TPL
disabled if such a crash is detected. Although there is some amount of
psychovisual quality loss with TPL disabled, this is preferable to being
unable to complete the encode.