### PR TITLE
Set required for input

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -98,7 +98,7 @@ pub struct CliOpts {
   /// Input file to encode
   ///
   /// Can be a video or vapoursynth (.py, .vpy) script.
-  #[clap(short, parse(from_os_str))]
+  #[clap(short, parse(from_os_str), required = true)]
   pub input: Vec<PathBuf>,
 
   /// Video output file


### PR DESCRIPTION
Not setting this causes a panic instead of a proper error message in the case of not specifying any arguments.