### PR TITLE
Replace memory writes with mask in sse4.1 aom/vpx parsing, fix edge case

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -493,12 +493,7 @@ impl Encoder {
   }
 
   /// Parses the number of encoded frames
-  ///
-  /// # Safety
-  ///
-  /// The caller should not attempt to read the contents of `line` after
-  /// this function has been called.
-  pub(crate) unsafe fn parse_encoded_frames(self, line: &mut str) -> Option<u64> {
+  pub(crate) fn parse_encoded_frames(self, line: &str) -> Option<u64> {
     use crate::parse::*;
 
     match self {
@@ -506,7 +501,7 @@ impl Encoder {
         cfg_if! {
           if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
             if is_x86_feature_detected!("sse4.1") && is_x86_feature_detected!("ssse3") {
-              return parse_aom_vpx_frames_sse41(line.as_bytes_mut());
+              return unsafe { parse_aom_vpx_frames_sse41(line.as_bytes()) };
             }
           }
         }

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -397,11 +397,7 @@ impl EncodeArgs {
             enc_stderr.push_str(line);
             enc_stderr.push('\n');
 
-            // SAFETY: we do not read the contents of `line` after this function call
-            if let Some(new) = unsafe { self.encoder.parse_encoded_frames(line) } {
-              // clippy is actually wrong that this does nothing, dropping a mutable
-              // reference does prevent it from being used again.
-              drop(line);
+            if let Some(new) = self.encoder.parse_encoded_frames(line) {
               if new > frame {
                 if self.verbosity == Verbosity::Normal {
                   inc_bar((new - frame) as u64);


### PR DESCRIPTION
If a single chunk had >=10,000 frames, there would be a singular line of text causing the sse4.1 code to report a garbage value, which happened because of an invalid assumption that the number of digits of the buffered frames and encoded frames is always the same. This also affected the fallback function but in a non-obnoxious way, causing it to just return `None` in this edge case instead of a garbage value.

This PR fixes that issue, along with replacing the very suboptimal writes back to main memory (which caused `parse_encoded_frames` to be marked as `unsafe`) in the sse4.1 code with significantly more sensible masking of xmm registers based on the number of digits found.