### PR TITLE
Remove ctrlc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,6 @@ dependencies = [
  "anyhow",
  "av1an-cli",
  "av1an-core",
- "ctrlc",
  "path_abs",
  "serde",
  "serde_json",
@@ -174,7 +173,6 @@ dependencies = [
  "anyhow",
  "av1an-core",
  "clap",
- "ctrlc",
  "ffmpeg-next",
  "flexi_logger",
  "once_cell",
@@ -448,16 +446,6 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
-dependencies = [
- "nix",
- "winapi",
 ]
 
 [[package]]
@@ -920,19 +908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06380d23b58dcdaf892fa36c3950cad3110e7d76851275d5f85c22eb9cdd614"
 dependencies = [
  "rayon",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+checksum = "b1121e32687f7f90b905d4775273305baa4f32cd418923e9b0fa726533221857"
 dependencies = [
  "atty",
  "bitflags",
@@ -373,11 +373,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+checksum = "7cbcf660a32ad0eda4b11996d8761432f499034f6e685bc6072337db662c85f8"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -663,6 +663,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1377,18 +1383,18 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1503,7 +1509,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1515,7 +1521,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1568,7 +1574,7 @@ checksum = "7ab7dbd121ce66af2176147a48c7e01aaf1f001837a18a7cf4317858606bbdf8"
 dependencies = [
  "anyhow",
  "cfg-expr",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "pkg-config",
  "strum 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = "1.0.42"
 serde_json = "1.0.64"
 serde = { version = "1.0.126", features = ["serde_derive"] }
 shlex = "1.0.0"
-ctrlc = "3.1.9"
 path_abs = "0.5.1"
 av1an-cli = { path = "av1an-cli", version = "0.2.1-2" }
 av1an-core = { path = "av1an-core", version = "0.2.0" }

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [dependencies]
 clap = { version = "3.0.0", features = ["derive"] }
 shlex = "1.0.0"
-ctrlc = "3.1.9"
 path_abs = "0.5.1"
 anyhow = "1.0.42"
 av1an-core = { path = "../av1an-core", version = "0.2.0" }

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -645,11 +645,6 @@ pub fn run() -> anyhow::Result<()> {
   let log_level = cli_args.log_level;
   let mut args = parse_cli(cli_args)?;
 
-  ctrlc::set_handler(|| {
-    println!("Stopped");
-    exit(0);
-  })?;
-
   let log = LogSpecBuilder::new().default(log_level).build();
 
   Logger::with(log)


### PR DESCRIPTION
Turns out the behavior is pretty much the same either way. This is probably left over from the initial port from python to rust, and as the rust version does not try to catch some sort of exception or something when pressing ctrl c, only one ctrl c is required for it to stop (a stark contrast to the python version).