### PR TITLE
Speed up CI, Reduce container image size

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,19 +251,11 @@ jobs:
           file: ./Dockerfile
           push: false
           tags: av1an:action
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Tar docker cache
-        run: tar -cf /tmp/docker-cache.tar /tmp/.buildx-cache
-
-      - name: Artifact docker cache
-        uses: actions/upload-artifact@v2
-        with:
-          name: docker-cache
-          path: /tmp/docker-cache.tar
 
   docker-publish:
     needs: [all-tests, docker]
@@ -272,14 +264,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@v2
-        with:
-          name: docker-cache
-          path: /tmp/
-
-      - name: Extract docker cache
-        run: tar -xf /tmp/docker-cache.tar -C /
 
       - name: Docker meta
         id: docker_meta
@@ -309,7 +293,8 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ jobs:
     container: shssoichiro/av1an-ci:latest
     steps:
       - uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache@v1
+
       - name: Validate encoders
         run: |
           which aomenc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,48 @@
-FROM archlinux:base-devel
-
-ENV MPLCONFIGDIR="/home/app_user/"
-ARG DEPENDENCIES="mkvtoolnix curl llvm clang"
+FROM archlinux:base-devel AS build
 
 RUN pacman -Syy --noconfirm
 
-# Install make dependencies
-RUN pacman -S --noconfirm rust clang nasm git
+# Install all dependencies (except for rav1e)
+RUN pacman -S --noconfirm rsync rust clang nasm git aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
+
+# Compile rav1e from git, as archlinux is still on rav1e 0.4
+RUN git clone https://github.com/xiph/rav1e /tmp/rav1e
+WORKDIR /tmp/rav1e
+RUN cargo build --release && \
+    strip ./target/release/rav1e 
+RUN mv ./target/release/rav1e /usr/local/bin
+
+# Build only dependencies to speed up subsequent builds
+RUN cargo new /tmp/av1an-deps
+COPY Cargo.toml Cargo.lock /tmp/av1an-deps/
+COPY av1an-cli/Cargo.toml /tmp/av1an-deps/av1an-cli/
+COPY av1an-core/Cargo.toml /tmp/av1an-deps/av1an-core/
+WORKDIR /tmp/av1an-deps
+RUN for d in /tmp/av1an-deps/av1an-* ; do cp -R /tmp/av1an-deps/src "$d"/; done && \
+    cargo build --release
+
+# Build av1an
+COPY . /tmp/Av1an
+WORKDIR /tmp/Av1an
+RUN cargo build --release
+RUN mv ./target/release/av1an /usr/local/bin
+
+
+
+FROM archlinux:base-devel
+
+ENV MPLCONFIGDIR="/home/app_user/"
+
+RUN pacman -Syy --noconfirm
 
 # Install all optional dependencies (except for rav1e)
 RUN pacman -S --noconfirm aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
 
-# Compile rav1e from git, as archlinux is still on rav1e 0.4
-RUN git clone https://github.com/xiph/rav1e && \
-    cd rav1e && \
-    cargo build --release && \
-    strip ./target/release/rav1e && \
-    mv ./target/release/rav1e /usr/local/bin && \
-    cd .. && rm -rf ./rav1e
+COPY --from=build /usr/local/bin/rav1e /usr/local/bin/rav1e
+COPY --from=build /usr/local/bin/av1an /usr/local/bin/av1an
 
 # Create user
 RUN useradd -ms /bin/bash app_user
-
-# Copy av1an and build av1an
-COPY --chown=app_user . /Av1an
-WORKDIR /Av1an
-RUN cargo build --release && \
-    mv ./target/release/av1an /usr/local/bin && \
-    cd .. && rm -rf ./Av1an
-
-# Remove build dependencies
-RUN pacman -R --noconfirm rust clang nasm git
 USER app_user
 
 VOLUME ["/videos"]


### PR DESCRIPTION
Use caching for cargo build to reduce the build times from 5 mins to 45 seconds when dependencies are non changing

Restructure the entire Dockerfile to use multistaging to reduce the docker image by ~500 mb from 1.05 GB to 584 MB.
Use github action internal caching so we dont have to deal with uploading and download the cache as an artifact.
Use cargo chef to build all the dependencies as a layer so that can be cached and have to only compile av1an itself.

Without cargo chef after my initial changes cold run was 9m 49s and when caching the build times came down to 6m 28s but the cache would be invalided on any code change so it was not usable
With cargo chef on a cold run it was still 9m 49s and a cached run it came down to 4m 57s, since this  is caching the dependencies and still building av1an the time going forward should be closer to the 5m mark than the 9m 49s cold run. 