### PR TITLE
Improve selection of HDR content

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -1088,7 +1088,9 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let res = self.input.resolution()?;
     let fps = self.input.frame_rate()?;
     let format = self.input.pixel_format()?;
-    let tfc = self.input.transfer_function()?;
+    let tfc = self
+      .input
+      .transfer_function_params_adjusted(&self.video_params)?;
     info!(
       "Input: {}x{} @ {:.3} fps, {}, {}",
       res.0,
@@ -1138,7 +1140,9 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
           u32::from(strength) * 100
         );
         let (width, height) = self.input.resolution()?;
-        let transfer = self.input.transfer_function()?;
+        let transfer = self
+          .input
+          .transfer_function_params_adjusted(&self.video_params)?;
         create_film_grain_file(&table, strength, width, height, transfer)?;
       } else {
         debug!("Using existing grain table");
@@ -1167,7 +1171,9 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
             u32::from(strength) * 100
           );
           let (width, height) = self.input.resolution()?;
-          let transfer = self.input.transfer_function()?;
+          let transfer = self
+            .input
+            .transfer_function_params_adjusted(&self.video_params)?;
           create_film_grain_file(&grain_table, strength, width, height, transfer)?;
           grain_table
         };


### PR DESCRIPTION
Currently this only applies to grain synth generation,
but the prior implementation of HDR detection only looked at the props
on the input video. Those may not necessarily be set correctly even if
the user is encoding to HDR, so we want to prioritize looking at the
encoder params, then fallback to checking the input if the user has not
set a transfer characteristic on the encoder.