### PR TITLE
Use std::available_parallelism instead of num_cpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ dependencies = [
  "log",
  "memchr",
  "nom",
- "num_cpus",
  "once_cell",
  "parking_lot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/master-of-zen/Av1an"
 keywords = ["video"]
 categories = ["command-line-utilities"]
 license = "GPL-3.0"
+rust-version = "1.59"
 edition = "2021"
 
 [[bin]]

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/master-of-zen/Av1an"
 keywords = ["video"]
 categories = ["command-line-utilities"]
 license = "GPL-3.0"
+rust-version = "1.59"
 edition = "2021"
 
 [dependencies]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "av1an-core"
 version = "0.3.1"
+rust-version = "1.59"
 edition = "2021"
 authors = ["Zen <master_of_zen@protonmail.com>"]
 description = """

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -21,7 +21,6 @@ atty = "0.2.14"
 av-format = "0.3.1"
 av-ivf = "0.2.2"
 memchr = "2.4.1"
-num_cpus = "1.13.0"
 anyhow = "1.0.42"
 rand = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -6,6 +6,7 @@ use std::process::ExitStatus;
 use std::sync::atomic::{self, AtomicU64};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
+use std::thread::available_parallelism;
 
 use cfg_if::cfg_if;
 use memchr::memmem;
@@ -123,7 +124,7 @@ impl<'a> Broker<'a> {
       cfg_if! {
         if #[cfg(any(target_os = "linux", target_os = "windows"))] {
           if let Some(threads) = set_thread_affinity {
-            let available_threads = num_cpus::get();
+            let available_threads = available_parallelism().expect("Unrecoverable: Failed to get thread count").get();
             let requested_threads = threads.saturating_mul(self.project.workers);
             if requested_threads > available_threads {
               warn!(

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -29,6 +29,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::string::ToString;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::thread::available_parallelism;
 use std::time::Instant;
 
 use ::ffmpeg::color::TransferCharacteristic;
@@ -327,7 +328,9 @@ pub fn determine_workers(encoder: Encoder) -> u64 {
   let mut system = sysinfo::System::new();
   system.refresh_memory();
 
-  let cpu = num_cpus::get() as u64;
+  let cpu = available_parallelism()
+    .expect("Unrecoverable: Failed to get thread count")
+    .get() as u64;
   // available_memory returns kb, convert to gb
   let ram_gb = system.available_memory() / 10_u64.pow(6);
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::{exit, Command, Stdio};
 use std::sync::atomic::{self, AtomicBool, AtomicU64, AtomicUsize};
 use std::sync::{mpsc, Arc};
+use std::thread::available_parallelism;
 use std::{cmp, fs, iter, thread};
 
 use ansi_term::{Color, Style};
@@ -1340,7 +1341,11 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
             Some(filter) => Some(filter),
             None => None,
           },
-          self.vmaf_threads.unwrap_or_else(num_cpus::get),
+          self.vmaf_threads.unwrap_or_else(|| {
+            available_parallelism()
+              .expect("Unrecoverable: Failed to get thread count")
+              .get()
+          }),
         ) {
           error!("VMAF calculation failed with error: {}", e);
         }

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -4,6 +4,7 @@ use std::convert::TryInto;
 use std::fmt::Error;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::thread::available_parallelism;
 
 use ffmpeg::format::Pixel;
 use splines::{Interpolation, Key, Spline};
@@ -299,7 +300,9 @@ pub fn vmaf_auto_threads(workers: usize) -> usize {
   const OVER_PROVISION_FACTOR: f64 = 1.25;
 
   // Logical CPUs
-  let threads = num_cpus::get();
+  let threads = available_parallelism()
+    .expect("Unrecoverable: Failed to get thread count")
+    .get();
 
   cmp::max(
     ((threads / workers) as f64 * OVER_PROVISION_FACTOR) as usize,


### PR DESCRIPTION
The [available_parallelism](https://doc.rust-lang.org/std/thread/fn.available_parallelism.html) function was made stable in Rust 1.59. This changeset makes use of it instead of the `num_cpus` crate. We still have transitive dependencies that use `num_cpus`, but we should still prefer to use stdlib code when possible.

This changeset also explicitly sets the minimum Rust version to 1.59. This was already the case, as it was required by Edition 2021, but now Cargo will show a helpful error message to users on an old-ish version.