### PR TITLE
Bump ffmpeg-next to 5.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "5.0.3"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585e5eaf57eceaa199ba6f6a1f46bdad7992930bb7b45b40275d9445b5ba2bc8"
+checksum = "a80971eee67be0079a1c8890bde68226fe9bd0441740fd6ddd0cee131486b321"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "5.0.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba12dea33516e30c160ce557c7e43dd857276368eb1cd0eef4fce6529f2dee5"
+checksum = "d780b36e092254367e2f1f21191992735c8e23f31a5a5a8678db3a79f775021f"
 dependencies = [
  "bindgen",
  "cc",

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -35,7 +35,7 @@ features = ["git", "build", "rustc", "cargo"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-next"
-version = "5.0.3"
+version = "5.1.1"
 
 [features]
 ffmpeg_static = ["ffmpeg/static", "ffmpeg/build"]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -63,7 +63,7 @@ features = ["const_generics", "const_new", "union"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-next"
-version = "5.0.3"
+version = "5.1.1"
 
 [dependencies.plotters]
 version = "0.3.1"


### PR DESCRIPTION
This bumps the `ffmpeg-next` crate to 5.1.1, making it compatible with additions from ffmpeg release 5.1.

Note that this won't fix builds with the AUR package `ffmpeg-git`, because ffmpeg `master` has changes which already make it incompatible to crate version 5.1.1.