### PR TITLE
Add extra conditional for tpl_crash_workaround

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -208,6 +208,7 @@ impl<'a> Broker<'a> {
           warn!("Encoder failed (on chunk {}):\n{}", chunk.index, e);
 
           if self.project.encoder == Encoder::aom
+            && !tpl_crash_workaround
             && memmem::rfind(e.stderr.as_bytes(), b"av1_tpl_stats_ready").is_some()
           {
             // aomenc has had a history of crashes related to TPL on certain chunks,


### PR DESCRIPTION
I think this would probably be good if somehow aomenc happens to crash *again* even with the tpl workaround. Realized this after I merged #444.