### PR TITLE
Include whether lsmash and ffms2 were found in version info

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -30,6 +30,18 @@ use once_cell::sync::OnceCell;
 // needs to be static, runtime allocated string to avoid evil hacks to
 // concatenate non-trivial strings at compile-time
 fn version() -> &'static str {
+  fn get_vs_info() -> String {
+    let isfound = |found: bool| if found { "Found" } else { "Not found" };
+    format!(
+      "\
+* VapourSynth Plugins
+  systems.innocent.lsmas : {}
+  com.vapoursynth.ffms2  : {}",
+      isfound(vapoursynth::is_lsmash_installed()),
+      isfound(vapoursynth::is_ffms2_installed())
+    )
+  }
+
   static INSTANCE: OnceCell<String> = OnceCell::new();
   INSTANCE.get_or_init(|| {
     match (
@@ -61,7 +73,9 @@ fn version() -> &'static str {
 
 * Date Info
    Build Date:  {}
-  Commit Date:  {}",
+  Commit Date:  {}
+
+{}",
           env!("CARGO_PKG_VERSION"),
           git_hash,
           cargo_profile,
@@ -69,11 +83,19 @@ fn version() -> &'static str {
           llvm_ver,
           target_triple,
           build_date,
-          commit_date
+          commit_date,
+          get_vs_info(),
         )
       }
-      // only include the semver on a release (when git information isn't available)
-      _ => env!("CARGO_PKG_VERSION").into(),
+      _ => format!(
+        "\
+{}
+
+{}",
+        // only include the semver on a release (when git information isn't available)
+        env!("CARGO_PKG_VERSION"),
+        get_vs_info()
+      ),
     }
   })
 }

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -35,11 +35,17 @@ static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
 });
 
 pub fn is_lsmash_installed() -> bool {
-  VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas")
+  static LSMASH_PRESENT: Lazy<bool> =
+    Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas"));
+
+  *LSMASH_PRESENT
 }
 
 pub fn is_ffms2_installed() -> bool {
-  VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2")
+  static FFMS2_PRESENT: Lazy<bool> =
+    Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2"));
+
+  *FFMS2_PRESENT
 }
 
 pub fn best_available_chunk_method() -> ChunkMethod {


### PR DESCRIPTION
This makes it very easy for the user to tell whether or not lsmash or ffms2 is installed, which can help in debugging/troubleshooting situations as well.