### PR TITLE
Remove data streams when encoding audio

### DIFF
--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -170,6 +170,7 @@ pub fn encode_audio<S: AsRef<OsStr>>(
       "-map_metadata",
       "0",
       "-vn",
+      "-dn",
       "-map",
       "0",
       "-map",


### PR DESCRIPTION
If an input file contains any data streams audio encoding will fail when trying to write a non-supported stream to the intermediary mkv.  This removes any data streams found in the input.  

```
Output {
    status: ExitStatus(
        unix_wait_status(
            256,
        ),
    ),
    stdout: "",
    stderr: "[matroska @ 0x565479976f00] Only audio, video, and subtitles are supported for Matroska.\nCould not write header for output file #0 (incorrect codec parameters ?): Invalid argument\nError initializing output stream 0:1 -- \n",
}
```