### PR TITLE
Automatic tiling for default settings

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -33,6 +33,7 @@ use grain::TransferFunction;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{
+  cmp::max,
   collections::hash_map::DefaultHasher,
   fs,
   fs::File,
@@ -166,6 +167,23 @@ impl Input {
         }
       }
     })
+  }
+
+  /// Calculates tiles from resolution
+  /// Don't convert tiles to encoder specific representation
+  /// Default video without tiling is 1,1
+  /// Return number of horizontal and vertical tiles
+  pub fn calculate_tiles(&self) -> (u32, u32) {
+    match self.resolution() {
+      Ok((h, v)) => {
+        // tile range 0-1440 pixels
+        let horizontal = max((h - 1) / 720, 1);
+        let vertical = max((v - 1) / 720, 1);
+
+        (horizontal, vertical)
+      }
+      _ => (1, 1),
+    }
   }
 }
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -555,7 +555,9 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     }
 
     if self.video_params.is_empty() {
-      self.video_params = self.encoder.get_default_arguments();
+      self.video_params = self
+        .encoder
+        .get_default_arguments(self.input.calculate_tiles());
     }
 
     if let Some(strength) = self.photon_noise {


### PR DESCRIPTION
Adds automatic tiling for aomenc, rav1e, svt-av1, vpx.
Encoder options are added if tiling is required.
Picture without tiles represented as (1, 1) tiles.
Tiles are set calculated from resolution, separately for horizontal and vertical resolution.
Default tile is 720 pixels, and tile calculation rounds down, so 1280x720 is (1,1) tiles, 1920x1080 is (2,1), and so on.

