### PR TITLE
Fix extra_splits when fps is NaN

### DIFF
--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -160,7 +160,7 @@ pub fn init_multi_progress_bar(len: u64, workers: usize, total_chunks: usize) {
         } else {
           "  {prefix:.dim} {msg}"
         }));
-      pb.set_prefix(format!("[Idle  {:width$}]", width = digits));
+      pb.set_prefix(format!("[Idle  {width:width$}]", width = digits));
       pbs.push(mpb.add(pb));
     }
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -790,7 +790,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       .store(self.frames, atomic::Ordering::SeqCst);
     let scenes_before = scenes.len();
     if !used_existing_cuts {
-      if let Some(split_len) = self.extra_splits_len {
+      if let Some(split_len @ 1..) = self.extra_splits_len {
         scenes = extra_splits(&scenes, self.frames, split_len);
         let scenes_after = scenes.len();
         info!(


### PR DESCRIPTION
Sometimes, `avg_frame_rate` returns NaN, which causes a divide-by-zero error in `extra_splits`. This PR fixes the behavior.

- Also fix other compiler warning.