### PR TITLE
Automatically add cq-level arg if it is not present

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,65 +105,69 @@ jobs:
           target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --chunk-method select
           du -h tt_sif.mkv
 
-      # TODO: remove the --crf/--quantizer/--cq-level params once the bug of not specifying them resulting in a panic is fixed
       - name: Testing target-quality aom
         run: |
-          target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4 --cq-level=0" -p1 --target-quality 95
+          target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4" -p1 --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing target-quality rav1e
         run: |
-          target/ci/av1an -i tt_sif.y4m -e rav1e --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --speed 10 --low-latency --quantizer 0" --target-quality 95
+          target/ci/av1an -i tt_sif.y4m -e rav1e --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --speed 10 --low-latency" --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing target-quality svt-av1
         run: |
-          target/ci/av1an -i tt_sif.y4m -e svt-av1 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset 8 --crf 0" --target-quality 95
+          target/ci/av1an -i tt_sif.y4m -e svt-av1 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset 8" --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing target-quality vpx
         run: |
-          target/ci/av1an -i tt_sif.y4m -e vpx --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=9 --rt --threads=4 --cq-level=0" -p1 --target-quality 95
+          target/ci/av1an -i tt_sif.y4m -e vpx --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=9 --rt --threads=4" -p1 --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing target-quality x265
         run: |
-          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast --crf 0" --target-quality 95
+          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing target-quality x264
+        run: |
+          target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --target-quality 95
+          du -h tt_sif.mkv
+
+      - name: Testing target-quality replace crf
         run: |
           target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast --crf 0" --target-quality 95
           du -h tt_sif.mkv
 
       - name: Testing probe-slow aom
         run: |
-          target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4 --cq-level=0" -p1 --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4" -p1 --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing probe-slow rav1e
         run: |
-          target/ci/av1an -i tt_sif.y4m -e rav1e --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --speed 10 --low-latency --quantizer 0" --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e rav1e --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --speed 10 --low-latency" --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing probe-slow svt-av1
         run: |
-          target/ci/av1an -i tt_sif.y4m -e svt-av1 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset 8 --crf 0" --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e svt-av1 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset 8" --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing probe-slow vpx
         run: |
-          target/ci/av1an -i tt_sif.y4m -e vpx --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=9 --rt --threads=4 --cq-level=0" -p1 --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e vpx --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=9 --rt --threads=4" -p1 --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing probe-slow x265
         run: |
-          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast --crf 0" --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing probe-slow x264
         run: |
-          target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast --crf 0" --target-quality 95 --probe-slow
+          target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --target-quality 95 --probe-slow
           du -h tt_sif.mkv
 
       - name: Testing chunk_hybrid aom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "affinity",
  "ansi_term",
  "anyhow",
+ "arrayvec 0.7.2",
  "av-format",
  "av-ivf",
  "av-scenechange",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -15,6 +15,7 @@ license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.14"
+arrayvec = "0.7.2"
 av-format = "0.3.1"
 av-ivf = "0.2.2"
 memchr = "2.4.1"

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -1,4 +1,5 @@
 use crate::{ffmpeg::compose_ffmpeg_pipe, inplace_vec, into_vec, list_index};
+use arrayvec::ArrayVec;
 use cfg_if::cfg_if;
 use ffmpeg_next::format::Pixel;
 use itertools::chain;
@@ -344,16 +345,36 @@ impl Encoder {
     }
   }
 
+  fn insert_q(self, q: usize) -> ArrayVec<String, 2> {
+    let mut output = ArrayVec::new();
+    match self {
+      Self::aom | Self::vpx => {
+        output.push(format!("--cq-level={}", q));
+      }
+      Self::rav1e => {
+        output.push("--quantizer".to_string());
+        output.push(q.to_string());
+      }
+      Self::svt_av1 | Self::x264 | Self::x265 => {
+        output.push("--crf".to_string());
+        output.push(q.to_string());
+      }
+    }
+    output
+  }
+
   /// Returns changed q/crf in command line arguments
-  pub fn man_command(self, params: Vec<String>, q: usize) -> Vec<String> {
-    let index = list_index(&params, self.q_match_fn())
-      .unwrap_or_else(|| panic!("No match found for params: {:#?}", params));
+  pub fn man_command(self, mut params: Vec<String>, q: usize) -> Vec<String> {
+    let index = list_index(&params, self.q_match_fn());
+    if let Some(index) = index {
+      let (replace_index, replace_q) = self.replace_q(index, q);
+      params[replace_index] = replace_q;
+    } else {
+      let args = self.insert_q(q);
+      params.extend_from_slice(&args);
+    }
 
-    let mut new_params = params;
-    let (replace_index, replace_q) = self.replace_q(index, q);
-    new_params[replace_index] = replace_q;
-
-    new_params
+    params
   }
 
   /// Parses the number of encoded frames

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -352,12 +352,12 @@ impl Encoder {
         output.push(format!("--cq-level={}", q));
       }
       Self::rav1e => {
-        output.push("--quantizer".to_string());
-        output.push(q.to_string());
+        output.push("--quantizer".into());
+        output.push(format!("{}", q));
       }
       Self::svt_av1 | Self::x264 | Self::x265 => {
-        output.push("--crf".to_string());
-        output.push(q.to_string());
+        output.push("--crf".into());
+        output.push(format!("{}", q));
       }
     }
     output


### PR DESCRIPTION
Currently, target quality requires a cq-level (or equivalent for the
encoder) arg to be present in order to work, so that it can replace the
existing cq-level with the new one. This commit makes it so that if the
arg is not present, av1an will insert it with the proper quality level.