### PR TITLE
Fix x265 2-pass params

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -208,16 +208,23 @@ impl Encoder {
       Self::x265 => chain!(
         into_array![
           "x265",
-          "--stitchable",
+          "--repeat-headers",
           "--log-level",
           "error",
           "--pass",
           "1",
-          "--demuxer",
-          "y4m",
+          "--y4m",
         ],
         params,
-        into_array!["--stats", format!("{}.log", fpf), "-", "-o", NULL]
+        into_array![
+          "--stats",
+          format!("{}.log", fpf),
+          "--analysis-reuse-file",
+          format!("{}_analysis.dat", fpf),
+          "-",
+          "-o",
+          NULL
+        ]
       )
       .collect(),
     }
@@ -283,16 +290,23 @@ impl Encoder {
       Self::x265 => chain!(
         into_array![
           "x265",
-          "--stitchable",
+          "--repeat-headers",
           "--log-level",
           "error",
           "--pass",
           "2",
-          "--demuxer",
-          "y4m",
+          "--y4m",
         ],
         params,
-        into_array!["--stats", format!("{}.log", fpf), "-", "-o", output]
+        into_array![
+          "--stats",
+          format!("{}.log", fpf),
+          "--analysis-reuse-file",
+          format!("{}_analysis.dat", fpf),
+          "-",
+          "-o",
+          output
+        ]
       )
       .collect(),
     }

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -409,7 +409,16 @@ impl Encoder {
         }
       }
       Encoder::x264 => into_vec!["--preset", "slow", "--crf", "25"],
-      Encoder::x265 => into_vec!["-p", "slow", "--crf", "25", "-D", "10"],
+      Encoder::x265 => into_vec![
+        "-p",
+        "slow",
+        "--crf",
+        "25",
+        "-D",
+        "10",
+        "--level-idc",
+        "5.0"
+      ],
     }
   }
 


### PR DESCRIPTION
Seems like it was copypasted from `x264`, but in `x265` some options are different. Plus added [`--analysis-reuse-file`](https://x265.readthedocs.io/en/master/cli.html#cmdoption-analysis-reuse-file) option which is used for [`--multi-pass-opt-analysis`](https://x265.readthedocs.io/en/master/cli.html#cmdoption-multi-pass-opt-analysis) and [`--multi-pass-opt-distortion`](https://x265.readthedocs.io/en/master/cli.html#cmdoption-multi-pass-opt-distortion) and ignored if neither specified.