### PR TITLE
Improve verbose progress for several encoders

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -100,7 +100,12 @@ impl Display for Encoder {
 
 impl Encoder {
   /// Composes 1st pass command for 1 pass encoding
-  pub fn compose_1_1_pass(self, params: Vec<String>, output: String) -> Vec<String> {
+  pub fn compose_1_1_pass(
+    self,
+    params: Vec<String>,
+    output: String,
+    frame_count: usize,
+  ) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=1"],
@@ -109,7 +114,7 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array!["rav1e", "-", "-y"],
+        into_array!["rav1e", "-", "-y", "--limit", frame_count.to_string()],
         params,
         into_array!["--output", output]
       )
@@ -134,13 +139,15 @@ impl Encoder {
           "error",
           "--demuxer",
           "y4m",
+          "--frames",
+          frame_count.to_string()
         ],
         params,
         into_array!["-", "-o", output]
       )
       .collect(),
       Self::x265 => chain!(
-        into_array!["x265", "--y4m"],
+        into_array!["x265", "--y4m", "--frames", frame_count.to_string()],
         params,
         into_array!["-", "-o", output]
       )
@@ -149,7 +156,7 @@ impl Encoder {
   }
 
   /// Composes 1st pass command for 2 pass encoding
-  pub fn compose_1_2_pass(self, params: Vec<String>, fpf: &str) -> Vec<String> {
+  pub fn compose_1_2_pass(self, params: Vec<String>, fpf: &str, frame_count: usize) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=2", "--pass=1"],
@@ -158,7 +165,14 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array!["rav1e", "-", "-y", "--quiet"],
+        into_array![
+          "rav1e",
+          "-",
+          "-y",
+          "--quiet",
+          "--limit",
+          frame_count.to_string()
+        ],
         params,
         into_array!["--first-pass", format!("{}.stat", fpf), "--output", NULL]
       )
@@ -200,6 +214,8 @@ impl Encoder {
           "1",
           "--demuxer",
           "y4m",
+          "--frames",
+          frame_count.to_string()
         ],
         params,
         into_array!["--stats", format!("{}.log", fpf), "-", "-o", NULL]
@@ -214,6 +230,8 @@ impl Encoder {
           "--pass",
           "1",
           "--y4m",
+          "--frames",
+          frame_count.to_string()
         ],
         params,
         into_array![
@@ -231,7 +249,13 @@ impl Encoder {
   }
 
   /// Composes 2st pass command for 2 pass encoding
-  pub fn compose_2_2_pass(self, params: Vec<String>, fpf: &str, output: String) -> Vec<String> {
+  pub fn compose_2_2_pass(
+    self,
+    params: Vec<String>,
+    fpf: &str,
+    output: String,
+    frame_count: usize,
+  ) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=2", "--pass=2"],
@@ -240,7 +264,14 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array!["rav1e", "-", "-y", "--quiet"],
+        into_array![
+          "rav1e",
+          "-",
+          "-y",
+          "--quiet",
+          "--limit",
+          frame_count.to_string()
+        ],
         params,
         into_array!["--second-pass", format!("{}.stat", fpf), "--output", output]
       )
@@ -282,6 +313,8 @@ impl Encoder {
           "2",
           "--demuxer",
           "y4m",
+          "--frames",
+          frame_count.to_string()
         ],
         params,
         into_array!["--stats", format!("{}.log", fpf), "-", "-o", output]
@@ -296,6 +329,8 @@ impl Encoder {
           "--pass",
           "2",
           "--y4m",
+          "--frames",
+          frame_count.to_string()
         ],
         params,
         into_array![

--- a/av1an-core/src/parse.rs
+++ b/av1an-core/src/parse.rs
@@ -198,6 +198,7 @@ pub fn parse_rav1e_frames(s: &str) -> Option<u64> {
   // encoded 122 frames, 126.416 fps, 16.32 Kb/s, elap. time: 1m 36s
   // encoded 1220 frames, 126.416 fps, 16.32 Kb/s, elap. time: 1m 36s
   // encoded 12207 frames, 126.416 fps, 16.32 Kb/s, elap. time: 1m 36s
+  // encoded 12/240 frames, 126.416 fps, 16.32 Kb/s, elap. time: 1m 36s
 
   if !s.starts_with(RAV1E_IGNORED_PREFIX) {
     return None;
@@ -206,6 +207,7 @@ pub fn parse_rav1e_frames(s: &str) -> Option<u64> {
   s.get(RAV1E_IGNORED_PREFIX.len()..)?
     .split_ascii_whitespace()
     .next()
+    .map(|val| val.split_once('/').map_or(val, |(val, _)| val))
     .and_then(|s| s.parse().ok())
 }
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -236,11 +236,16 @@ impl EncodeArgs {
       video_params.push("--enable-tpl-model=0".to_string());
     }
     let mut enc_cmd = if passes == 1 {
-      encoder.compose_1_1_pass(video_params, chunk.output())
+      encoder.compose_1_1_pass(video_params, chunk.output(), chunk.frames)
     } else if current_pass == 1 {
-      encoder.compose_1_2_pass(video_params, fpf_file.to_str().unwrap())
+      encoder.compose_1_2_pass(video_params, fpf_file.to_str().unwrap(), chunk.frames)
     } else {
-      encoder.compose_2_2_pass(video_params, fpf_file.to_str().unwrap(), chunk.output())
+      encoder.compose_2_2_pass(
+        video_params,
+        fpf_file.to_str().unwrap(),
+        chunk.output(),
+        chunk.frames,
+      )
     };
 
     if let Some(per_shot_target_quality_cq) = chunk.tq_cq {
@@ -379,7 +384,7 @@ impl EncodeArgs {
 
           if let Ok(line) = simdutf8::basic::from_utf8_mut(&mut buf) {
             if self.verbosity == Verbosity::Verbose && !line.contains('\n') {
-              update_mp_msg(worker_id, (*line).to_string());
+              update_mp_msg(worker_id, line.trim().to_string());
             }
             // This needs to be done before parse_encoded_frames, as it potentially
             // mutates the string


### PR DESCRIPTION
By passing the frame count for the chunk to the encoder, we can allow the encoder to show an improved progress bar for each chunk in verbose mode.