### PR TITLE
Fix panic in parse_aom_vpx_frames_sse41()

### DIFF
--- a/av1an-core/src/parse.rs
+++ b/av1an-core/src/parse.rs
@@ -158,7 +158,11 @@ pub unsafe fn parse_aom_vpx_frames_sse41(s: &[u8]) -> Option<u64> {
   };
 
   let ascending = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-  let num_digits = first_space_index - first_digit_index;
+  let num_digits = match first_space_index.checked_sub(first_digit_index) {
+    Some(nd) => nd,
+    None => return None,
+  };
+
   let dynamic_mask = _mm_cmplt_epi8(ascending, _mm_set1_epi8(num_digits as i8));
 
   // At this point, we have done all the setup and can use the actual SIMD integer


### PR DESCRIPTION
On some rare inputs (that can happen in real world scenarios), this function panics. This PR fixes that issue. I have also fuzzed this function and the fallback `parse_aom_vpx_frames` and no other obvious panics or crashes seem to happen in debug mode, at least on the randomized inputs used in fuzzing.