### PR TITLE
Implement alternate input for scene detection

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -116,6 +116,10 @@ pub struct CliOpts {
   #[clap(short, parse(from_os_str), required = true)]
   pub input: Vec<PathBuf>,
 
+  /// Alternate input for scene detection (must have the same frame count)
+  #[clap(short = 'I', parse(from_os_str))]
+  pub input_sc: Option<PathBuf>,
+
   /// Video output file
   #[clap(short, parse(from_os_str))]
   pub output_file: Option<PathBuf>,
@@ -547,6 +551,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
     };
 
     let input = Input::from(input);
+    let input_sc = args.input_sc.as_ref().map(Input::from);
 
     // TODO make an actual constructor for this
     let mut arg = EncodeArgs {
@@ -646,6 +651,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         }
       },
       input,
+      input_sc,
       output_pix_format: PixelFormat {
         format: args.pix_format,
         bit_depth: args.encoder.get_format_bit_depth(args.pix_format)?,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -57,6 +57,7 @@ pub struct EncodeArgs {
   pub frames: usize,
 
   pub input: Input,
+  pub input_sc: Option<Input>,
   pub temp: String,
   pub output_file: String,
 
@@ -695,7 +696,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
 
     Ok(match self.split_method {
       SplitMethod::AvScenechange => av_scenechange_detect(
-        &self.input,
+        self.input_sc.as_ref().unwrap_or(&self.input),
         self.encoder,
         self.frames,
         self.min_scene_len,


### PR DESCRIPTION
This patch came from this av1an branch made by @redzic 
https://github.com/master-of-zen/Av1an/tree/input-sc

I just refactored to make it work on master, but that's about it.

I've been using it for months(always on the same input source), and it's been working well to prevent my Vapoursynth filters from wrecking the scene detection speed, and I haven't had any problems.

We can expand this to make it work for other kind of inputs(ffmpeg) and make it work in target-quality, but otherwise, that's fine :)