### PR TITLE
Display chunk index instead of worker index in verbose mode

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -113,6 +113,8 @@ impl<'a> Broker<'a> {
     mut set_thread_affinity: Option<usize>,
     audio_size_bytes: Arc<AtomicU64>,
   ) {
+    assert!(self.total_chunks != 0);
+
     if !self.chunk_queue.is_empty() {
       let (sender, receiver) = crossbeam_channel::bounded(self.chunk_queue.len());
 
@@ -212,6 +214,7 @@ impl<'a> Broker<'a> {
       tq.per_shot_target_quality_routine(chunk)?;
     }
 
+    // we display the index, so we need to subtract 1 to get the max index
     let padding = printable_base10_digits(self.total_chunks - 1) as usize;
 
     // Run all passes for this chunk

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -25,6 +25,7 @@ use thiserror::Error;
 pub struct Broker<'a> {
   pub max_tries: usize,
   pub chunk_queue: Vec<Chunk>,
+  pub total_chunks: usize,
   pub project: &'a EncodeArgs,
   pub target_quality: Option<TargetQuality<'a>>,
 }
@@ -214,9 +215,13 @@ impl<'a> Broker<'a> {
     let mut tpl_crash_workaround = false;
     for current_pass in 1..=self.project.passes {
       for r#try in 1..=self.max_tries {
-        let res = self
-          .project
-          .create_pipes(chunk, current_pass, worker_id, tpl_crash_workaround);
+        let res = self.project.create_pipes(
+          chunk,
+          current_pass,
+          worker_id,
+          self.total_chunks,
+          tpl_crash_workaround,
+        );
         if let Err((e, frames)) = res {
           if self.project.verbosity == Verbosity::Normal {
             dec_bar(frames);

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -1,4 +1,5 @@
 use crate::progress_bar::update_progress_bar_estimates;
+use crate::util::printable_base10_digits;
 use crate::DoneChunk;
 use crate::{
   ffmpeg, finish_multi_progress_bar, finish_progress_bar, get_done,
@@ -211,6 +212,8 @@ impl<'a> Broker<'a> {
       tq.per_shot_target_quality_routine(chunk)?;
     }
 
+    let padding = printable_base10_digits(self.total_chunks - 1) as usize;
+
     // Run all passes for this chunk
     let mut tpl_crash_workaround = false;
     for current_pass in 1..=self.project.passes {
@@ -219,7 +222,7 @@ impl<'a> Broker<'a> {
           chunk,
           current_pass,
           worker_id,
-          self.total_chunks,
+          padding,
           tpl_crash_workaround,
         );
         if let Err((e, frames)) = res {

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -180,10 +180,9 @@ pub fn init_multi_progress_bar(len: u64, workers: usize, total_chunks: usize) {
   });
 }
 
-pub fn update_mp_chunk(worker_idx: usize, chunk: usize, total_chunks: usize) {
-  let digits = printable_base10_digits(total_chunks) as usize;
+pub fn update_mp_chunk(worker_idx: usize, chunk: usize, padding: usize) {
   if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
-    pbs[worker_idx].set_prefix(format!("[Chunk {:>digits$}]", chunk, digits = digits));
+    pbs[worker_idx].set_prefix(format!("[Chunk {:>digits$}]", chunk, digits = padding));
   }
 }
 

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -144,15 +144,15 @@ pub fn reset_mp_bar_at(pos: u64) {
   }
 }
 
-pub fn init_multi_progress_bar(len: u64, workers: usize) {
+pub fn init_multi_progress_bar(len: u64, workers: usize, total_chunks: usize) {
   MULTI_PROGRESS_BAR.get_or_init(|| {
     let mpb = MultiProgress::new();
 
     let mut pbs = Vec::new();
 
-    let digits = printable_base10_digits(workers) as usize;
+    let digits = printable_base10_digits(total_chunks) as usize;
 
-    for i in 1..=workers {
+    for _ in 1..=workers {
       let pb = ProgressBar::hidden()
         // no spinner on windows, so we remove the prefix to line up with the progress bar
         .with_style(ProgressStyle::default_spinner().template(if cfg!(windows) {
@@ -160,7 +160,7 @@ pub fn init_multi_progress_bar(len: u64, workers: usize) {
         } else {
           "  {prefix:.dim} {msg}"
         }));
-      pb.set_prefix(format!("[Worker {:>digits$}]", i, digits = digits));
+      pb.set_prefix(format!("[Idle  {:width$}]", width = digits));
       pbs.push(mpb.add(pb));
     }
 
@@ -178,6 +178,13 @@ pub fn init_multi_progress_bar(len: u64, workers: usize) {
 
     (mpb, pbs)
   });
+}
+
+pub fn update_mp_chunk(worker_idx: usize, chunk: usize, total_chunks: usize) {
+  let digits = printable_base10_digits(total_chunks) as usize;
+  if let Some((_, pbs)) = MULTI_PROGRESS_BAR.get() {
+    pbs[worker_idx].set_prefix(format!("[Chunk {:>digits$}]", chunk, digits = digits));
+  }
 }
 
 pub fn update_mp_msg(worker_idx: usize, msg: String) {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -225,10 +225,10 @@ impl EncodeArgs {
     chunk: &Chunk,
     current_pass: u8,
     worker_id: usize,
-    total_chunks: usize,
+    padding: usize,
     tpl_crash_workaround: bool,
   ) -> Result<(), (EncoderCrash, u64)> {
-    update_mp_chunk(worker_id, chunk.index, total_chunks);
+    update_mp_chunk(worker_id, chunk.index, padding);
 
     let fpf_file = Path::new(&chunk.temp)
       .join("split")

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::grain::create_film_grain_file;
 use crate::parse::valid_params;
-use crate::progress_bar::update_progress_bar_estimates;
 use crate::progress_bar::{reset_bar_at, reset_mp_bar_at};
+use crate::progress_bar::{update_mp_chunk, update_progress_bar_estimates};
 use crate::vapoursynth::{is_ffms2_installed, is_lsmash_installed};
 use crate::ChunkOrdering;
 use crate::{
@@ -225,8 +225,11 @@ impl EncodeArgs {
     chunk: &Chunk,
     current_pass: u8,
     worker_id: usize,
+    total_chunks: usize,
     tpl_crash_workaround: bool,
   ) -> Result<(), (EncoderCrash, u64)> {
+    update_mp_chunk(worker_id, chunk.index, total_chunks);
+
     let fpf_file = Path::new(&chunk.temp)
       .join("split")
       .join(format!("{}_fpf", chunk.name()));
@@ -1164,7 +1167,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
         init_progress_bar(self.frames as u64);
         reset_bar_at(initial_frames as u64);
       } else if self.verbosity == Verbosity::Verbose {
-        init_multi_progress_bar(self.frames as u64, self.workers);
+        init_multi_progress_bar(self.frames as u64, self.workers, total_chunks);
         reset_mp_bar_at(initial_frames as u64);
       }
 
@@ -1180,6 +1183,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
       let broker = Broker {
         chunk_queue,
+        total_chunks,
         project: self,
         target_quality: if self.target_quality.is_some() {
           Some(TargetQuality::new(self))


### PR DESCRIPTION
The chunk index would be much more useful for users who are using
verbose mode. Worker index is easily derived from counting the lines,
and is not particularly useful.

![Screenshot 2022-01-18 194916](https://user-images.githubusercontent.com/5951392/150043500-4b84f787-c615-4de6-9104-c236f22841b2.png)