### PR TITLE
Reduce length of mkvmerge command

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -198,7 +198,7 @@ pub fn mkvmerge(
     .collect();
 
   let mut cmd = Command::new("mkvmerge");
-  cmd.current_dir(&encode_dir);
+  cmd.current_dir(encode_dir.canonicalize()?);
   cmd.arg("-o");
   cmd.arg(fix_path(output));
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -937,6 +937,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let splits = self.split_routine()?;
 
     let chunk_queue = self.load_or_gen_chunk_queue(splits)?;
+    let num_chunks = chunk_queue.len();
 
     if self.resume {
       let chunks_done = get_done().done.len();
@@ -1068,7 +1069,12 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
           )?;
         }
         ConcatMethod::MKVMerge => {
-          concat::mkvmerge(self.temp.as_ref(), self.output_file.as_ref())?;
+          concat::mkvmerge(
+            self.temp.as_ref(),
+            self.output_file.as_ref(),
+            self.encoder,
+            num_chunks,
+          )?;
         }
         ConcatMethod::FFmpeg => {
           concat::ffmpeg(self.temp.as_ref(), self.output_file.as_ref())?;


### PR DESCRIPTION
This will not fully fix mkvmerge on Windows yet but this should at least reduce the length of the executed mkvmerge command by using relative paths. A full fix that breaks up the mkvmerge command into multiple commands if there are too many chunks is coming later.