### PR TITLE
Update indicatif + `cargo update`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,12 +702,10 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.17.0-beta.1"
-source = "git+https://github.com/mitsuhiko/indicatif?rev=1fa875fefab83e8aee6bc80d881decf155382d8a#1fa875fefab83e8aee6bc80d881decf155382d8a"
+source = "git+https://github.com/mitsuhiko/indicatif?rev=ddc9fa9f0af35fa86c9e74784b3874003235e141#ddc9fa9f0af35fa86c9e74784b3874003235e141"
 dependencies = [
  "console",
  "number_prefix",
- "once_cell",
- "regex",
 ]
 
 [[package]]
@@ -1734,11 +1732,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -28,7 +28,7 @@ splines = "4.0.0"
 # the latest git version is currently required since wide_bar
 # with ANSI escape codes is broken on both the stable release
 # and the beta and the fix only exists in the git version
-indicatif = { git = "https://github.com/mitsuhiko/indicatif", rev = "1fa875fefab83e8aee6bc80d881decf155382d8a" }
+indicatif = { git = "https://github.com/mitsuhiko/indicatif", rev = "ddc9fa9f0af35fa86c9e74784b3874003235e141" }
 
 once_cell = "1.8.0"
 chrono = "0.4.19"


### PR DESCRIPTION
The issue with the new parser has been fixed as of the latest commit, and the new parser is much faster than the old regex. `indicatif` now no longer depends directly on regex, but `console` still uses regex to parse ansi escape codes. Eventually it should be possible to remove regex entirely as a non-build/dev dependency.