### PR TITLE
Update vapoursynth and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "affinity"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,21 +209,6 @@ dependencies = [
  "vapoursynth",
  "which",
  "y4m",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
 ]
 
 [[package]]
@@ -528,28 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "ffmpeg-next"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,12 +571,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "git2"
@@ -877,16 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,15 +953,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -1336,12 +1259,6 @@ name = "rust_hawktracer_proc_macro"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb626abdbed5e93f031baae60d72032f56bc964e11ac2ff65f2ba3ed98d6d3e1"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -1774,23 +1691,21 @@ dependencies = [
 [[package]]
 name = "vapoursynth"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e378bb0210b411e41b16083e2cf274d3fcb3c92071dbcc332cbac713ab6c33a0"
+source = "git+https://github.com/redzic/vapoursynth-rs?rev=be8e2c0340d6a93500403c242e02015bb926c80b#be8e2c0340d6a93500403c242e02015bb926c80b"
 dependencies = [
+ "anyhow",
  "bitflags",
- "failure",
- "failure_derive",
  "lazy_static",
+ "thiserror",
  "vapoursynth-sys",
 ]
 
 [[package]]
 name = "vapoursynth-sys"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ad7879f2893d1574b128d26e65aedf38c3c01ac3af1c7d09cc6bc4c5148b87"
+source = "git+https://github.com/redzic/vapoursynth-rs?rev=be8e2c0340d6a93500403c242e02015bb926c80b#be8e2c0340d6a93500403c242e02015bb926c80b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -66,7 +66,8 @@ default-features = false
 features = ["svg_backend", "line_series"]
 
 [dependencies.vapoursynth]
-version = "0.3.0"
+git = "https://github.com/redzic/vapoursynth-rs"
+rev = "be8e2c0340d6a93500403c242e02015bb926c80b"
 features = ["vsscript-functions", "vapoursynth-functions"]
 
 [dependencies.tokio]


### PR DESCRIPTION
The vapoursynth crate is still running on the deprecated failure crate. In my fork, I updated to thiserror + anyhow, and migrated to edition 2021. I opened a PR upstream: https://github.com/YaLTeR/vapoursynth-rs/pull/14

Not sure whether we want to leave this PR open until these changes are merged upstream or just merge it now (as this change reduces the number of dependencies by ~20). @shssoichiro thoughts?