### PR TITLE
0.4.0 nvenc ffmpeg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "av1an-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "av1an-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "affinity",
  "ansi_term",

--- a/av1an-cli/Cargo.toml
+++ b/av1an-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av1an-cli"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Zen <master_of_zen@protonmail.com>"]
 description = """
 Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding [Command line library]
@@ -22,7 +22,7 @@ clap = { version = "3.0.0", features = ["derive"] }
 shlex = "1.0.0"
 path_abs = "0.5.1"
 anyhow = "1.0.42"
-av1an-core = { path = "../av1an-core", version = "0.3.1" }
+av1an-core = { path = "../av1an-core", version = "0.4" }
 thiserror = "1.0.30"
 once_cell = "1.8.0"
 ansi_term = "0.12.1"

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av1an-core"
-version = "0.3.2"
+version = "0.4.0"
 rust-version = "1.63"
 edition = "2021"
 authors = ["Zen <master_of_zen@protonmail.com>"]


### PR DESCRIPTION
INFO [av1an_core::Settings] AV1AN: V.4.0
INFO [av1an_core::settings] Input: 1280x536 @ 23.976 fps, YUV420P, SDR
INFO [av1an_core::Settings] Queue: 1355 ,Workers: 4 ,Passes 1 ,Codec: h264_nvenc
INFO [av1an_core::Settings] VMAF CODEC:NVENC,SCALLING:CUDA
INFO [av1an_core::Settings] TARGET VMAF:Some(95.3)
INFO [av1an_core::Settings] OUTPUT_SCALE:"960:-2"
INFO [av1an_core::Settings] CHUNK_METHOD:Segment
00:11:29 ▕███████████▍                ▏  41%  95308/232056 (fps=138.14,speed=5.78x, eta 16m, 2735.9 Kbps, est. 3.19 GiB)