### PR TITLE
Update to ffmpeg 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,8 +501,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-next"
 version = "5.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a1fc87054b079ade0b081b023c5fef309cd4bbcb569c09eed2aa39b25a0a11"
+source = "git+https://github.com/shssoichiro/rust-ffmpeg-1?branch=fix-get-best-stream#a0d7fdb30f70ed3b7e74cf5fd844e3881026c9f0"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763e484feceb7dd021b21c5c6f81aee06b1594a743455ec7efbf72e6355e447b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "errno",
  "libc",
  "num_cpus",
@@ -129,7 +129,7 @@ dependencies = [
  "av-data",
  "av-format",
  "log",
- "nom 7.1.0",
+ "nom",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ dependencies = [
  "path_abs",
  "serde",
  "serde_json",
- "shlex 1.1.0",
+ "shlex",
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ dependencies = [
  "flexi_logger",
  "once_cell",
  "path_abs",
- "shlex 1.1.0",
+ "shlex",
  "thiserror",
  "vergen 6.0.2",
 ]
@@ -186,7 +186,7 @@ dependencies = [
  "av-format",
  "av-ivf",
  "av-scenechange",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -220,13 +220,12 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "lazy_static",
  "lazycell",
@@ -235,7 +234,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 0.1.1",
+ "shlex",
 ]
 
 [[package]]
@@ -270,20 +269,20 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 5.1.2",
+ "nom",
 ]
 
 [[package]]
@@ -294,12 +293,6 @@ checksum = "30aa9e2ffbb838c6b451db14f3cd8e63ed622bf859f9956bc93845a10fafc26a"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -322,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -333,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -350,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -388,7 +381,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -398,7 +391,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -409,7 +402,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -422,7 +415,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -432,7 +425,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_cpus",
  "parking_lot",
  "serde",
@@ -507,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "4.4.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676cda947a87a1e8a42e154059c567e75de64860252cce52c684acd8c074fa0"
+checksum = "70a1fc87054b079ade0b081b023c5fef309cd4bbcb569c09eed2aa39b25a0a11"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",
@@ -518,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "4.4.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de57234f2c49c6e093fe67bbbaa9142c228f6e2d5533ef27980993d5b6adef2a"
+checksum = "6ba12dea33516e30c160ce557c7e43dd857276368eb1cd0eef4fce6529f2dee5"
 dependencies = [
  "bindgen",
  "cc",
@@ -563,7 +556,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -719,9 +712,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -747,11 +740,11 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cc",
+ "cfg-if",
  "winapi",
 ]
 
@@ -782,7 +775,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -814,9 +807,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -841,16 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce095842aee9aa3ecbda7a5d2a4df680375fd128a8596b6b56f8e497e231f483"
 dependencies = [
  "rayon",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -988,7 +971,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1115,14 +1098,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1145,15 +1127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rav1e"
 version = "0.5.0"
 source = "git+https://github.com/xiph/rav1e?rev=660a4ddd5b57610b3006777910c133919b9f1625#660a4ddd5b57610b3006777910c133919b9f1625"
@@ -1164,7 +1137,7 @@ dependencies = [
  "arrayvec",
  "bitstream-io",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "interpolate_name",
  "itertools",
  "libc",
@@ -1322,20 +1295,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shlex"
@@ -1393,9 +1360,9 @@ checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
 name = "stfu8"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf70433e3300a3c395d06606a700cdf4205f4f14dbae2c6833127c6bb22db77"
+checksum = "019f0c664fd85d5a87dcfb62b40b691055392a35a6e59f4df83d4b770db7e876"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1476,7 +1443,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d82ade9d6621d4ca052a00bb6ea9ed513d223cba75a84625c5e9c0698ab6f5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -1598,9 +1565,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -1680,7 +1647,7 @@ name = "v_frame"
 version = "0.2.5"
 source = "git+https://github.com/xiph/rav1e?rev=660a4ddd5b57610b3006777910c133919b9f1625#660a4ddd5b57610b3006777910c133919b9f1625"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "noop_proc_macro",
  "num-derive",
  "num-traits",
@@ -1705,7 +1672,7 @@ name = "vapoursynth-sys"
 version = "0.3.0"
 source = "git+https://github.com/YaLTeR/vapoursynth-rs?rev=074417335ff9c139956c62771835798c9a302e67#074417335ff9c139956c62771835798c9a302e67"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1730,7 +1697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3893329bee75c101278e0234b646fa72221547d63f97fb66ac112a0569acd110"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "chrono",
  "enum-iterator",
  "getset",
@@ -1764,7 +1731,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,5 @@ overflow-checks = true
 
 [patch.crates-io]
 rav1e = { git = "https://github.com/xiph/rav1e", rev = "660a4ddd5b57610b3006777910c133919b9f1625" }
+# TODO: switch to upstream once the issue with av_find_best_stream is fixed.
+ffmpeg-next = { git = "https://github.com/shssoichiro/rust-ffmpeg-1", branch = "fix-get-best-stream" }

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -32,8 +32,9 @@ version = "6"
 default-features = false
 features = ["git", "build", "rustc", "cargo"]
 
-[dependencies.ffmpeg-next]
-version = "4.4.0"
+[dependencies.ffmpeg]
+package = "ffmpeg-next"
+version = "5.0.2"
 
 [features]
-ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]
+ffmpeg_static = ["ffmpeg/static", "ffmpeg/build"]

--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -1,3 +1,4 @@
+use ::ffmpeg::format::Pixel;
 use ansi_term::{Color, Style};
 use anyhow::{anyhow, Context};
 use anyhow::{bail, ensure};
@@ -6,7 +7,6 @@ use av1an_core::settings::{InputPixelFormat, PixelFormat};
 use av1an_core::ScenecutMethod;
 use av1an_core::{ffmpeg, into_vec};
 use av1an_core::{ChunkOrdering, Input};
-use ffmpeg_next::format::Pixel;
 use flexi_logger::writers::LogWriter;
 use flexi_logger::{FileSpec, Level, LevelFilter, LogSpecBuilder, Logger};
 use path_abs::{PathAbs, PathInfo};
@@ -526,7 +526,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<EncodeArgs> {
         Input::Video(path) => InputPixelFormat::FFmpeg {
           format: ffmpeg::get_pixel_format(path.as_ref()).with_context(|| {
             format!(
-              "FFmpeg failed to get pixel format for input video {:?}",
+              "ffmpeg: failed to get pixel format for input video {:?}",
               path
             )
           })?,
@@ -534,7 +534,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<EncodeArgs> {
         Input::VapourSynth(path) => InputPixelFormat::VapourSynth {
           bit_depth: crate::vapoursynth::bit_depth(path.as_ref()).with_context(|| {
             format!(
-              "VapourSynth failed to get bit depth for input video {:?}",
+              "vapoursynth: failed to get bit depth for input video {:?}",
               path
             )
           })?,

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -57,8 +57,9 @@ version = "1.7.0"
 default-features = false
 features = ["const_generics", "const_new", "union"]
 
-[dependencies.ffmpeg-next]
-version = "4.4.0"
+[dependencies.ffmpeg]
+package = "ffmpeg-next"
+version = "5.0.2"
 
 [dependencies.plotters]
 version = "0.3.1"
@@ -79,7 +80,7 @@ version = "5.0.0"
 features = ["serde"]
 
 [features]
-ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]
+ffmpeg_static = ["ffmpeg/static", "ffmpeg/build"]
 vapoursynth_new_api = [
   "vapoursynth/vapoursynth-api-32",
   "vapoursynth/vsscript-api-31",

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -1,7 +1,7 @@
 use crate::{ffmpeg::compose_ffmpeg_pipe, inplace_vec, into_array, into_vec, list_index};
 use arrayvec::ArrayVec;
 use cfg_if::cfg_if;
-use ffmpeg_next::format::Pixel;
+use ffmpeg::format::Pixel;
 use itertools::chain;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -1,8 +1,8 @@
 use crate::{into_array, into_vec};
-use ffmpeg_next::color::TransferCharacteristic;
-use ffmpeg_next::format::{input, Pixel};
-use ffmpeg_next::media::Type as MediaType;
-use ffmpeg_next::Error::StreamNotFound;
+use ffmpeg::color::TransferCharacteristic;
+use ffmpeg::format::{input, Pixel};
+use ffmpeg::media::Type as MediaType;
+use ffmpeg::Error::StreamNotFound;
 use path_abs::{PathAbs, PathInfo};
 use std::path::PathBuf;
 use std::{
@@ -41,7 +41,7 @@ pub fn compose_ffmpeg_pipe<S: Into<String>>(
 }
 
 /// Get frame count using FFmpeg
-pub fn num_frames(source: &Path) -> Result<usize, ffmpeg_next::Error> {
+pub fn num_frames(source: &Path) -> Result<usize, ffmpeg::Error> {
   let mut ictx = input(&source)?;
   let input = ictx
     .streams()
@@ -57,7 +57,7 @@ pub fn num_frames(source: &Path) -> Result<usize, ffmpeg_next::Error> {
   )
 }
 
-pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg_next::Error> {
+pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg::Error> {
   let ictx = input(&source)?;
   let input = ictx
     .streams()
@@ -67,49 +67,53 @@ pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg_next::Error> {
   Ok(f64::from(rate.numerator()) / f64::from(rate.denominator()))
 }
 
-pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg_next::Error> {
-  let ictx = ffmpeg_next::format::input(&source)?;
+pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg::Error> {
+  let ictx = ffmpeg::format::input(&source)?;
 
   let input = ictx
     .streams()
     .best(MediaType::Video)
     .ok_or(StreamNotFound)?;
 
-  let decoder = input.codec().decoder().video()?;
+  let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
+    .decoder()
+    .video()?;
 
   Ok(decoder.format())
 }
 
-pub fn resolution(source: &Path) -> Result<(u32, u32), ffmpeg_next::Error> {
-  let ictx = ffmpeg_next::format::input(&source)?;
+pub fn resolution(source: &Path) -> Result<(u32, u32), ffmpeg::Error> {
+  let ictx = ffmpeg::format::input(&source)?;
 
   let input = ictx
     .streams()
     .best(MediaType::Video)
     .ok_or(StreamNotFound)?;
 
-  let decoder = input.codec().decoder().video()?;
+  let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
+    .decoder()
+    .video()?;
 
   Ok((decoder.width(), decoder.height()))
 }
 
-pub fn transfer_characteristics(
-  source: &Path,
-) -> Result<TransferCharacteristic, ffmpeg_next::Error> {
-  let ictx = ffmpeg_next::format::input(&source)?;
+pub fn transfer_characteristics(source: &Path) -> Result<TransferCharacteristic, ffmpeg::Error> {
+  let ictx = ffmpeg::format::input(&source)?;
 
   let input = ictx
     .streams()
     .best(MediaType::Video)
     .ok_or(StreamNotFound)?;
 
-  let decoder = input.codec().decoder().video()?;
+  let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
+    .decoder()
+    .video()?;
 
   Ok(decoder.color_transfer_characteristic())
 }
 
 /// Returns vec of all keyframes
-pub fn get_keyframes(source: &Path) -> Result<Vec<usize>, ffmpeg_next::Error> {
+pub fn get_keyframes(source: &Path) -> Result<Vec<usize>, ffmpeg::Error> {
   let mut ictx = input(&source)?;
   let input = ictx
     .streams()

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -25,10 +25,10 @@ use crate::{
   progress_bar::{finish_multi_progress_bar, finish_progress_bar},
   target_quality::TargetQuality,
 };
+use ::ffmpeg::color::TransferCharacteristic;
 use anyhow::Context;
 use chunk::Chunk;
 use dashmap::DashMap;
-use ffmpeg_next::color::TransferCharacteristic;
 use grain::TransferFunction;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -127,7 +127,7 @@ impl Input {
     const FAIL_MSG: &str = "Failed to get frame rate for input video";
     Ok(match &self {
       Input::Video(path) => {
-        ffmpeg::frame_rate(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+        crate::ffmpeg::frame_rate(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
       Input::VapourSynth(path) => {
         vapoursynth::frame_rate(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -1,8 +1,8 @@
-use ffmpeg_next::format::Pixel;
+use ffmpeg::format::Pixel;
 use smallvec::{smallvec, SmallVec};
 
 use crate::Encoder;
-use crate::{ffmpeg, into_smallvec, progress_bar, Input, ScenecutMethod, Verbosity};
+use crate::{into_smallvec, progress_bar, Input, ScenecutMethod, Verbosity};
 use ansi_term::Style;
 use av_scenechange::{detect_scene_changes, DetectionOptions, SceneDetectionSpeed};
 
@@ -123,7 +123,7 @@ pub fn scene_detect(
       }
     }
     Input::Video(path) => {
-      let input_pix_format = ffmpeg::get_pixel_format(path.as_ref())
+      let input_pix_format = crate::ffmpeg::get_pixel_format(path.as_ref())
         .unwrap_or_else(|e| panic!("FFmpeg failed to get pixel format for input video: {:?}", e));
       bit_depth = encoder.get_format_bit_depth(sc_pix_format.unwrap_or(input_pix_format))?;
       Command::new("ffmpeg")

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -8,7 +8,7 @@ use crate::{
   broker::{Broker, EncoderCrash},
   chunk::Chunk,
   concat::{self, ConcatMethod},
-  create_dir, determine_workers, ffmpeg,
+  create_dir, determine_workers,
   ffmpeg::compose_ffmpeg_pipe,
   finish_multi_progress_bar, get_done, init_done, into_vec,
   progress_bar::{
@@ -25,7 +25,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, Context};
 use crossbeam_utils;
-use ffmpeg_next::format::Pixel;
+use ffmpeg::format::Pixel;
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
@@ -126,8 +126,8 @@ pub struct EncodeArgs {
 impl EncodeArgs {
   /// Initialize logging routines and create temporary directories
   pub fn initialize(&mut self) -> anyhow::Result<()> {
-    ffmpeg_next::init()?;
-    ffmpeg_next::util::log::set_level(ffmpeg_next::util::log::level::Level::Fatal);
+    ffmpeg::init()?;
+    ffmpeg::util::log::set_level(ffmpeg::util::log::level::Level::Fatal);
 
     if !self.resume && Path::new(&self.temp).is_dir() {
       fs::remove_dir_all(&self.temp)
@@ -930,7 +930,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
     let input = self.input.as_video_path();
 
-    let keyframes = ffmpeg::get_keyframes(input).unwrap();
+    let keyframes = crate::ffmpeg::get_keyframes(input).unwrap();
 
     let segments_set: Vec<(usize, usize)> = splits.iter().copied().tuple_windows().collect();
 
@@ -1114,7 +1114,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
         let audio_params = self.audio_params.as_slice();
         let audio_size_ref = Arc::clone(&audio_size_bytes);
         Some(s.spawn(move |_| {
-          let audio_output = ffmpeg::encode_audio(input, temp, audio_params);
+          let audio_output = crate::ffmpeg::encode_audio(input, temp, audio_params);
           get_done().audio_done.store(true, atomic::Ordering::SeqCst);
 
           let progress_file = Path::new(temp).join("done.json");

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -5,7 +5,7 @@ use crate::{
   vmaf::{self, read_weighted_vmaf},
   Encoder,
 };
-use ffmpeg_next::format::Pixel;
+use ffmpeg::format::Pixel;
 use splines::{Interpolation, Key, Spline};
 use std::{
   cmp,


### PR DESCRIPTION
- Also rename ffmpeg-next in Cargo.toml, and refer to our own ffmpeg module by `crate::ffmpeg`