### PR TITLE
Use github cache action instead of using gha. Dedupe Dockerfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
@@ -251,11 +259,17 @@ jobs:
           file: ./Dockerfile
           push: false
           tags: av1an:action
-          cache-from: type=gha
-          cache-to: type=gha, mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
 
   docker-publish:
     needs: [all-tests, docker]
@@ -284,6 +298,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -293,8 +315,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,33 @@
-FROM archlinux:base-devel AS planner
+FROM archlinux:base-devel AS build-base
+
 RUN pacman -Syy --noconfirm
+RUN pacman -S --noconfirm rust clang nasm git aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
 
-# Install all dependencies (except for rav1e)
-RUN pacman -S --noconfirm rsync rust clang nasm git aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
-
+RUN cargo install cargo-chef
 WORKDIR /tmp/Av1an
-RUN cargo install cargo-chef 
+
+
+FROM build-base AS planner
+
 COPY . .
 RUN cargo chef prepare  --recipe-path recipe.json
 
 
+FROM build-base AS cacher
 
-
-FROM archlinux:base-devel AS cacher
-RUN pacman -Syy --noconfirm
-
-# Install all dependencies (except for rav1e)
-RUN pacman -S --noconfirm rsync rust clang nasm git aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
-
-WORKDIR /tmp/Av1an
-RUN cargo install cargo-chef
 COPY --from=planner /tmp/Av1an/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 
-
-
-FROM archlinux:base-devel AS build
-
-RUN pacman -Syy --noconfirm
-
-# Install all dependencies (except for rav1e)
-RUN pacman -S --noconfirm rsync rust clang nasm git aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
+FROM build-base AS build
 
 # Compile rav1e from git, as archlinux is still on rav1e 0.4
-RUN git clone https://github.com/xiph/rav1e /tmp/rav1e
-WORKDIR /tmp/rav1e
-RUN cargo build --release && \
-    strip ./target/release/rav1e 
-RUN mv ./target/release/rav1e /usr/local/bin
+RUN git clone https://github.com/xiph/rav1e && \
+    cd rav1e && \
+    cargo build --release && \
+    strip ./target/release/rav1e && \
+    mv ./target/release/rav1e /usr/local/bin && \
+    cd .. && rm -rf ./rav1e
 
 # Build av1an
 COPY . /tmp/Av1an
@@ -46,10 +35,9 @@ COPY . /tmp/Av1an
 # Copy over the cached dependencies
 COPY --from=cacher /tmp/Av1an/target /tmp/Av1an/target
 
-WORKDIR /tmp/Av1an
-RUN cargo build --release
-RUN mv ./target/release/av1an /usr/local/bin
-
+RUN cargo build --release && \
+    mv ./target/release/av1an /usr/local/bin && \
+    cd .. && rm -rf ./Av1an
 
 
 FROM archlinux:base-devel AS runtime


### PR DESCRIPTION
Action: 
- Use github cache action instead of using gha for the cache-from/to, this allows us to use the cache from the docker stage in the docker-publish stage and also doesnt show an artifact on the github action page. 
- Removed digest from docker stage as there is no digest since its not uploaded anywhere.

Docker:
- Reduce duplication so its easier to change the base image and add dependencies in a single place instead of in multiple place like before with the build dependencies.
- Removed rsync as that was a dependency I added when testing solutions around and isnt needed anymore