### PR TITLE
Call fix_path for mkvmerge concat

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -176,7 +176,7 @@ pub fn mkvmerge(
     let p = p.as_ref().display().to_string();
     if let Some(path) = p.strip_prefix(UNC_PREFIX) {
       path.to_string()
-    } else{
+    } else {
       p
     }
   }

--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -174,9 +174,9 @@ pub fn mkvmerge(
     const UNC_PREFIX: &str = r#"\\?\"#;
 
     let p = p.as_ref().display().to_string();
-    if p.starts_with(UNC_PREFIX) {
-      p[UNC_PREFIX.len()..].to_string()
-    } else {
+    if let Some(path) = p.strip_prefix(UNC_PREFIX) {
+      path.to_string()
+    } else{
       p
     }
   }
@@ -206,7 +206,7 @@ pub fn mkvmerge(
   let options_json_contents = mkvmerge_options_json(
     num_chunks,
     encoder,
-    output.to_str().unwrap(),
+    &fix_path(output.to_str().unwrap()),
     audio_file.as_deref(),
   );
 


### PR DESCRIPTION
Somehow I missed this in PR #523.