### PR TITLE
Automate Windows binary releases on changes to master

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,5 +1,8 @@
 name: Build Av1an (Windows x64)
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   build:
@@ -78,8 +81,11 @@ jobs:
           CARGO_TERM_COLOR: always
         run: cargo build -rv
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+      - name: Create prerelease
+        uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
-          name: av1an
-          path: target/release/av1an.exe
+          repo_token: ${{ github.token }}
+          automatic_release_tag: latest
+          prerelease: true
+          draft: false
+          files: target/release/av1an.exe

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,10 +7,10 @@ jobs:
 
     env:
       vsynth_ver: R58
-      vsynth_path: C:\Program Files\Vapoursynth
+      vsynth_path: C:/Program Files/Vapoursynth
 
     steps:
-      - name: Python 3.10 setup
+      - name: Python 3 setup
         uses: actions/setup-python@v4
         with:
           python-version: '~3.10'
@@ -22,22 +22,17 @@ jobs:
           version: 2.15.05
           from-source: false
 
-      - name: PowerShell module installation
-        uses: potatoqualitee/psmodulecache@v4.5
-        with:
-          modules-to-cache: 7Zip4Powershell
-
       - name: FFmpeg hashsum
         run: |
           $hashSum = (Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z.sha256').Content
           echo "ff_hash=$hashSum" | Out-File $env:GITHUB_ENV -Append
           Write-Output "Latest release: $hashSum"
 
-      - name: FFmpeg cache check
+      - name: FFmpeg cache
         id: cache-ff
         uses: actions/cache@v3
         with:
-          path: C:\ffmpeg
+          path: C:/ffmpeg
           key: ff-${{ env.ff_hash }}
 
       - if: steps.cache-ff.outputs.cache-hit != 'true'
@@ -45,14 +40,13 @@ jobs:
         run: |
           $tempFile = New-TemporaryFile
           Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z' -OutFile $tempFile -TimeoutSec 10
-          Expand-7Zip $tempFile 'C:\ffmpeg'
+          7z x -y -o'C:/ffmpeg' "$tempFile"
 
       - name: FFmpeg environment variable
         run: |
-          $ffDir = Get-Item "C:\ffmpeg\ffmpeg*shared" | Select-Object -First 1 -ExpandProperty FullName
-          echo "FFMPEG_DIR=$ffDir" | Out-File $env:GITHUB_ENV -Append
+          echo "FFMPEG_DIR=$((Get-ChildItem -Directory C:/ffmpeg).FullName)" | Out-File $env:GITHUB_ENV -Append
 
-      - name: VapourSynth cache check
+      - name: VapourSynth cache
         id: cache-vsynth
         uses: actions/cache@v3
         with:
@@ -64,18 +58,19 @@ jobs:
         run: |
           $tempFile = New-TemporaryFile
           $uri = 'https://github.com/vapoursynth/vapoursynth/releases/download/VER/VapourSynth64-Portable-VER.7z'.Replace('VER', "${{ env.vsynth_ver }}")
-          Invoke-WebRequest $uri -OutFile $tempFile -TimeoutSec 10
-          Expand-7Zip $tempFile $env:vsynth_path
+          Invoke-WebRequest $uri -OutFile "$tempFile" -TimeoutSec 10
+          7z x -y -o"$env:vsynth_path" "$tempFile"
 
       - uses: actions/checkout@v3
 
-      - name: Package cache check
+      - name: Package cache
         uses: actions/cache@v3
         with:
           path: |
-            ~\.cargo\git
-            ~\.cargo\registry
-          key: cargo-${{ hashFiles('**\Cargo.toml', '**\Cargo.lock') }}
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
 
       - name: Av1an build


### PR DESCRIPTION
Second part of #530.

First commit has some general improvements. The improved caching cuts the build time by around half.

Second commit kicks off the workflow on every push to `master` and automatically creates a prerelease with the Windows binary. This release is always called `latest` and can only exist once. This means the previous `latest` release will be deleted and then re-created with the new Windows binary. The latest release can always be found under the same URL (example https://github.com/FreezyLemon/Av1an/releases/tag/latest).

This does not cover full, tagged releases. But those can be made by downloading the last `av1an.exe` and manually attaching it to the release, which makes it easier, I think.