### PR TITLE
Add quotes to ffmpeg concat method

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -260,7 +260,7 @@ pub fn ffmpeg(temp: &Path, output: &Path) -> anyhow::Result<()> {
     for i in files {
       writeln!(
         contents,
-        "file {}",
+        "file '{}'",
         format!("{}", i.path().display())
           .replace('\\', r"\\")
           .replace(' ', r"\ ")


### PR DESCRIPTION
The ffmpeg concat demuxer can take quoted filenames which allows for spaces in the paths passed to ffmpeg. This aligns with the recommendation from the [wiki](https://trac.ffmpeg.org/wiki/Concatenate).