### PR TITLE
Fix clippy warnings

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -73,7 +73,7 @@ impl StringOrBytes {
   pub fn as_bytes(&self) -> &[u8] {
     match self {
       Self::String(s) => s.as_bytes(),
-      Self::Bytes(b) => &b,
+      Self::Bytes(b) => b,
     }
   }
 }
@@ -99,7 +99,6 @@ impl Display for EncoderCrash {
 
 impl<'a> Broker<'a> {
   /// Main encoding loop. set_thread_affinity may be ignored if the value is invalid.
-  #[allow(clippy::needless_pass_by_value)]
   pub fn encoding_loop(
     self,
     tx: Sender<()>,

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -63,7 +63,7 @@ pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg_next::Error> {
     .best(MediaType::Video)
     .ok_or(StreamNotFound)?;
   let rate = input.avg_frame_rate();
-  Ok(rate.numerator() as f64 / rate.denominator() as f64)
+  Ok(f64::from(rate.numerator()) / f64::from(rate.denominator()))
 }
 
 pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg_next::Error> {

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::drop_ref)]
 #![allow(clippy::unsafe_derive_deserialize)]
+#![allow(clippy::needless_pass_by_value)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
I disabled `clippy::needless_pass_by_value` since it's mostly catching false-positives nowadays (like complaining about a type that is technically not `Copy` but is just internally a `u64`, although it was useful in the beginning when there was a lot of passing `Vec<i32>` by value).