### PR TITLE
[Draft] Per-chunk luminance-based q/cq boosting

### DIFF
--- a/av1an-cli/src/lib.rs
+++ b/av1an-cli/src/lib.rs
@@ -372,6 +372,10 @@ pub struct CliOpts {
   #[clap(long, default_value = "yuv420p10le", help_heading = "ENCODING")]
   pub pix_format: Pixel,
 
+  /// Enables the low-luma boost
+  #[clap(long, help_heading = "ENCODING")]
+  pub luma_boost: bool,
+
   /// Path to a file specifying zones within the video with differing encoder settings.
   ///
   /// The zones file should include one zone per line,
@@ -623,6 +627,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         .photon_noise
         .and_then(|arg| if arg == 0 { None } else { Some(arg) }),
       chroma_noise: args.chroma_noise,
+      luma_boost: args.luma_boost,
       sc_pix_format: args.sc_pix_format,
       keep: args.keep,
       max_tries: args.max_tries,

--- a/av1an-core/src/boost.rs
+++ b/av1an-core/src/boost.rs
@@ -1,0 +1,76 @@
+use std::{io::Read, process::{Stdio, Command}};
+
+use crate::{Input, scenes::Scene, encoder::Encoder, chunk::Chunk};
+
+pub trait Pixel {}
+
+pub fn analyze<T: Pixel>(input: &Input, encoder: Encoder, scene: Scene, chunk: Chunk) -> anyhow::Result<Vec<f32>> {
+  let mut decoder = build_decoder(input, encoder)?;
+  let bit_depth = decoder.get_bit_depth();
+  assert!(bit_depth == 8, "currently only supports 8-bit input");
+
+  
+
+  let frames = scene.end_frame - scene.start_frame;
+  let mut result: Vec<f32> = Vec::with_capacity(frames);
+  while let Ok(frame) = decoder.read_frame() {
+    let luma = frame.get_y_plane();
+    let mut sum: u32 = 0;
+    for b in luma.iter().copied() {
+      sum += b as u32;
+    }
+    
+    result.push(sum as f32 / luma.len() as f32);
+  }
+
+  Ok(result)
+}
+
+fn analyze_8bit() {
+
+}
+
+fn analyze_hbd() {
+
+}
+
+fn get_average_luma(scene: Scene) {
+
+}
+
+fn build_decoder(input: &Input, encoder: Encoder) -> anyhow::Result<y4m::Decoder<impl Read>> {
+  let decoder = match input {
+    Input::VapourSynth(path) => {
+      let vspipe = Command::new("vspipe")
+        .arg("-c")
+        .arg("y4m")
+        .arg(path)
+        .arg("-")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?
+        .stdout
+        .unwrap();
+  
+      y4m::Decoder::new(vspipe)?
+    },
+    Input::Video(path) => {
+      let ffpipe = Command::new("ffmpeg")
+        .args(["-r", "1", "-i"])
+        .arg(path)
+        //.args(filters.as_ref())
+        .args(["-f", "yuv4mpegpipe", "-strict", "-1", "-"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?
+        .stdout
+        .unwrap();
+      
+      y4m::Decoder::new(ffpipe)?
+    },
+  };
+
+  Ok(decoder)
+}

--- a/av1an-core/src/boost.rs
+++ b/av1an-core/src/boost.rs
@@ -5,15 +5,15 @@ use crate::{chunk::Chunk, encoder::Encoder};
 const BOOST_THRESHOLD: f32 = 50.0;
 
 pub fn boost_low_luma(chunk: &Chunk, encoder: Encoder) -> Option<usize> {
-  if let Ok(luma) = get_avg_luma(chunk) {
-    if luma < BOOST_THRESHOLD {
-      return Some(
-        encoder.get_boosted_q(BOOST_THRESHOLD - luma)
-      );
+  get_avg_luma(chunk).map_or(None, |luma| {
+    if BOOST_THRESHOLD > luma {
+      Some(
+        encoder.get_boosted_q((BOOST_THRESHOLD - luma) / BOOST_THRESHOLD)
+      )
+    } else {
+      None
     }
-  }
-
-  None
+  })
 }
 
 pub fn get_avg_luma(chunk: &Chunk) -> anyhow::Result<f32> {

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -867,7 +867,8 @@ impl Encoder {
     impl_this_function!(x264, x265, vpx, aom, rav1e, svt_av1)
   }
 
-  pub fn get_boosted_q(self, luma_delta: f32) -> usize {
+  pub fn get_boosted_q(self, boost_strength: f32) -> usize {
+    // boost strength is a float in the range (0,1]
     match &self {
       Encoder::aom => todo!(),
       Encoder::rav1e => todo!(),

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -866,6 +866,17 @@ impl Encoder {
     }
     impl_this_function!(x264, x265, vpx, aom, rav1e, svt_av1)
   }
+
+  pub fn get_boosted_q(self, luma_delta: f32) -> usize {
+    match &self {
+      Encoder::aom => todo!(),
+      Encoder::rav1e => todo!(),
+      Encoder::vpx => todo!(),
+      Encoder::svt_av1 => todo!(),
+      Encoder::x264 => todo!(),
+      Encoder::x265 => todo!(),
+    }
+  }
 }
 
 #[derive(Error, Debug)]

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -47,6 +47,7 @@ use crate::encoder::Encoder;
 use crate::progress_bar::{finish_multi_progress_bar, finish_progress_bar};
 use crate::target_quality::TargetQuality;
 
+pub mod boost;
 pub mod broker;
 pub mod chunk;
 pub mod concat;

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -23,6 +23,7 @@ use rand::thread_rng;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::ChildStderr;
 
+use crate::boost::boost_low_luma;
 use crate::broker::{Broker, EncoderCrash};
 use crate::chunk::Chunk;
 use crate::concat::{self, ConcatMethod};
@@ -243,6 +244,12 @@ impl EncodeArgs {
     } else {
       encoder.compose_2_2_pass(video_params, fpf_file.to_str().unwrap(), chunk.output())
     };
+
+    if self.luma_boost {
+      if let Some(boosted_q) = boost_low_luma(chunk, encoder) {
+        enc_cmd = encoder.man_command(enc_cmd, boosted_q);
+      }
+    }
 
     if let Some(per_shot_target_quality_cq) = chunk.tq_cq {
       enc_cmd = encoder.man_command(enc_cmd, per_shot_target_quality_cq as usize);

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -83,6 +83,7 @@ pub struct EncodeArgs {
   pub set_thread_affinity: Option<usize>,
   pub photon_noise: Option<u8>,
   pub chroma_noise: bool,
+  pub luma_boost: bool,
   pub zones: Option<PathBuf>,
 
   // FFmpeg params


### PR DESCRIPTION
I recently saw someone on the Discord ask for this, and thought it would be a neat feature to implement.

Some things that still need to be done:
1. high bitdepth support: This could basically be fixed by using [av-scenechange's y4m read_frame function](https://github.com/rust-av/av-scenechange/blob/4804462f2b6ae6209609cd95b5d9739264bf614f/src/y4m.rs#L40) and rewriting a bit of code, but that module is private atm
2. Configuring a boosting threshold (below which avg luma value should we boost a scene?)
3. Configuring a per-encoder Q/CQ delta: Not every encoder needs the same amount of CQ "boosting". This might need community feedback as its not easy to test imo
4. Should the CQ boost scale linearly? Maybe this needs per-encoder tuning too.
5. `--luma-boost` (maybe needs a rename) can conflict with other options like `--target-quality`

I'll investigate python Av1an to see if I can find some info on 2 and 3

Just let me know if I'm going in the right direction here