### PR TITLE
Log video info at the start of encode

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -145,6 +145,19 @@ impl Input {
     })
   }
 
+  pub fn pixel_format(&self) -> anyhow::Result<String> {
+    const FAIL_MSG: &str = "Failed to get resolution for input video";
+    Ok(match self {
+      Input::VapourSynth(video) => {
+        crate::vapoursynth::pixel_format(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      }
+      Input::Video(video) => {
+        let fmt = crate::ffmpeg::get_pixel_format(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?;
+        format!("{:?}", fmt)
+      }
+    })
+  }
+
   pub fn transfer_function(&self) -> anyhow::Result<TransferFunction> {
     const FAIL_MSG: &str = "Failed to get transfer characteristics for input video";
     Ok(match self {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -25,7 +25,7 @@ use crate::broker::{Broker, EncoderCrash};
 use crate::chunk::Chunk;
 use crate::concat::{self, ConcatMethod};
 use crate::ffmpeg::{compose_ffmpeg_pipe, num_frames};
-use crate::grain::create_film_grain_file;
+use crate::grain::{create_film_grain_file, TransferFunction};
 use crate::parse::valid_params;
 use crate::progress_bar::{
   finish_progress_bar, inc_bar, inc_mp_bar, init_multi_progress_bar, init_progress_bar,
@@ -1084,6 +1084,22 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       } else {
         None
       };
+
+    let res = self.input.resolution()?;
+    let fps = self.input.frame_rate()?;
+    let format = self.input.pixel_format()?;
+    let tfc = self.input.transfer_function()?;
+    info!(
+      "Input: {}x{} @ {:.3} fps, {}, {}",
+      res.0,
+      res.1,
+      fps,
+      format,
+      match tfc {
+        TransferFunction::SMPTE2084 => "HDR",
+        TransferFunction::BT1886 => "SDR",
+      }
+    );
 
     let splits = self.split_routine()?;
 

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -269,3 +269,19 @@ pub fn transfer_characteristics(source: &Path) -> anyhow::Result<u8> {
 
   get_transfer(&mut environment)
 }
+
+pub fn pixel_format(source: &Path) -> anyhow::Result<String> {
+  // Create a new VSScript environment.
+  let mut environment = Environment::new().unwrap();
+
+  // Evaluate the script.
+  environment
+    .eval_file(source, EvalFlags::SetWorkingDir)
+    .unwrap();
+
+  let info = get_clip_info(&mut environment);
+  match info.format {
+    Property::Variable => bail!("Variable pixel format not supported"),
+    Property::Constant(x) => Ok(x.name().to_string()),
+  }
+}


### PR DESCRIPTION
Adds a new log line to the start of each encode with info such as the following:

```
INFO [av1an_core::settings] Input: 854x480 @ 30.000 fps, YUV420P8, SDR
```

This should help to ensure that input is as a user expects.