### PR TITLE
Don't panic if ffmpeg fails to count frames

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -430,19 +430,15 @@ impl EncodeArgs {
       let encoded_frames = num_frames(chunk.output().as_ref());
 
       let err_str = match encoded_frames {
-        Ok(encoded_frames) if encoded_frames != chunk.frames => {
-          Some(format!(
-            "FRAME MISMATCH: chunk {}: {}/{} (actual/expected frames)",
-            chunk.index, encoded_frames, chunk.frames
-          ))
-        },
-        Err(error) => {
-          Some(format!(
-            "FAILED TO COUNT FRAMES: chunk {}: {}",
-            chunk.index, error
-          ))
-        },
-        _ => None
+        Ok(encoded_frames) if encoded_frames != chunk.frames => Some(format!(
+          "FRAME MISMATCH: chunk {}: {}/{} (actual/expected frames)",
+          chunk.index, encoded_frames, chunk.frames
+        )),
+        Err(error) => Some(format!(
+          "FAILED TO COUNT FRAMES: chunk {}: {}",
+          chunk.index, error
+        )),
+        _ => None,
       };
 
       if let Some(err_str) = err_str {


### PR DESCRIPTION
Sometimes with broken input `num_frames` fails to count frames and `.unwrap()` panics. Unfortunately since it panics in threaded code, this panic does not stop app from running and instead thread just hangs forever and tui shows some weird visual glitches.