### PR TITLE
Lastrosade sc only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,7 +225,6 @@ jobs:
       - name: Testing sc-only
         run: |
           target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
-          rm tt_sif.json
           du -h tt_sif.json
 
   docker:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Testing sc-only
         run: |
           target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
-          du -h tt_sif.json
+        if: du -h tt_sif.json || cat tt_sif.json
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,6 +222,11 @@ jobs:
           target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4" -c mkvmerge
           du -h tt_sif.mkv
 
+      - name: Testing sc-only
+        run: |
+          target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
+          du -h tt_sif.json
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,8 +224,11 @@ jobs:
 
       - name: Testing sc-only
         run: |
+          cat tt_sif.json
           target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
-        if: du -h tt_sif.json || cat tt_sif.json
+          cat tt_sif.json
+          du -h tt_sif.json
+        continue-on-error: true
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,10 +224,8 @@ jobs:
 
       - name: Testing sc-only
         run: |
-          cat tt_sif.json
-          target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
-          cat tt_sif.json
-          du -h tt_sif.json
+          target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif_scenes.json"
+          du -h tt_sif_scenes.json
         continue-on-error: true
 
   docker:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,6 +225,7 @@ jobs:
       - name: Testing sc-only
         run: |
           target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif.json"
+          rm tt_sif.json
           du -h tt_sif.json
 
   docker:

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -189,7 +189,7 @@ pub struct CliOpts {
   pub sc_method: ScenecutMethod,
 
   /// Run scene detection only
-  #[clap(long, help_heading = "SCENE DETECTION")]
+  #[clap(long, requires("scenes"), help_heading = "SCENE DETECTION")]
   pub sc_only: bool,
 
   /// Perform scene detection with this pixel format

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -187,6 +187,10 @@ pub struct CliOpts {
   /// Fast: Very fast, but less accurate. Determines keyframes based on the raw difference between pixels.
   #[clap(long, possible_values = &["standard", "fast"], default_value_t = ScenecutMethod::Standard, help_heading = "SCENE DETECTION")]
   pub sc_method: ScenecutMethod,
+  
+  /// Run scene detection only
+  #[clap(long, help_heading = "SCENE DETECTION")]
+  pub sc_only: bool,
 
   /// Perform scene detection with this pixel format
   #[clap(long, help_heading = "SCENE DETECTION")]

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -169,7 +169,13 @@ pub struct CliOpts {
   pub set_thread_affinity: Option<usize>,
 
   /// File location for scenes
-  #[clap(short, long, parse(from_os_str), help_heading = "SCENE DETECTION"), requires_if(true, sc_only)]
+  #[clap(
+    short,
+    long,
+    parse(from_os_str),
+    help_heading = "SCENE DETECTION",
+    requires_if(true, sc_only)
+  )]
   pub scenes: Option<PathBuf>,
 
   /// Method used to determine chunk boundaries

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -187,7 +187,7 @@ pub struct CliOpts {
   /// Fast: Very fast, but less accurate. Determines keyframes based on the raw difference between pixels.
   #[clap(long, possible_values = &["standard", "fast"], default_value_t = ScenecutMethod::Standard, help_heading = "SCENE DETECTION")]
   pub sc_method: ScenecutMethod,
-  
+
   /// Run scene detection only
   #[clap(long, help_heading = "SCENE DETECTION")]
   pub sc_only: bool,

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -188,7 +188,9 @@ pub struct CliOpts {
   #[clap(long, possible_values = &["standard", "fast"], default_value_t = ScenecutMethod::Standard, help_heading = "SCENE DETECTION")]
   pub sc_method: ScenecutMethod,
 
-  /// Run scene detection only
+  /// Run the scene detection only before exiting
+  ///
+  /// Requires a scene file with --scenes.
   #[clap(long, requires("scenes"), help_heading = "SCENE DETECTION")]
   pub sc_only: bool,
 

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -169,13 +169,7 @@ pub struct CliOpts {
   pub set_thread_affinity: Option<usize>,
 
   /// File location for scenes
-  #[clap(
-    short,
-    long,
-    parse(from_os_str),
-    help_heading = "SCENE DETECTION",
-    requires_if(true, sc_only)
-  )]
+  #[clap( short, long, parse(from_os_str), help_heading = "SCENE DETECTION")]
   pub scenes: Option<PathBuf>,
 
   /// Method used to determine chunk boundaries

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -169,7 +169,7 @@ pub struct CliOpts {
   pub set_thread_affinity: Option<usize>,
 
   /// File location for scenes
-  #[clap( short, long, parse(from_os_str), help_heading = "SCENE DETECTION")]
+  #[clap(short, long, parse(from_os_str), help_heading = "SCENE DETECTION")]
   pub scenes: Option<PathBuf>,
 
   /// Method used to determine chunk boundaries

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -169,7 +169,7 @@ pub struct CliOpts {
   pub set_thread_affinity: Option<usize>,
 
   /// File location for scenes
-  #[clap(short, long, parse(from_os_str), help_heading = "SCENE DETECTION")]
+  #[clap(short, long, parse(from_os_str), help_heading = "SCENE DETECTION"), requires_if(true, sc_only)]
   pub scenes: Option<PathBuf>,
 
   /// Method used to determine chunk boundaries

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -557,6 +557,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<EncodeArgs> {
     scenes: args.scenes,
     split_method: args.split_method,
     sc_method: args.sc_method,
+    sc_only: args.sc_only,
     sc_downscale_height: args.sc_downscale_height,
     target_quality: args.target_quality,
     verbosity: if args.quiet {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1065,10 +1065,6 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let splits = self.split_routine()?;
 
     if self.sc_only {
-      if (self.scenes.is_some().not() || scene_file.exists().not()) {
-        warn!("You must specify the path for a scene file");
-      }
-
       debug!("scene detection only");
 
       if let Err(e) = fs::remove_dir_all(&self.temp) {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1063,7 +1063,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       };
 
     let splits = self.split_routine()?;
-    
+
     if self.sc_only {
       debug!("scene detection only");
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -81,6 +81,7 @@ pub struct EncodeArgs {
   pub split_method: SplitMethod,
   pub sc_pix_format: Option<Pixel>,
   pub sc_method: ScenecutMethod,
+  pub sc_only: bool,
   pub sc_downscale_height: Option<usize>,
   pub extra_splits_len: Option<usize>,
   pub min_scene_len: usize,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1065,6 +1065,11 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let splits = self.split_routine()?;
 
     if self.sc_only {
+
+      if (self.scenes.is_some().not() || scene_file.exists().not()) {
+        warn!("You must specify the path for a scene file");
+      }
+
       debug!("scene detection only");
 
       if let Err(e) = fs::remove_dir_all(&self.temp) {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1063,6 +1063,16 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       };
 
     let splits = self.split_routine()?;
+    
+    if self.sc_only {
+      debug!("scene detection only");
+
+      if let Err(e) = fs::remove_dir_all(&self.temp) {
+        warn!("Failed to delete temp directory: {}", e);
+      }
+
+      exit(0);
+    }
 
     let (chunk_queue, total_chunks) = self.load_or_gen_chunk_queue(splits)?;
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1065,7 +1065,6 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let splits = self.split_routine()?;
 
     if self.sc_only {
-
       if (self.scenes.is_some().not() || scene_file.exists().not()) {
         warn!("You must specify the path for a scene file");
       }


### PR DESCRIPTION
This pull request adds the `--sc-only` boolean argument which forces av1an to stop after scene detection as per #573 

Right now it simply deletes the temporary directory after the run

What would be optimal would be to not create any temp dir if both:
1. The input is a vpy script.
2. -s is specified.