### PR TITLE
Fix CI Windows builds

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: FFmpeg hashsum
         run: |
-          $hashSum = (Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z.sha256').Content
+          $hashSum = (Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-5.0.1-full_build-shared.7z.sha256').Content
           echo "ff_hash=$hashSum" | Out-File $env:GITHUB_ENV -Append
           Write-Output "Latest release: $hashSum"
 
@@ -42,7 +42,7 @@ jobs:
         name: FFmpeg installation
         run: |
           $tempFile = New-TemporaryFile
-          Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z' -OutFile $tempFile -TimeoutSec 10
+          Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-5.0.1-full_build-shared.7z' -OutFile $tempFile -TimeoutSec 10
           7z x -y -o'C:/ffmpeg' "$tempFile"
 
       - name: FFmpeg environment variable

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,24 +25,11 @@ jobs:
           version: 2.15.05
           from-source: false
 
-      - name: FFmpeg hashsum
-        run: |
-          $hashSum = (Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-5.0.1-full_build-shared.7z.sha256').Content
-          echo "ff_hash=$hashSum" | Out-File $env:GITHUB_ENV -Append
-          Write-Output "Latest release: $hashSum"
-
-      - name: FFmpeg cache
-        id: cache-ff
-        uses: actions/cache@v3
-        with:
-          path: C:/ffmpeg
-          key: ff-${{ env.ff_hash }}
-
       - if: steps.cache-ff.outputs.cache-hit != 'true'
         name: FFmpeg installation
         run: |
           $tempFile = New-TemporaryFile
-          Invoke-WebRequest 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-5.0.1-full_build-shared.7z' -OutFile $tempFile -TimeoutSec 10
+          Invoke-WebRequest 'https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-full_build-shared.7z' -OutFile $tempFile -TimeoutSec 10
           7z x -y -o'C:/ffmpeg' "$tempFile"
 
       - name: FFmpeg environment variable

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,7 +29,7 @@ jobs:
         name: FFmpeg installation
         run: |
           $tempFile = New-TemporaryFile
-          Invoke-WebRequest 'https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-full_build-shared.7z' -OutFile $tempFile -TimeoutSec 10
+          Invoke-WebRequest 'https://github.com/GyanD/codexffmpeg/releases/download/5.1/ffmpeg-5.1-full_build-shared.7z' -OutFile $tempFile -TimeoutSec 10
           7z x -y -o'C:/ffmpeg' "$tempFile"
 
       - name: FFmpeg environment variable


### PR DESCRIPTION
After FFmpeg release 5.1, gyan.dev updated their "latest" release from 5.0.1 to 5.1, which currently breaks the build (`ffmpeg-next` and `ffmpeg-sys-next` don't support 5.1 yet). To circumvent this in the future, I've fixed the version to 5.0.1 and switched to the GitHub mirror (older releases get removed from gyan.dev at some point).

This requires removing the cache functionality, because there's no way to get a file hash from GitHub release assets. This doesn't affect the build time much though.

I've [tested this on my fork already, and it works without a problem.](https://github.com/FreezyLemon/Av1an/actions/runs/2790530028)

Ignore the 2 commits, I'm just too lazy to squash them manually :D