### PR TITLE
Improvements to grain synth gamma handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,8 @@ dependencies = [
  "paste",
  "path_abs",
  "plotters",
+ "quickcheck",
+ "quickcheck_macros",
  "rand",
  "serde",
  "serde_json",
@@ -1091,6 +1093,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -80,6 +80,10 @@ features = ["rt", "process", "io-util"]
 version = "5.0.0"
 features = ["serde"]
 
+[dev-dependencies]
+quickcheck = { version = "1.0.3", default-features = false }
+quickcheck_macros = "1"
+
 [features]
 ffmpeg_static = ["ffmpeg/static", "ffmpeg/build"]
 vapoursynth_new_api = [


### PR DESCRIPTION
- Fixes BT.1886 to use the more correct formula and gamma
- Simplify the `mid_tone` function
- Add quickcheck tests around `to_linear`/`from_linear`