### PR TITLE
Fix Windows build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "splines"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1732,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "winapi",
 ]
 

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -76,7 +76,7 @@ features = ["vsscript-functions", "vapoursynth-functions"]
 
 [dependencies.tokio]
 version = "1"
-features = ["rt", "process", "io-util"]
+features = ["rt", "process", "io-util", "net"]
 
 [dependencies.dashmap]
 version = "5.0.0"


### PR DESCRIPTION
tokio 1.21.0+ requires the `net` feature to be able to use `enable_io` on non-Unix platforms:
[1.20.0 docs](https://docs.rs/tokio/1.20.0/tokio/runtime/struct.Builder.html#method.enable_io) vs [1.21.0 docs](https://docs.rs/tokio/1.21.0/tokio/runtime/struct.Builder.html#method.enable_io).

So I enabled the feature and now the build [works](https://github.com/FreezyLemon/Av1an/actions/runs/3435210294) again.