### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     </br>
 </h1>
 
-<h2 align="center">A cross-platform framework to streamline encoding</h2>
+<h2 align="center">A cross-platform framework to streamline video encoding</h2>
 
 ![alt text](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)
 
@@ -14,20 +14,20 @@
 <a href="https://crates.io/crates/av1an"><img src="https://img.shields.io/crates/v/av1an.svg"></a>
 
 </h4>
-<h2 align="center">Easy, Fast, Efficient and Feature Rich</h2>
+<h2 align="center">Easy, Fast, Efficient and Feature-Rich</h2>
 
-### <center>An easy way to start using AV1 / HEVC / H264 / VP9 / VP8 encoding. AOM, RAV1E, SVT-AV1, VPX, x265, x264 are supported</center>
+### <center>An easy way to start using AV1, HEVC/H.265, AVC/H.264, VP9, and VP8 encoders.<br> AOM, RAV1E, SVT-AV1, VPX, x265, x264 are supported.</center>
 
 Example with default parameters:
 
     av1an -i input
 
-With your own parameters:
+Or with your own parameters:
 
     av1an -i input -v " --cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
     --target-quality 95 -a " -c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 
-<h2 align="center">Usage</h2>
+<h2 align="center">General Usage</h2>
 
     -i  --input             Input file, or Vapoursynth (.py,.vpy) script
                             (relative or absolute path)
@@ -61,7 +61,7 @@ With your own parameters:
     -c  --concat            Concatenation method to use for splits Default: ffmpeg
                             [possible values: ffmpeg, mkvmerge, ivf]
 
-<h3 align="center">FFmpeg options</h3>
+<h3 align="center">FFmpeg Options</h3>
 
     -a  --audio-params      FFmpeg audio settings (Default: copy audio from source to output)
                             Example: -a '-c:a libopus -b:a  64k'
@@ -76,7 +76,7 @@ With your own parameters:
     --pix-format            Setting custom pixel/bit format for piping
                             (Default: 'yuv420p10le')
 
-### <center>Segmenting<center>
+<h3 align="center">Chunking Options</h3>
 
     --split-method          Method used for generating splits. (Default: av-scenechange)
                             Options: `av-scenechange`, `none`
@@ -130,43 +130,48 @@ With your own parameters:
 
 <h2 align="center">Main Features</h2>
 
-**Splitting video by scenes for parallel encoding** because AV1 encoders are currently not very good at multithreading and encoding is limited to a very limited number of threads.
+Av1an allows for **splitting input video by scenes for parallel encoding** to improve encoding performance, because most AV1 encoders are currently not very good at multithreading and encoding is limited to a very limited number of threads.
 
 - [Vapoursynth](http://www.vapoursynth.com) script input support.
 - Speed up video encoding.
-- Target Quality mode. Targeting end result reference visual quality. VMAF used as a substructure
+- "Target Quality" mode. Targeting end result reference visual quality. VMAF used as a substructure
 - Resuming encoding without loss of encoded progress.
 - Simple and clean console look.
 - Automatic detection of the number of workers the host can handle.
 - Both video and audio transcoding.
 
-## Install
+## Installation
 
+Av1an can be installed in two main ways, either:
 - With a package manager:
   - Cargo: `cargo install av1an`
   - Arch Linux: `pacman -S av1an`
+    
+- Or do it manually:
+  - Clone repository or download from [Releases](https://github.com/master-of-zen/Av1an/releases), then do `cargo build --release`.
 
-- Prerequisites:
-  - [Install FFmpeg](https://ffmpeg.org/download.html)
-  - [Vapoursynth](http://www.vapoursynth.com/)
-  - Recommended to install lsmash/ffms2 for faster and better processing
+- Make sure to install these prerequisites first:
+  - Install nasm, llvm, clang, and [FFmpeg](https://ffmpeg.org/download.html)
+  - [Install Vapoursynth](http://www.vapoursynth.com/)
+  - Recommended to install lsmash/ffms2 for faster and better processing.
 
-- Encoder of choice:
-  - [Install AOMENC](https://aomedia.googlesource.com/aom/)
-  - [Install rav1e](https://github.com/xiph/rav1e)
+An encoder is also required, install any of these depending on the format/codec:
+- For AV1:
+  - [Install aomenc](https://aomedia.googlesource.com/aom/)
   - [Install SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1)
-  - [Install vpx](https://chromium.googlesource.com/webm/libvpx/) VP9, VP8 encoding
+  - [Install rav1e](https://github.com/xiph/rav1e)
+- For VP9/VP8:
+  - [Install libvpx](https://chromium.googlesource.com/webm/libvpx/)
 
-- Optional :
-  - [ffms2](https://github.com/FFMS/ffms2)
-  - [lsmash](https://github.com/VFR-maniac/L-SMASH-Works)
-  - [mkvmerge](https://mkvtoolnix.download/)
+Av1an also supports these optional components:
+- Chunking components:
+  - [Install ffms2](https://github.com/FFMS/ffms2)
+  - [Install lsmash](https://github.com/VFR-maniac/L-SMASH-Works)
+- Other components:
+  - [Install mkvmerge](https://mkvtoolnix.download/)
+  - [Install VMAF](https://github.com/Netflix/vmaf) (required for `--target-quality` and `--vmaf`)
 
-- Manually:
-  - Clone Repo or Download from Releases
-  - `cargo build --release`
-
-## Docker
+## Usage in Docker
 
 Av1an can be run in a Docker container with the following command if you are in the current directory
 Linux


### PR DESCRIPTION
I have tried to improve the wording for the README.md file and section of the repository.

Generally, beside improved wording, some specific changes are:
- Encoders list in "Installation" section now split based on format/codec (AV1, VP9/VP8)
- Added VMAF as optional supported components, including link to it's repository page.<br>(Also marked as required for "Target Quality" mode. But correct me if I was wrong)