### PR TITLE
Use `-c y4m` instead of deprecated `-y` in vspipe

### DIFF
--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -216,7 +216,8 @@ fn build_decoder(
     Input::VapourSynth(path) => {
       bit_depth = crate::vapoursynth::bit_depth(path.as_ref())?;
       let vspipe = Command::new("vspipe")
-        .arg("-y")
+        .arg("-c")
+        .arg("y4m")
         .arg(path)
         .arg("-")
         .stdin(Stdio::null())

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -866,7 +866,8 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     let vspipe_cmd_gen: Vec<OsString> = into_vec![
       "vspipe",
       vs_script,
-      "-y",
+      "-c",
+      "y4m",
       "-",
       "-s",
       format!("{}", scene.start_frame),

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -144,7 +144,7 @@ pub fn plot(
         "-"
       ]
     ),
-    Input::VapourSynth(ref path) => ref_smallvec!(OsStr, 8, ["vspipe", "-y", path, "-"]),
+    Input::VapourSynth(ref path) => ref_smallvec!(OsStr, 8, ["vspipe", "-c", "y4m", path, "-"]),
   };
 
   run_vmaf(


### PR DESCRIPTION
This was deprecated quite a long time ago,
anyone who hasn't updated to a compatible version by now
is probably experiencing other errors due to plugins
being incompatible.

This should also eliminate the deprecation warning
that vspipe outputs, which confuses basically every person
who runs into an encoder crash while using av1an.