### PR TITLE
Use published ffmpeg-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "5.0.2"
-source = "git+https://github.com/zmwangx/rust-ffmpeg?rev=0054b0e51b35ed240b193c7a93455714b4d75726#0054b0e51b35ed240b193c7a93455714b4d75726"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5eaf57eceaa199ba6f6a1f46bdad7992930bb7b45b40275d9445b5ba2bc8"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,4 @@ overflow-checks = true
 
 [patch.crates-io]
 av-scenechange = { git = "https://github.com/rust-av/av-scenechange", rev = "0c63f493200eeccc21193d129fc63cb1265e40fa" }
-# TODO: switch to release version once the fix for av_get_best_stream is published on crates.io.
-ffmpeg-next = { git = "https://github.com/zmwangx/rust-ffmpeg", rev = "0054b0e51b35ed240b193c7a93455714b4d75726" }
 console = { git = "https://github.com/console-rs/console", rev = "5484ea9d9f6884f6685349708e27bf08fab7703c" }

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -34,7 +34,7 @@ features = ["git", "build", "rustc", "cargo"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-next"
-version = "5.0.2"
+version = "5.0.3"
 
 [features]
 ffmpeg_static = ["ffmpeg/static", "ffmpeg/build"]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -60,7 +60,7 @@ features = ["const_generics", "const_new", "union"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-next"
-version = "5.0.2"
+version = "5.0.3"
 
 [dependencies.plotters]
 version = "0.3.1"


### PR DESCRIPTION
The get_best_stream fix has been published in ffmpeg-next 5.0.3, so we can use it from crates.io now.