### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@ TEMP STUFF
 
 Av1an is written in Rust and can be used on Linux, macOS and Windows. It is highly configurable but tries to set good default values to make it easier to use.
 
-### Supported encoders
-
-- AV1: aomenc, rav1e, SVT-AV1
-- H.264/AVC: x264
-- H.265/HEVC: x265
-- VP8, VP9: VPX
+Binary releases for Windows are also available from this repository's [releases page](https://github.com/master-of-zen/Av1an/releases).
 
 ---
 
@@ -24,6 +19,7 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 ## Table of Contents
 
 - [Installation](#installation)
+- [Supported encoders](#supported-encoders)
 - [Usage](#usage)
 - [Configuration](#configuration)
 - [Building](#building-av1an)
@@ -32,41 +28,39 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 
 ## Installation
 
-- Make sure to install these prerequisites first:
-  - [FFmpeg](https://ffmpeg.org/download.html)
-  - [Vapoursynth](http://www.vapoursynth.com/)
-  - lsmash/ffms2 are recommended but not required for faster and better processing.
+The simplest way to install av1an is to use a package manager. There are also pre-built [Docker images](#usage-in-docker) which include all dependencies and are frequently updated.
 
-Av1an can be installed in two main ways, either:
-- With a package manager:
-  - Cargo: `cargo install av1an`
-  - Arch Linux: `pacman -S av1an`
+### Package managers
 
-At least one encoder is also required, install any of these that you wish to use:
+Arch Linux & Manjaro: `pacman -S av1an`
 
-For AV1:
-  - [Install aomenc](https://aomedia.googlesource.com/aom/)
-  - [Install SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1)
-  - [Install rav1e](https://github.com/xiph/rav1e)
+If your distribution's package manager does not have Av1an or if you're on Windows, you can still install it manually.
 
-For VP8 and VP9:
-  - [Install libvpx](https://chromium.googlesource.com/webm/libvpx/)
+### Manual installation
 
-For H.264/AVC:
-  - [Install x264](https://www.videolan.org/developers/x264.html)
+Prerequisites:
 
-For H.265/HEVC:
-  - [Install x265](https://www.videolan.org/developers/x265.html)
+- [FFmpeg](https://ffmpeg.org/download.html)
+- [Vapoursynth](https://github.com/vapoursynth/vapoursynth/releases)
+- At least one [encoder](#supported-encoders)
 
-Av1an also supports these optional components:
-- Chunking components:
-  - [Install ffms2](https://github.com/FFMS/ffms2)
-  - [Install lsmash](https://github.com/VFR-maniac/L-SMASH-Works)
-- Other components:
-  - [Install mkvmerge](https://mkvtoolnix.download/)
-  - [Install VMAF](https://github.com/Netflix/vmaf) (required for `--target-quality` and `--vmaf`)
+Optional:
 
-Binary releases for Windows are also available from this repository's [releases page](https://github.com/master-of-zen/Av1an/releases).
+- [ffms2](https://github.com/FFMS/ffms2) for better chunking
+- [L-SMASH](https://github.com/VFR-maniac/L-SMASH-Works) for better chunking
+- [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge for file concatenation (FFmpeg by default)
+- [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF and to use [target quality mode](docs/TargetQuality.md)
+
+## Supported encoders
+
+At least one encoder is required to use Av1an. Install any of these that you wish to use.
+
+- [aomenc](https://aomedia.googlesource.com/aom/) (AV1)
+- [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1) (AV1)
+- [rav1e](https://github.com/xiph/rav1e) (AV1)
+- [libvpx](https://chromium.googlesource.com/webm/libvpx/) (VP8 and VP9)
+- [x264](https://www.videolan.org/developers/x264.html) (H.264/AVC)
+- [x265](https://www.videolan.org/developers/x265.html) (H.265/HEVC)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
 
-Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by running multiple encoder processes in parallel. This can improve CPU usage and increases the speed of some AV1 encoders dramatically.
+Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by running multiple encoder processes in parallel. This can improve CPU usage and encoding speed. The speed increase can be very significant if the selected encoder does not multi-thread well on its own.
 
 Av1an can also calculate a VMAF score for you to assess the encode quality, and it can even target a specific VMAF score when encoding.
 
@@ -13,21 +13,23 @@ Av1an can also calculate a VMAF score for you to assess the encode quality, and 
 - Vastly improved encoding speed for some encoders
 - Cancel and resume encoding without loss of progress
 - [VapourSynth](http://www.vapoursynth.com) script support
-- [Target Quality](/docs/TargetQuality.md) mode, using [VMAF](https://github.com/Netflix/vmaf) to automatically set encoder options to achieve the wanted visual quality
+- [Target Quality](/docs/TargetQuality.md) mode, using VMAF to automatically set encoder options to achieve the desired video quality
 - Simple and clean console interface
 - Convenient Docker images available
 - Cross-platform application written in Rust
 
 ## Supported encoders
 
-At least one encoder is required to use Av1an. Install any of these that you wish to use.
+At least one encoder is required to use Av1an. The following encoders are supported:
 
 - [aomenc](https://aomedia.googlesource.com/aom/) (AV1)
-- [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1) (AV1)
+- [SvtAv1EncApp](https://gitlab.com/AOMediaCodec/SVT-AV1) (AV1)
 - [rav1e](https://github.com/xiph/rav1e) (AV1)
-- [libvpx](https://chromium.googlesource.com/webm/libvpx/) (VP8 and VP9)
+- [vpxenc](https://chromium.googlesource.com/webm/libvpx/) (VP8 and VP9)
 - [x264](https://www.videolan.org/developers/x264.html) (H.264/AVC)
 - [x265](https://www.videolan.org/developers/x265.html) (H.265/HEVC)
+
+Note that Av1an requires the executable encoder. If you use a package manager to install encoders, check that the installation includes an executable encoder (e.g. vpxenc, SvtAv1EncApp) from the list above. Just installing the library (e.g. libvpx, libSvtAv1Enc) is not enough.
 
 ## Installation
 
@@ -78,7 +80,7 @@ Or use a VapourSynth script and custom parameters:
 av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10 --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 ```
 
-To check all available options for your version of Av1an use `av1an -h`.
+To check all available options for your version of Av1an use `av1an --help`.
 
 ## Support the developer
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by running multiple encoder processes in parallel. This can improve CPU usage and encoding speed. The speed increase can be very significant if the selected encoder does not multi-thread well on its own.
 
-Av1an can also calculate a VMAF score for you to assess the encode quality, and it can even target a specific VMAF score when encoding.
+Av1an can also calculate a [VMAF](https://github.com/Netflix/vmaf) score for you to assess the encode quality, and it can even target a specific VMAF score when encoding.
 
 ## Features
 
-- Vastly improved encoding speed for some encoders
+- Vastly improved encoding speed for some encoders (especially `aomenc`, `rav1e` and `vpxenc`)
 - Cancel and resume encoding without loss of progress
 - [VapourSynth](http://www.vapoursynth.com) script support
 - [Target Quality](/docs/TargetQuality.md) mode, using VMAF to automatically set encoder options to achieve the desired video quality

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Avian
+# Av1an
 
 [![Discord server](https://discordapp.com/api/guilds/696849974230515794/embed.png)](https://discord.gg/Ar8MvJh)
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
@@ -6,18 +6,17 @@
 
 Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by running multiple encoder processes in parallel. This can improve CPU usage and increases the speed of some AV1 encoders dramatically.
 
-Av1an can also calculate a VMAF score for you to assess the encode quality, and it can even target a specific quality level when encoding.
+Av1an can also calculate a VMAF score for you to assess the encode quality, and it can even target a specific VMAF score when encoding.
 
 ## Features
 
 - Vastly improved encoding speed for some encoders
 - Cancel and resume encoding without loss of progress
-- [VapourSynth](http://www.vapoursynth.com) script input support
+- [VapourSynth](http://www.vapoursynth.com) script support
 - [Target Quality](/docs/TargetQuality.md) mode, using [VMAF](https://github.com/Netflix/vmaf) to automatically set encoder options to achieve the wanted visual quality
-- Automatic detection of parallel worker amount based on the available hardware
 - Simple and clean console interface
 - Convenient Docker images available
-- Cross-platform, works on Linux, macOS and Windows
+- Cross-platform application written in Rust
 
 ## Supported encoders
 
@@ -30,7 +29,6 @@ At least one encoder is required to use Av1an. Install any of these that you wis
 - [x264](https://www.videolan.org/developers/x264.html) (H.264/AVC)
 - [x265](https://www.videolan.org/developers/x265.html) (H.265/HEVC)
 
-
 ## Installation
 
 The simplest way to install av1an is to use a package manager. There are also pre-built [Docker images](/docs/docker.md) which include all dependencies and are frequently updated.
@@ -41,7 +39,7 @@ For Windows users that do not want to use Docker, prebuilt binaries are also inc
 
 Arch Linux & Manjaro: `pacman -S av1an`
 
-If your distribution's package manager does not have Av1an or if you're on Windows, you can still install it manually.
+If your distribution's package manager does not have Av1an or if you're on Windows, you can still install Av1an manually.
 
 ### Manual installation
 
@@ -53,10 +51,10 @@ Prerequisites:
 
 Optional:
 
-- [L-SMASH](https://github.com/VFR-maniac/L-SMASH-Works) for better chunking
-- [ffms2](https://github.com/FFMS/ffms2) for better chunking
-- [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge for file concatenation (FFmpeg by default)
-- [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF and to use [target quality mode](docs/TargetQuality.md)
+- [L-SMASH](https://github.com/VFR-maniac/L-SMASH-Works) for an alternative chunking method (recommended)
+- [ffms2](https://github.com/FFMS/ffms2) for an alternative chunking method
+- [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation
+- [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF scores and to use [target quality mode](docs/TargetQuality.md)
 
 ## Usage
 
@@ -74,7 +72,7 @@ av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 
 
 To check all available options for your version of Av1an use `av1an -h`.
 
-### Support the developer
+## Support the developer
 
 Bitcoin - 1GTRkvV4KdSaRyFDYTpZckPKQCoWbWkJV1
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 - [Installation](#installation)
 - [Supported encoders](#supported-encoders)
 - [Usage](#usage)
-- [Configuration](#configuration)
 - [Building](#building-av1an)
 
 ---
@@ -85,118 +84,19 @@ At least one encoder is required to use Av1an. Install any of these that you wis
 
 ## Usage
 
-Example with default parameters:
+Encode a video file with the default parameters:
 
-    av1an -i input
+```sh
+av1an -i input.mkv
+```
 
-Or with your own parameters:
+Or use a Vapoursynth script and custom parameters:
 
-    av1an -i input -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
-    --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
+```sh
+av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10 --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
+```
 
-## Configuration
-
-<h2 align="center">General Usage</h2>
-
-    -i  --input             Input file, or Vapoursynth (.py,.vpy) script
-                            (relative or absolute path)
-
-    -o  --output-file       Name/Path for output file (Default: (input file name)_(encoder).mkv)
-                            Output is `mkv` by default
-                            Ouput extension can be set to: `mkv`, `webm`, `mp4`
-
-    -e  --encoder           Encoder to use
-                            [default: aom] [possible values: aom, rav1e, vpx, svt-av1, x264, x265]
-
-    -v  --video-params      Encoder settings flags (If not set, will be used default parameters.)
-                            Must be inside ' ' or " "
-
-    -p  --passes            Set number of passes for encoding
-                            (Default: AOMENC: 2, rav1e: 1, SVT-AV1: 1,
-                            VPX: 2, x265: 1, x264: 1)
-
-    -w  --workers           Override number of workers.
-
-    -r  --resume            Resumes encoding.
-
-    --keep                  Doesn't delete temporary folders after encode has finished.
-
-    -q  --quiet             Do not print a progress bar to the terminal.
-
-    -l  --logging           Path to .log file(By default created in temp folder)
-
-    --temp                  Set path for the temporary folder. [default: .hash]
-
-    -c  --concat            Concatenation method to use for splits Default: ffmpeg
-                            [possible values: ffmpeg, mkvmerge, ivf]
-
-<h3 align="center">FFmpeg Options</h3>
-
-    -a  --audio-params      FFmpeg audio settings (Default: copy audio from source to output)
-                            Example: -a '-c:a libopus -b:a  64k'
-
-    -f  --ffmpeg            FFmpeg options video options.
-                            Applied to each encoding segment individually.
-                            (Warning: Cropping doesn't work with Target VMAF mode
-                            without specifying it in --vmaf-filter)
-                            Example:
-                            --ff " -vf scale=320:240 "
-
-    --pix-format            Setting custom pixel/bit format for piping
-                            (Default: 'yuv420p10le')
-
-<h3 align="center">Chunking Options</h3>
-
-    --split-method          Method used for generating splits. (Default: av-scenechange)
-                            Options: `av-scenechange`, `none`
-                            `none` -  skips scenedetection.
-
-    -m  --chunk-method      Determine the method in which chunks are made for encoding.
-                            By default the best method is selected automatically.
-                            [possible values: segment, select, ffms2, lsmash, hybrid]
-
-    -s  --scenes            File to save/read scenes.
-
-    -x  --extra-split       Size of chunk after which it will be split [default: fps * 10]
-
-    --min-scene-len         Specifies the minimum number of frames in each split.
-
-<h3 align="center">Target Quality</h3>
-
-    --target-quality        Quality value to target.
-                            VMAF used as substructure for algorithms.
-                            When using this mode, you must use quantizer/quality modes of encoder.
-
-    --target-quality-method Type of algorithm for use.
-                            Options: per_shot
-
-    --min-q, --max-q        Min,Max Q values limits
-                            If not set by the user, the default for encoder range will be used.
-
-    --vmaf                  Calculate VMAF after encoding is done and make a plot.
-
-    --vmaf-path             Custom path to libvmaf models.
-                            example: --vmaf-path "vmaf_v0.6.1.pkl"
-                            Recommended to place both files in encoding folder
-                            (`vmaf_v0.6.1.pkl` and `vmaf_v0.6.1.pkl.model`)
-                            (Required if VMAF calculation doesn't work by default)
-
-    --vmaf-res              Resolution for VMAF calculation.
-                            [default: 1920x1080]
-
-    --probes                Number of probes for target quality. [default: 4]
-
-    --probe-slow            Use probided video encoding parameters for vmaf probes.
-
-    --vmaf-filter           Filter used for VMAF calculation. The passed format is filter_complex.
-                            So if crop filter used ` -ff " -vf crop=200:1000:0:0 "`
-                            `--vmaf-filter` must be : ` --vmaf-filter "crop=200:1000:0:0"`
-
-    --probing-rate          Setting rate for VMAF probes. Using every N frame used in probe.
-                            [default: 4]
-
-    --vmaf-threads          Limit number of threads that are used for VMAF calculation
-
+To check all available options for your version of Av1an use `av1an -h`.
 
 ## Building Av1an
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Binary releases for Windows are also available from this repository's [releases 
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
 
-Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by automatically splitting your input file into smaller segments and encoding these segments in parallel. This helps the most with AV1 encoders, because they are not good at multithreading.
+Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by automatically splitting the input file into smaller segments and encoding these segments in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ Prerequisites:
 
 Optional:
 
-- [L-SMASH](https://github.com/VFR-maniac/L-SMASH-Works) for an alternative chunking method (recommended)
-- [ffms2](https://github.com/FFMS/ffms2) for an alternative chunking method
+- [L-SMASH](https://github.com/AkarinVS/L-SMASH-Works) VapourSynth plugin for better chunking (recommended)
+- [ffms2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF scores and to use [target quality mode](docs/TargetQuality.md)
+
+### VapourSynth plugins on Windows
+
+If you want to install the L-SMASH or ffms2 plugins and are on Windows, then you have [two installation options](http://vapoursynth.com/doc/installation.html#plugins-and-scripts). The easiest way is using the included plugin script:
+
+1. Open your VapourSynth installation directory
+2. Open a command prompt or PowerShell window via Shift + Right click
+3. Run `python3 vsrepo.py install lsmas ffms2`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -86,4 +86,6 @@ To check all available options for your version of Av1an use `av1an --help` or u
 
 Bitcoin - 1GTRkvV4KdSaRyFDYTpZckPKQCoWbWkJV1
 
+## See Av1an in action
+
 ![av1an fully utilizing a 96-core CPU for video encoding](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)

--- a/README.md
+++ b/README.md
@@ -227,9 +227,19 @@ With a command prompt, `cd` into the directory containing this repository's sour
 
 To use the binary, copy all the `dll` files from `ffmpeg-5.0.1-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.
 
-## Usage in Docker
+## Av1an in Docker
 
-Av1an can be run in a Docker container with the following command if you are in the current directory
+The [docker image](https://hub.docker.com/r/masterofzen/av1an) is frequently updated and includes all supported encoders and all optional components. It is based on Arch Linux and provides recent versions of encoders and libraries.
+
+The image provides three types of tags that you can use:
+- `masterofzen/av1an:master` for the latest commit from `master`
+- `masterofzen/av1an:sha-#######` for a specific git commit (short hash)
+- (outdated) `masterofzen/av1an:latest` for the latest stable release (old python version)
+
+### Examples
+
+The following examples assume the file you want to encode is in your current working directory.
+
 Linux
 
 ```bash
@@ -242,11 +252,13 @@ Windows
 docker run --privileged -v "${PWD}:/videos" -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
 ```
 
-Docker can also be built by using
+The image can also be manually built by running 
 
 ```bash
 docker build -t "av1an" .
 ```
+
+in the root directory of this repository. The dependencies will automatically be installed into the image, no manual installations necessary.
 
 To specify a different directory to use you would replace $(pwd) with the directory
 
@@ -255,17 +267,6 @@ docker run --privileged -v "/c/Users/masterofzen/Videos":/videos --user $(id -u)
 ```
 
 The --user flag is required on linux to avoid permission issues with the docker container not being able to write to the location, if you get permission issues ensure your user has access to the folder that you are using to encode.
-
-### Docker tags
-
-The docker image has the following tags
-
-|    Tag    | Description                                           |
-| :-------: | ----------------------------------------------------- |
-|   latest  | Contains the latest stable av1an version release      |
-|   master  | Contains the latest av1an commit to the master branch |
-| sha-##### | Contains the commit of the hash that is referenced    |
-|    #.##   | Stable av1an version release                          |
 
 ### Support the developer
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,74 @@
-<h1 align="center">
-    <br>
-    Av1an
-    </br>
-</h1>
+TEMP STUFF
 
-<h2 align="center">A cross-platform framework to streamline video encoding</h2>
+Av1an is written in Rust and can be used on Linux, macOS and Windows. It is highly configurable but tries to set good default values to make it easier to use.
 
-![alt text](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)
+### Supported encoders
 
-<h4 align="center">
-<a href="https://discord.gg/Ar8MvJh"><img src="https://discordapp.com/api/guilds/696849974230515794/embed.png" alt="Discord server" /></a>
-<img src="https://github.com/master-of-zen/Av1an/workflows/tests/badge.svg">
-<a href="https://crates.io/crates/av1an"><img src="https://img.shields.io/crates/v/av1an.svg"></a>
+- AV1: aomenc, rav1e, SVT-AV1
+- H.264/AVC: x264
+- H.265/HEVC: x265
+- VP8, VP9: VPX
 
-</h4>
-<h2 align="center">Easy, Fast, Efficient and Feature-Rich</h2>
+---
 
-### <center>An easy way to start using AV1, HEVC/H.265, AVC/H.264, VP9, and VP8 encoders.<br> AOM, RAV1E, SVT-AV1, VPX, x265, x264 are supported.</center>
+# Avian
+
+[![Discord server](https://discordapp.com/api/guilds/696849974230515794/embed.png)](https://discord.gg/Ar8MvJh)
+[![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
+[![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
+
+Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by automatically splitting your input file into smaller segments and encoding these segments in parallel. This helps the most with AV1 encoders, because they are not good at multithreading.
+
+---
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Building](#building-av1an)
+
+---
+
+## Installation
+
+- Make sure to install these prerequisites first:
+  - [FFmpeg](https://ffmpeg.org/download.html)
+  - [Vapoursynth](http://www.vapoursynth.com/)
+  - lsmash/ffms2 are recommended but not required for faster and better processing.
+
+Av1an can be installed in two main ways, either:
+- With a package manager:
+  - Cargo: `cargo install av1an`
+  - Arch Linux: `pacman -S av1an`
+
+At least one encoder is also required, install any of these that you wish to use:
+
+For AV1:
+  - [Install aomenc](https://aomedia.googlesource.com/aom/)
+  - [Install SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1)
+  - [Install rav1e](https://github.com/xiph/rav1e)
+
+For VP8 and VP9:
+  - [Install libvpx](https://chromium.googlesource.com/webm/libvpx/)
+
+For H.264/AVC:
+  - [Install x264](https://www.videolan.org/developers/x264.html)
+
+For H.265/HEVC:
+  - [Install x265](https://www.videolan.org/developers/x265.html)
+
+Av1an also supports these optional components:
+- Chunking components:
+  - [Install ffms2](https://github.com/FFMS/ffms2)
+  - [Install lsmash](https://github.com/VFR-maniac/L-SMASH-Works)
+- Other components:
+  - [Install mkvmerge](https://mkvtoolnix.download/)
+  - [Install VMAF](https://github.com/Netflix/vmaf) (required for `--target-quality` and `--vmaf`)
+
+Binary releases for Windows are also available from this repository's [releases page](https://github.com/master-of-zen/Av1an/releases).
+
+## Usage
 
 Example with default parameters:
 
@@ -26,6 +78,8 @@ Or with your own parameters:
 
     av1an -i input -v " --cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
     --target-quality 95 -a " -c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
+
+## Configuration
 
 <h2 align="center">General Usage</h2>
 
@@ -140,45 +194,8 @@ Av1an allows for **splitting input video by scenes for parallel encoding** to im
 - Automatic detection of the number of workers the host can handle.
 - Both video and audio transcoding.
 
-## Installation
 
-- Make sure to install these prerequisites first:
-  - [FFmpeg](https://ffmpeg.org/download.html)
-  - [Vapoursynth](http://www.vapoursynth.com/)
-  - lsmash/ffms2 are recommended but not required for faster and better processing.
-
-Av1an can be installed in two main ways, either:
-- With a package manager:
-  - Cargo: `cargo install av1an`
-  - Arch Linux: `pacman -S av1an`
-
-At least one encoder is also required, install any of these that you wish to use:
-
-For AV1:
-  - [Install aomenc](https://aomedia.googlesource.com/aom/)
-  - [Install SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1)
-  - [Install rav1e](https://github.com/xiph/rav1e)
-
-For VP8 and VP9:
-  - [Install libvpx](https://chromium.googlesource.com/webm/libvpx/)
-
-For H.264/AVC:
-  - [Install x264](https://www.videolan.org/developers/x264.html)
-
-For H.265/HEVC:
-  - [Install x265](https://www.videolan.org/developers/x265.html)
-
-Av1an also supports these optional components:
-- Chunking components:
-  - [Install ffms2](https://github.com/FFMS/ffms2)
-  - [Install lsmash](https://github.com/VFR-maniac/L-SMASH-Works)
-- Other components:
-  - [Install mkvmerge](https://mkvtoolnix.download/)
-  - [Install VMAF](https://github.com/Netflix/vmaf) (required for `--target-quality` and `--vmaf`)
-
-Binary releases for Windows are also available from this repository's [releases page](https://github.com/master-of-zen/Av1an/releases).
-
-### Manual compilation
+## Building Av1an
 
 To compile Av1an from source, [NASM](https://www.nasm.us/), [clang/LLVM](https://llvm.org/), [FFmpeg](https://ffmpeg.org/), [VapourSynth](https://www.vapoursynth.com/), and [Rust](https://www.rust-lang.org/) are required. Only FFmpeg and VapourSynth are required to run Av1an, the rest of the dependencies are required only for compilation.
 
@@ -259,3 +276,5 @@ The docker image has the following tags
 ### Support the developer
 
 Bitcoin - 1GTRkvV4KdSaRyFDYTpZckPKQCoWbWkJV1
+
+![av1an fully utilizing a 96-core CPU for video encoding](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Binary releases for Windows are also available from this repository's [releases 
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
 
-Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by automatically splitting the input file into smaller segments and encoding these segments in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically.
+Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency and speed by automatically splitting the input file into smaller segments and encoding these segments in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically.
 
 ---
 
 ## Table of Contents
 
+- [Features](#features)
+- [How it works](#how-it-works)
 - [Installation](#installation)
 - [Supported encoders](#supported-encoders)
 - [Usage](#usage)
@@ -25,6 +27,25 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 - [Building](#building-av1an)
 
 ---
+
+## Features
+
+- Vastly improved encoding speed for some encoders
+- Cancel and resume encoding without loss of progress
+- [Vapoursynth](http://www.vapoursynth.com) script input support
+- "Target Quality" mode, using VMAF to automatically set encoder options to achieve the wanted visual quality
+- Automatic detection of worker number based on available hardware
+- Simple and clean console look
+- Convenient Docker images available
+- Cross-platform, works on Linux, macOS and Windows
+
+## How it works
+
+Av1an uses a process called scene detection to split the input into smaller segments. It then encodes these segments (also called chunks) separately, starting multiple instances of the chosen encoder to better utilize the CPU and RAM than a single encoder would. Some of the AV1 encoders in particular are not very good at multithreading and will see the biggest speed improvement when using Av1an.
+
+Because every segment can be encoded separately, cancelling the encoding process does not lose all progress. All 
+
+After all segments have been encoded, they are concatenated into a single video. After all other processing steps like audio encoding are done, everything is combined into the resulting file. 
 
 ## Installation
 
@@ -70,8 +91,8 @@ Example with default parameters:
 
 Or with your own parameters:
 
-    av1an -i input -v " --cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
-    --target-quality 95 -a " -c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
+    av1an -i input -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10
+    --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 
 ## Configuration
 
@@ -175,18 +196,6 @@ Or with your own parameters:
                             [default: 4]
 
     --vmaf-threads          Limit number of threads that are used for VMAF calculation
-
-<h2 align="center">Main Features</h2>
-
-Av1an allows for **splitting input video by scenes for parallel encoding** to improve encoding performance, because most AV1 encoders are currently not very good at multithreading and encoding is limited to a very limited number of threads.
-
-- [Vapoursynth](http://www.vapoursynth.com) script input support.
-- Speed up video encoding.
-- "Target Quality" mode. Targeting end result reference visual quality. VMAF used as a substructure
-- Resuming encoding without loss of encoded progress.
-- Simple and clean console look.
-- Automatic detection of the number of workers the host can handle.
-- Both video and audio transcoding.
 
 
 ## Building Av1an

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Or use a VapourSynth script and custom parameters:
 av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10 --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 ```
 
-To check all available options for your version of Av1an use `av1an --help`.
+To check all available options for your version of Av1an use `av1an --help` or use the online [reference](docs/help.md) (possibly outdated).
 
 ## Support the developer
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
-TEMP STUFF
-
-Av1an is written in Rust and can be used on Linux, macOS and Windows. It is highly configurable but tries to set good default values to make it easier to use.
-
-Binary releases for Windows are also available from this repository's [releases page](https://github.com/master-of-zen/Av1an/releases).
-
----
-
 # Avian
 
 [![Discord server](https://discordapp.com/api/guilds/696849974230515794/embed.png)](https://discord.gg/Ar8MvJh)
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
 
-Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency and speed by automatically splitting the input file into smaller segments and encoding these segments in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically.
+Av1an is a video encoding framework for modern encoders written in Rust. It can increase your encoding efficiency and speed by splitting the input file into smaller segments and encoding them in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically. Av1an also helps you with VMAF calculations, and can even target a specific quality level for your encodes.
 
 ---
 
@@ -23,7 +15,6 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 - [Installation](#installation)
 - [Supported encoders](#supported-encoders)
 - [Usage](#usage)
-- [Building](#building-av1an)
 
 ---
 
@@ -31,10 +22,10 @@ Av1an is a video encoding framework for modern encoders. It can increase your en
 
 - Vastly improved encoding speed for some encoders
 - Cancel and resume encoding without loss of progress
-- [Vapoursynth](http://www.vapoursynth.com) script input support
-- "Target Quality" mode, using VMAF to automatically set encoder options to achieve the wanted visual quality
-- Automatic detection of worker number based on available hardware
-- Simple and clean console look
+- [VapourSynth](http://www.vapoursynth.com) script input support
+- [Target Quality](/docs/TargetQuality.md) mode, using [VMAF](https://github.com/Netflix/vmaf) to automatically set encoder options to achieve the wanted visual quality
+- Automatic detection of parallel worker amount based on the available hardware
+- Simple and clean console interface
 - Convenient Docker images available
 - Cross-platform, works on Linux, macOS and Windows
 
@@ -50,6 +41,8 @@ After all segments have been encoded, they are concatenated into a single video.
 
 The simplest way to install av1an is to use a package manager. There are also pre-built [Docker images](#usage-in-docker) which include all dependencies and are frequently updated.
 
+For Windows users that do not want to use Docker, prebuilt binaries are also included in every [release](https://github.com/master-of-zen/Av1an/releases), and a [nightly build](https://github.com/master-of-zen/Av1an/releases/tag/latest) of the current `master` branch is also available.
+
 ### Package managers
 
 Arch Linux & Manjaro: `pacman -S av1an`
@@ -61,13 +54,13 @@ If your distribution's package manager does not have Av1an or if you're on Windo
 Prerequisites:
 
 - [FFmpeg](https://ffmpeg.org/download.html)
-- [Vapoursynth](https://github.com/vapoursynth/vapoursynth/releases)
+- [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases)
 - At least one [encoder](#supported-encoders)
 
 Optional:
 
-- [ffms2](https://github.com/FFMS/ffms2) for better chunking
 - [L-SMASH](https://github.com/VFR-maniac/L-SMASH-Works) for better chunking
+- [ffms2](https://github.com/FFMS/ffms2) for better chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge for file concatenation (FFmpeg by default)
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF and to use [target quality mode](docs/TargetQuality.md)
 
@@ -90,51 +83,13 @@ Encode a video file with the default parameters:
 av1an -i input.mkv
 ```
 
-Or use a Vapoursynth script and custom parameters:
+Or use a VapourSynth script and custom parameters:
 
 ```sh
 av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 10 --target-quality 95 -a "-c:a libopus -ac 2 -b:a 192k" -l my_log -o output.mkv
 ```
 
 To check all available options for your version of Av1an use `av1an -h`.
-
-## Building Av1an
-
-To compile Av1an from source, [NASM](https://www.nasm.us/), [clang/LLVM](https://llvm.org/), [FFmpeg](https://ffmpeg.org/), [VapourSynth](https://www.vapoursynth.com/), and [Rust](https://www.rust-lang.org/) are required. Only FFmpeg and VapourSynth are required to run Av1an, the rest of the dependencies are required only for compilation.
-
-Rust 1.59.0 or newer is currently required to build Av1an.
-
-#### Compilation on Linux
-
-- Install these dependencies from your distribution's package manager.
-  - On Arch Linux, these are the `rust`, `nasm`, `clang`, `ffmpeg`, and `vapoursynth` packages.
-
-Then clone and build Av1an:
-
-```
-git clone https://github.com/master-of-zen/Av1an && cd Av1an
-cargo build --release
-```
-
-The resulting binary will be the file `./target/release/av1an`.
-
-#### Compilation on Windows
-
-To install Rust on Windows, first install [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). Then, download [`rustup-init.exe`](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe), run the program, and follow the onscreen instructions. Choose "Proceed with installation (default)" when prompted.
-
-Next, install [Python](https://www.python.org/) 3.10 or 3.8 (preferrably for all users). This is required for VapourSynth. Then, install VapourSynth from [this installer](https://github.com/vapoursynth/vapoursynth/releases/download/R58/VapourSynth64-R58.exe).
-
-Next, install NASM by using [this installer](https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-installer-x64.exe).
-
-Then, download a build of FFmpeg from here: https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-full_build-shared.7z
-
-Extract the file `ffmpeg-5.0.1-full_build-shared.7z` to a directory, then create a new environment variable called `FFMPEG_DIR` (this can be done with with the "Edit environment variables for your account" function available in the control panel), and set it to the directory that you extracted the original file to (for example, set it to `C:\Users\Username\Downloads\ffmpeg-5.0.1-full_build-shared`).
-
-Then, clone this repository (which can either be done via the git command line tool with the command `git clone https://github.com/master-of-zen/Av1an`, or by downloading and extracting the source code from the GitHub UI, which can be done with the "Download ZIP" button in the dropdown of the "Code" button near the top of the page).
-
-With a command prompt, `cd` into the directory containing this repository's source code, and run the command `cargo build --release`. If this command executes successfully with no errors, the binary (`av1an.exe`) will be the file `./target/release/av1an.exe` (relative to the directory containing the source code).
-
-To use the binary, copy all the `dll` files from `ffmpeg-5.0.1-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.
 
 ## Av1an in Docker
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,9 @@
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
 
-Av1an is a video encoding framework for modern encoders written in Rust. It can increase your encoding efficiency and speed by splitting the input file into smaller segments and encoding them in parallel. This improves CPU usage when you have a lot of CPU cores and increases the speed of some AV1 encoders dramatically. Av1an also helps you with VMAF calculations, and can even target a specific quality level for your encodes.
+Av1an is a video encoding framework for modern encoders. It can increase your encoding efficiency by running multiple encoder processes in parallel. This can improve CPU usage and increases the speed of some AV1 encoders dramatically.
 
----
-
-## Table of Contents
-
-- [Features](#features)
-- [How it works](#how-it-works)
-- [Installation](#installation)
-- [Supported encoders](#supported-encoders)
-- [Usage](#usage)
-
----
+Av1an can also calculate a VMAF score for you to assess the encode quality, and it can even target a specific quality level when encoding.
 
 ## Features
 
@@ -29,17 +19,21 @@ Av1an is a video encoding framework for modern encoders written in Rust. It can 
 - Convenient Docker images available
 - Cross-platform, works on Linux, macOS and Windows
 
-## How it works
+## Supported encoders
 
-Av1an uses a process called scene detection to split the input into smaller segments. It then encodes these segments (also called chunks) separately, starting multiple instances of the chosen encoder to better utilize the CPU and RAM than a single encoder would. Some of the AV1 encoders in particular are not very good at multithreading and will see the biggest speed improvement when using Av1an.
+At least one encoder is required to use Av1an. Install any of these that you wish to use.
 
-Because every segment can be encoded separately, cancelling the encoding process does not lose all progress. All 
+- [aomenc](https://aomedia.googlesource.com/aom/) (AV1)
+- [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1) (AV1)
+- [rav1e](https://github.com/xiph/rav1e) (AV1)
+- [libvpx](https://chromium.googlesource.com/webm/libvpx/) (VP8 and VP9)
+- [x264](https://www.videolan.org/developers/x264.html) (H.264/AVC)
+- [x265](https://www.videolan.org/developers/x265.html) (H.265/HEVC)
 
-After all segments have been encoded, they are concatenated into a single video. After all other processing steps like audio encoding are done, everything is combined into the resulting file. 
 
 ## Installation
 
-The simplest way to install av1an is to use a package manager. There are also pre-built [Docker images](#usage-in-docker) which include all dependencies and are frequently updated.
+The simplest way to install av1an is to use a package manager. There are also pre-built [Docker images](/docs/docker.md) which include all dependencies and are frequently updated.
 
 For Windows users that do not want to use Docker, prebuilt binaries are also included in every [release](https://github.com/master-of-zen/Av1an/releases), and a [nightly build](https://github.com/master-of-zen/Av1an/releases/tag/latest) of the current `master` branch is also available.
 
@@ -64,17 +58,6 @@ Optional:
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge for file concatenation (FFmpeg by default)
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF and to use [target quality mode](docs/TargetQuality.md)
 
-## Supported encoders
-
-At least one encoder is required to use Av1an. Install any of these that you wish to use.
-
-- [aomenc](https://aomedia.googlesource.com/aom/) (AV1)
-- [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1) (AV1)
-- [rav1e](https://github.com/xiph/rav1e) (AV1)
-- [libvpx](https://chromium.googlesource.com/webm/libvpx/) (VP8 and VP9)
-- [x264](https://www.videolan.org/developers/x264.html) (H.264/AVC)
-- [x265](https://www.videolan.org/developers/x265.html) (H.265/HEVC)
-
 ## Usage
 
 Encode a video file with the default parameters:
@@ -90,47 +73,6 @@ av1an -i input.vpy -v "--cpu-used=3 --end-usage=q --cq-level=30 --threads=8" -w 
 ```
 
 To check all available options for your version of Av1an use `av1an -h`.
-
-## Av1an in Docker
-
-The [docker image](https://hub.docker.com/r/masterofzen/av1an) is frequently updated and includes all supported encoders and all optional components. It is based on Arch Linux and provides recent versions of encoders and libraries.
-
-The image provides three types of tags that you can use:
-- `masterofzen/av1an:master` for the latest commit from `master`
-- `masterofzen/av1an:sha-#######` for a specific git commit (short hash)
-- (outdated) `masterofzen/av1an:latest` for the latest stable release (old python version)
-
-### Examples
-
-The following examples assume the file you want to encode is in your current working directory.
-
-Linux
-
-```bash
-docker run --privileged -v "$(pwd):/videos" --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
-```
-
-Windows
-
-```powershell
-docker run --privileged -v "${PWD}:/videos" -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
-```
-
-The image can also be manually built by running 
-
-```bash
-docker build -t "av1an" .
-```
-
-in the root directory of this repository. The dependencies will automatically be installed into the image, no manual installations necessary.
-
-To specify a different directory to use you would replace $(pwd) with the directory
-
-```bash
-docker run --privileged -v "/c/Users/masterofzen/Videos":/videos --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
-```
-
-The --user flag is required on linux to avoid permission issues with the docker container not being able to write to the location, if you get permission issues ensure your user has access to the folder that you are using to encode.
 
 ### Support the developer
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Av1an
 
+![av1an fully utilizing a 96-core CPU for video encoding](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)
+
 [![Discord server](https://discordapp.com/api/guilds/696849974230515794/embed.png)](https://discord.gg/Ar8MvJh)
 [![CI tests](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml/badge.svg)](https://github.com/master-of-zen/Av1an/actions/workflows/tests.yml)
 [![](https://img.shields.io/crates/v/av1an.svg)](https://crates.io/crates/av1an)
@@ -85,7 +87,3 @@ To check all available options for your version of Av1an use `av1an --help` or u
 ## Support the developer
 
 Bitcoin - 1GTRkvV4KdSaRyFDYTpZckPKQCoWbWkJV1
-
-## See Av1an in action
-
-![av1an fully utilizing a 96-core CPU for video encoding](https://cdn.discordapp.com/attachments/804148977347330048/928879953825640458/av1an_preview.jpg)

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -1,0 +1,57 @@
+# Compiling Av1an
+
+You can natively build Av1an on Linux and Windows. Cross-compilation is not supported.
+
+## Compiling on Linux
+
+To compile Av1an from source, you need the following dependencies:
+
+- [Rust](https://www.rust-lang.org/) (version 1.59.0 or higher)
+- [NASM](https://www.nasm.us/)
+- [clang/LLVM](https://llvm.org/)
+- [FFmpeg](https://ffmpeg.org/)
+- [VapourSynth](https://www.vapoursynth.com/)
+
+On Arch Linux, you can install these dependencies by running
+
+```sh
+pacman -S --needed rust nasm clang ffmpeg vapoursynth
+```
+
+Installation instructions on other distros will vary.
+
+After installing the dependencies, you need to clone the repository and start the build process:
+
+```sh
+git clone https://github.com/master-of-zen/Av1an && cd Av1an
+cargo build --release
+```
+
+The resulting binary will be the file `./target/release/av1an`.
+
+## Compiling on Windows
+
+If you just want a current build of Av1an that is newer than the last official release, you can find a pre-built binary of the current `master` branch at https://github.com/master-of-zen/Av1an/releases/tag/latest.
+
+If you want to build the binary yourself, you will need the following dependencies:
+
+- [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) - this is a dependency for Rust
+- [The Rust toolchain](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)
+- [Python](https://www.python.org/) (version 3.8 or 3.10) - this is a dependency for VapourSynth. Recommended to install for all users
+- [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases/download/R58/VapourSynth64-R58.exe)
+- [NASM](https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-installer-x64.exe)
+- [FFmpeg](https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-full_build-shared.7z) (thanks to [gyan](https://github.com/GyanD) for providing these builds)
+
+Extract the file `ffmpeg-5.0.1-full_build-shared.7z` to a directory, then create a new environment variable called `FFMPEG_DIR` (this can be done with with the "Edit environment variables for your account" function available in the control panel), and set it to the directory that you extracted the original file to (for example, set it to `C:\Users\Username\Downloads\ffmpeg-5.0.1-full_build-shared`).
+
+Then, either clone the repository by running
+
+```sh
+git clone https://github.com/master-of-zen/Av1an
+```
+
+Or download and extract the [source code](https://github.com/master-of-zen/Av1an/archive/refs/heads/master.zip) manually.
+
+Open a command prompt or PowerShell window inside the cloned repository/extracted ZIP folder and run the command `cargo build --release`. If this command executes successfully with no errors, `av1an.exe` will be in the folder `target\release`.
+
+To use `av1an.exe`, copy all the `.dll` files from `ffmpeg-5.0.1-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Av1an documentation
-
-

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,40 @@
+# Av1an in Docker
+
+The [docker image](https://hub.docker.com/r/masterofzen/av1an) is frequently updated and includes all supported encoders and all optional components. It is based on Arch Linux and provides recent versions of encoders and libraries.
+
+The image provides three types of tags that you can use:
+- `masterofzen/av1an:master` for the latest commit from `master`
+- `masterofzen/av1an:sha-#######` for a specific git commit (short hash)
+- (outdated) `masterofzen/av1an:latest` for the latest stable release (old python version)
+
+## Examples
+
+The following examples assume the file you want to encode is in your current working directory.
+
+Linux
+
+```bash
+docker run --privileged -v "$(pwd):/videos" --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
+```
+
+Windows
+
+```powershell
+docker run --privileged -v "${PWD}:/videos" -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
+```
+
+The image can also be manually built by running 
+
+```bash
+docker build -t "av1an" .
+```
+
+in the root directory of this repository. The dependencies will automatically be installed into the image, no manual installations necessary.
+
+To specify a different directory to use you would replace $(pwd) with the directory
+
+```bash
+docker run --privileged -v "/c/Users/masterofzen/Videos":/videos --user $(id -u):$(id -g) -it --rm masterofzen/av1an:latest -i S01E01.mkv {options}
+```
+
+The --user flag is required on linux to avoid permission issues with the docker container not being able to write to the location, if you get permission issues ensure your user has access to the folder that you are using to encode.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ The [docker image](https://hub.docker.com/r/masterofzen/av1an) is frequently upd
 The image provides three types of tags that you can use:
 - `masterofzen/av1an:master` for the latest commit from `master`
 - `masterofzen/av1an:sha-#######` for a specific git commit (short hash)
-- (outdated) `masterofzen/av1an:latest` for the latest stable release (old python version)
+- (outdated) `masterofzen/av1an:latest` for the latest stable __python__ release
 
 ## Examples
 
@@ -25,7 +25,7 @@ docker run --privileged -v "${PWD}:/videos" -it --rm masterofzen/av1an:latest -i
 
 The image can also be manually built by running 
 
-```bash
+```sh
 docker build -t "av1an" .
 ```
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,417 @@
+# Av1an CLI reference
+
+`av1an [OPTIONS] -i <INPUT>`
+
+---
+
+## Available options
+
+- [General](#general)
+- [Scene detection](#scene-detection)
+- [Encoding](#encoding)
+- [VMAF](#vmaf)
+- [Target Quality](#target-quality)
+
+---
+
+## General
+
+```
+-i <INPUT>
+		Input file to encode
+		
+		Can be a video or vapoursynth (.py, .vpy) script.
+
+-o <OUTPUT_FILE>
+		Video output file
+
+	--temp <TEMP>
+		Temporary directory to use
+		
+		If not specified, the temporary directory name is a hash of the input file name.
+
+-q, --quiet
+		Disable printing progress to the terminal
+
+	--verbose
+		Print extra progress info and stats to terminal
+
+-l, --log-file <LOG_FILE>
+		Log file location [default: <temp dir>/log.log]
+
+	--log-level <LOG_LEVEL>
+		Set log level for log file (does not affect command-line log level)
+		
+		error: Designates very serious errors.
+		
+		warn: Designates hazardous situations.
+		
+		info: Designates useful information.
+		
+		debug: Designates lower priority information.
+		
+		trace: Designates very low priority, often extremely verbose, information. Includes
+		rav1e scenechange decision info.
+		
+		[default: DEBUG]
+		[possible values: error, warn, info, debug, trace]
+
+-r, --resume
+		Resume previous session from temporary directory
+
+-k, --keep
+		Do not delete the temporary folder after encoding has finished
+
+	--force
+		Do not check if the encoder arguments specified by -v/--video-params are valid
+
+-y
+		Overwrite output file without confirmation
+
+	--max-tries <MAX_TRIES>
+		Maximum number of chunk restarts for an encode
+		
+		[default: 3]
+
+-w, --workers <WORKERS>
+		Number of workers to spawn [0 = automatic]
+		
+		[default: 0]
+
+	--set-thread-affinity <SET_THREAD_AFFINITY>
+		Pin each worker to a specific set of threads of this size (disabled by default)
+		
+		This is currently only supported on Linux and Windows, and does nothing on unsupported
+		platforms. Leaving this option unspecified allows the OS to schedule all processes
+		spawned.
+
+-h, --help
+		Print help information
+
+-V, --version
+		Print version information
+```
+
+## Scene detection
+
+```
+-s, --scenes <SCENES>
+		File location for scenes
+
+	--split-method <SPLIT_METHOD>
+		Method used to determine chunk boundaries
+		
+		"av-scenechange" uses an algorithm to analyze which frames of the video are the start
+		of new scenes, while "none" disables scene detection entirely (and only relies on
+		-x/--extra-split to add extra scenecuts).
+		
+		[default: av-scenechange]
+		[possible values: av-scenechange, none]
+
+	--sc-method <SC_METHOD>
+		Scene detection algorithm to use for av-scenechange
+		
+		Standard: Most accurate, still reasonably fast. Uses a cost-based algorithm to determine
+		keyframes.
+		
+		Fast: Very fast, but less accurate. Determines keyframes based on the raw difference
+		between pixels.
+		
+		[default: standard]
+		[possible values: standard, fast]
+
+	--sc-only
+		Run the scene detection only before exiting
+		
+		Requires a scene file with --scenes.
+
+	--sc-pix-format <SC_PIX_FORMAT>
+		Perform scene detection with this pixel format
+
+	--sc-downscale-height <SC_DOWNSCALE_HEIGHT>
+		Optional downscaling for scene detection
+		
+		Specify as the desired maximum height to scale to (e.g. "720" to downscale to 720p
+		— this will leave lower resolution content untouched). Downscaling improves scene
+		detection speed but lowers accuracy, especially when scaling to very low resolutions.
+		
+		By default, no downscaling is performed.
+
+-x, --extra-split <EXTRA_SPLIT>
+		Maximum scene length
+		
+		When a scenecut is found whose distance to the previous scenecut is greater than the
+		value specified by this option, one or more extra splits (scenecuts) are added. Set this
+		option to 0 to disable adding extra splits.
+
+	--min-scene-len <MIN_SCENE_LEN>
+		Minimum number of frames for a scenecut
+		
+		[default: 24]
+```
+
+## Encoding
+
+```
+-e, --encoder <ENCODER>
+		Video encoder to use
+		
+		[default: aom]
+		[possible values: aom, rav1e, vpx, svt-av1, x264, x265]
+
+-v, --video-params <VIDEO_PARAMS>
+		Parameters for video encoder
+		
+		These parameters are for the encoder binary directly, so the ffmpeg syntax cannot be
+		used. For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary
+		takes this value with double dashes, as in "--crf <crf>". See the --help output of each
+		encoder for a list of valid options.
+
+-p, --passes <PASSES>
+		Number of encoder passes
+		
+		Since aom and vpx benefit from two-pass mode even with constant quality mode (unlike
+		other encoders in which two-pass mode is used for more accurate VBR rate control), two-
+		pass mode is used by default for these encoders.
+		
+		When using aom or vpx with RT mode (--rt), one-pass mode is always used regardless
+		of the value specified by this flag (as RT mode in aom and vpx only supports one-pass
+		encoding).
+		
+		[possible values: 1, 2]
+
+-a, --audio-params <AUDIO_PARAMS>
+		Audio encoding parameters (ffmpeg syntax)
+		
+		If not specified, "-c:a copy" is used.
+		
+		Do not use ffmpeg's -map syntax with this option. Instead, use the colon syntax with
+		each parameter you specify.
+		
+		Subtitles are always copied by default.
+		
+		Example to encode all audio tracks with libopus at 128k:
+		
+		-a="-c:a libopus -b:a 128k"
+		
+		Example to encode the first audio track with libopus at 128k, and the second audio track
+		with aac at 24k, where only the second track is downmixed to a single channel:
+		
+		-a="-c:a:0 libopus -b:a:0 128k -c:a:1 aac -ac:a:1 1 -b:a:1 24k"
+
+-f, --ffmpeg <FFMPEG_FILTER_ARGS>
+		FFmpeg filter options
+
+-m, --chunk-method <CHUNK_METHOD>
+		Method used for piping exact ranges of frames to the encoder
+		
+		Methods that require an external vapoursynth plugin:
+		
+		lsmash - Generally the best and most accurate method. Does not require intermediate
+		files. Errors generally only occur if the input file itself is broken (for example,
+		if the video bitstream is invalid in some way, video players usually try to recover
+		from the errors as much as possible even if it results in visible artifacts, while
+		lsmash will instead throw an error). Requires the lsmashsource vapoursynth plugin to
+		be installed.
+		
+		ffms2 - Accurate and does not require intermediate files. Can sometimes have bizarre
+		bugs that are not present in lsmash (that can cause artifacts in the piped output).
+		Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to
+		be installed.
+		
+		Methods that only require ffmpeg:
+		
+		hybrid - Uses a combination of segment and select. Usually accurate but requires
+		intermediate files (which can be large). Avoids decoding irrelevant frames by seeking to
+		the first keyframe before the requested frame and decoding only a (usually very small)
+		number of irrelevant frames until relevant frames are decoded and piped to the encoder.
+		
+		select - Extremely slow, but accurate. Does not require intermediate files. Decodes
+		from the first frame to the requested frame, without skipping irrelevant frames (causing
+		quadratic decoding complexity).
+		
+		segment - Create chunks based on keyframes in the source. Not frame exact, as it can
+		only split on keyframes in the source. Requires intermediate files (which can be large).
+		
+		Default: lsmash (if available), otherwise ffms2 (if available), otherwise hybrid.
+		
+		[possible values: segment, select, ffms2, lsmash, hybrid]
+
+	--chunk-order <CHUNK_ORDER>
+		The order in which av1an will encode chunks
+		
+		Available methods:
+		
+		long-to-short - The longest chunks will be encoded first. This method results in the
+		smallest amount of time with idle cores, as the encode will not be waiting on a very
+		long chunk to finish at the end of the encode after all other chunks have finished.
+		
+		short-to-long - The shortest chunks will be encoded first.
+		
+		sequential - The chunks will be encoded in the order they appear in the video.
+		
+		random - The chunks will be encoded in a random order. This will provide a more accurate
+		estimated filesize sooner in the encode.
+		
+		[default: long-to-short]
+		[possible values: long-to-short, short-to-long, sequential, random]
+
+	--photon-noise <PHOTON_NOISE>
+		Generates a photon noise table and applies it using grain synthesis [strength: 0-64]
+		(disabled by default)
+		
+		Photon noise tables are more visually pleasing than the film grain generated by aomenc,
+		and provide a consistent level of grain regardless of the level of grain in the source.
+		Strength values correlate to ISO values, e.g. 1 = ISO 100, and 64 = ISO 6400. This
+		option currently only supports aomenc.
+		
+		An encoder's grain synthesis will still work without using this option, by specifying
+		the correct parameter to the encoder. However, the two should not be used together, and
+		specifying this option will disable aomenc's internal grain synthesis.
+
+-c, --concat <CONCAT>
+		Determines method used for concatenating encoded chunks and audio into output file
+		
+		ffmpeg - Uses ffmpeg for concatenation. Unfortunately, ffmpeg sometimes produces files
+		with partially broken audio seeking, so mkvmerge should generally be preferred if
+		available. ffmpeg concatenation also produces broken files with the --enable-keyframe-
+		filtering=2 option in aomenc, so it is disabled if that option is used. However, ffmpeg
+		can mux into formats other than matroska (.mkv), such as WebM. To output WebM, use
+		a .webm extension in the output file.
+		
+		mkvmerge - Generally the best concatenation method (as it does not have either of the
+		aforementioned issues that ffmpeg has), but can only produce matroska (.mkv) files.
+		Requires mkvmerge to be installed.
+		
+		ivf - Experimental concatenation method implemented in av1an itself to concatenate to an
+		ivf file (which only supports VP8, VP9, and AV1, and does not support audio).
+		
+		[default: ffmpeg]
+		[possible values: ffmpeg, mkvmerge, ivf]
+
+	--pix-format <PIX_FORMAT>
+		FFmpeg pixel format
+		
+		[default: yuv420p10le]
+
+	--zones <ZONES>
+		Path to a file specifying zones within the video with differing encoder settings.
+		
+		The zones file should include one zone per line,
+		with each arg within a zone space-separated.
+		No quotes or escaping are needed around the encoder args,
+		as these are assumed to be the last argument.
+		
+		The zone args on each line should be in this order:
+		
+		```
+		start_frame end_frame encoder reset(opt) video_params
+		```
+		
+		For example:
+		
+		```
+		136 169 aom --photon-noise 4 --cq-level=32
+		169 1330 rav1e reset -s 3 -q 42
+		```
+		
+		Example line 1 will encode frames 136-168 using aomenc
+		with the argument `--cq-level=32` and enable av1an's `--photon-noise` option.
+		Note that the end frame number is *exclusive*.
+		The start and end frame will both be forced to be scenecuts.
+		Additional scene detection will still be applied within the zones.
+		`-1` can be used to refer to the last frame in the video.
+		
+		The default behavior as shown on line 1 is to preserve
+		any options passed to `--video-params` or `--photon-noise`
+		in av1an, and append or overwrite the additional zone settings.
+		
+		Example line 2 will encode frames 169-1329 using rav1e.
+		The `reset` keyword instructs av1an to ignore any settings
+		which affect the encoder, and use only the parameters from this zone.
+		
+		For segments where no zone is specified,
+		the settings passed to av1an itself will be used.
+		
+		The video params which may be specified include any parameters
+		that are allowed by the encoder, as well as the following av1an options:
+		
+		- `-x`/`--extra-split`
+		- `--min-scene-len`
+		- `--passes`
+		- `--photon-noise` (aomenc only)
+```
+
+## VMAF
+
+```
+	--vmaf
+		Plot an SVG of the VMAF for the encode
+		
+		This option is independent of --target-quality, i.e. it can be used with or without it.
+		The SVG plot is created in the same directory as the output file.
+
+	--vmaf-path <VMAF_PATH>
+		Path to VMAF model (used by --vmaf and --target-quality)
+		
+		If not specified, ffmpeg's default is used.
+
+	--vmaf-res <VMAF_RES>
+		Resolution used for VMAF calculation
+		
+		[default: 1920x1080]
+
+	--vmaf-threads <VMAF_THREADS>
+		Number of threads to use for VMAF calculation
+
+	--vmaf-filter <VMAF_FILTER>
+		Filter applied to source at VMAF calcualation
+		
+		This option should be specified if the source is cropped, for example.
+```
+
+## Target Quality
+
+```
+	--target-quality <TARGET_QUALITY>
+		Target a VMAF score for encoding (disabled by default)
+		
+		For each chunk, target quality uses an algorithm to find the quantizer/crf needed to
+		achieve a certain VMAF score. Target quality mode is much slower than normal encoding,
+		but can improve the consistency of quality in some cases.
+		
+		The VMAF score range is 0-100 (where 0 is the worst quality, and 100 is the best).
+		Floating-point values are allowed.
+
+	--probes <PROBES>
+		Maximum number of probes allowed for target quality
+		
+		[default: 4]
+
+	--probing-rate <PROBING_RATE>
+		Framerate for probes, 1 - original
+		
+		[default: 1]
+
+	--probe-slow
+		Use encoding settings for probes specified by --video-params rather than faster, less
+		accurate settings
+		
+		Note that this always performs encoding in one-pass mode, regardless of --passes.
+
+	--min-q <MIN_Q>
+		Lower bound for target quality Q-search early exit
+		
+		If min_q is tested and the probe's VMAF score is lower than target_quality, the Q-search
+		early exits and min_q is used for the chunk.
+		
+		If not specified, the default value is used (chosen per encoder).
+
+	--max-q <MAX_Q>
+		Upper bound for target quality Q-search early exit
+		
+		If max_q is tested and the probe's VMAF score is higher than target_quality, the Q-
+		search early exits and max_q is used for the chunk.
+		
+		If not specified, the default value is used (chosen per encoder).
+```


### PR DESCRIPTION
After seeing that the README was pretty outdated, I decided to try and update it a bit. Some things I'm not 100% about:

- The first few sentences. These are pretty important as far as READMEs go, so feel free to edit/propose stuff
- Saying `lsmash` is the recommended choice. This just seemed like the generally preferred choice from what I read in Discord 
- I think "use `av1an --help` for a CLI reference" is easier to maintain than listing every option in the readme
- Where to put the image of the 96-worker encode

Feel free to give feedback on these things and in general.