### PR TITLE
Fix av1an versions in root cargo toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "av1an-cli"
-version = "0.2.1-2"
+version = "0.3.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "av1an-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "affinity",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = "1.0.64"
 serde = { version = "1.0.126", features = ["serde_derive"] }
 shlex = "1.0.0"
 path_abs = "0.5.1"
-av1an-cli = { path = "av1an-cli", version = "0.2.1-2" }
-av1an-core = { path = "av1an-core", version = "0.2.0" }
+av1an-cli = { path = "av1an-cli", version = "0.3.0" }
+av1an-core = { path = "av1an-core", version = "0.3.0" }
 
 [features]
 default = ["vapoursynth_new_api"]


### PR DESCRIPTION
Currently av1an at the root directly will fail to compile from scratch or run e.g. cargo update. This fixes that issue.