### PR TITLE
Remove overhead at the start and in between scene detection and encoding

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -531,6 +531,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<EncodeArgs> {
     vmaf_res: args.vmaf_res,
     workers: args.workers,
     set_thread_affinity: args.set_thread_affinity,
+    vs_script: None,
   };
 
   encode_args.startup_check()?;

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -58,7 +58,7 @@ pub mod util;
 pub mod vapoursynth;
 pub mod vmaf;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Input {
   VapourSynth(PathBuf),
   Video(PathBuf),
@@ -212,7 +212,6 @@ pub enum ChunkMethod {
 /// Determine the optimal number of workers for an encoder
 #[must_use]
 pub fn determine_workers(encoder: Encoder) -> u64 {
-  // TODO look for lighter weight solution? sys-info maybe?
   let mut system = sysinfo::System::new();
   system.refresh_memory();
 

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -87,6 +87,11 @@ pub fn get_first_multi_progress_bar() -> Option<&'static ProgressBar> {
   }
 }
 
+pub fn set_len(len: u64) {
+  let pb = PROGRESS_BAR.get().unwrap();
+  pb.set_length(len);
+}
+
 pub fn reset_bar_at(pos: u64) {
   if let Some(pb) = PROGRESS_BAR.get() {
     pb.reset();

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -7,6 +7,7 @@ use ansi_term::Style;
 use av_scenechange::{detect_scene_changes, DetectionOptions, SceneDetectionSpeed};
 
 use std::process::{Command, Stdio};
+use std::thread;
 
 pub fn av_scenechange_detect(
   input: &Input,
@@ -17,13 +18,20 @@ pub fn av_scenechange_detect(
   sc_pix_format: Option<Pixel>,
   sc_method: ScenecutMethod,
   sc_downscale_height: Option<usize>,
-) -> anyhow::Result<Vec<usize>> {
+) -> anyhow::Result<(Vec<usize>, usize)> {
   if verbosity != Verbosity::Quiet {
     eprintln!("{}", Style::default().bold().paint("Scene detection"));
     progress_bar::init_progress_bar(total_frames as u64);
   }
 
-  let mut frames = scene_detect(
+  let input2 = input.clone();
+  let frame_thread = thread::spawn(move || {
+    let frames = input2.frames();
+    progress_bar::set_len(frames as u64);
+    frames
+  });
+
+  let mut scenecuts = scene_detect(
     input,
     encoder,
     if verbosity == Verbosity::Quiet {
@@ -39,15 +47,17 @@ pub fn av_scenechange_detect(
     sc_downscale_height,
   )?;
 
+  let frames = frame_thread.join().unwrap();
+
   progress_bar::finish_progress_bar();
 
-  if frames[0] == 0 {
+  if scenecuts[0] == 0 {
     // TODO refactor the chunk creation to not require this
     // Currently, this is required for compatibility with create_video_queue_vs
-    frames.remove(0);
+    scenecuts.remove(0);
   }
 
-  Ok(frames)
+  Ok((scenecuts, frames))
 }
 
 /// Detect scene changes using rav1e scene detector.

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -3,7 +3,6 @@ use std::{
   fs::File,
   io::Write,
   path::{Path, PathBuf},
-  process::{Command, Stdio},
 };
 use vapoursynth::video_info::VideoInfo;
 
@@ -28,7 +27,7 @@ static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
       plugins
         .get::<&[u8]>(plugin)
         .ok()
-        .and_then(|slice| std::str::from_utf8(slice).ok())
+        .and_then(|slice| simdutf8::basic::from_utf8(slice).ok())
         .and_then(|s| s.split(';').nth(1))
         .map(ToOwned::to_owned)
     })
@@ -134,13 +133,10 @@ pub fn create_vs_file(
   chunk_method: ChunkMethod,
 ) -> anyhow::Result<PathBuf> {
   let temp: &Path = temp.as_ref();
-  let source = Path::new(source).canonicalize()?;
+  let source = source.canonicalize()?;
 
   let load_script_path = temp.join("split").join("loadscript.vpy");
 
-  if load_script_path.exists() {
-    return Ok(load_script_path);
-  }
   let mut load_script = File::create(&load_script_path)?;
 
   let cache_file = PathAbs::new(temp.join("split").join(format!(
@@ -168,16 +164,6 @@ core.{}({:?}, cachefile={:?}).set_output()",
     )
     .as_bytes(),
   )?;
-
-  // TODO use vapoursynth crate instead
-  Command::new("vspipe")
-    .arg("-i")
-    .arg(&load_script_path)
-    .args(["-i", "-"])
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()?
-    .wait()?;
 
   Ok(load_script_path)
 }


### PR DESCRIPTION
This PR mainly changes the behavior in 2 ways:

1. We now get the frame count and do scene detection in parallel. Initially, only the number of processed frames are shown, and the percentage stays at 100%, and the total frame count is 0. When the actual frame count is available, the progress bar is updated to reflect that. This can help I/O bound situations where the source is very large and the frame count takes a long time to calculate.
2. We also generate the vapoursynth cache in parallel with the scene detection and calculating the frame count. This eliminates the pause between scene detection and actual encoding (if vspipe finishes generating the cache in time, which will be the case 99% of the time, and it will still reduce the overhead in the very unlikely case that it hasn't finished yet).

Also fixes bug where vapoursynth input wouldn't work if you specified anything other than lsmash or ffms2 for the chunk method.

However, there is still some overhead when using hybrid or segment as the chunk method, as segmenting the input file cannot be done before the split locations are known.