### PR TITLE
Upgrade ffmpeg-the-third to fix static builds

### DIFF
--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -63,7 +63,7 @@ features = ["const_generics", "const_new", "union"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-the-third"
-version = "1.1.1"
+version = "1.1.2"
 features = ["serialize"]
 
 [dependencies.plotters]

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -40,7 +40,7 @@ features = ["git", "build", "rustc", "cargo"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-the-third"
-version = "1.1.1"
+version = "1.1.2"
 features = ["serialize"]
 
 [features]


### PR DESCRIPTION
The recent updates to the ffmpeg dependencies broke the `ffmpeg_static` feature to request linking against a static build of ffmpeg due to an upstream change in how the ffmpeg repo tagged releases: https://github.com/shssoichiro/ffmpeg-the-third/pull/3

ffmpeg-the-third v1.1.2 includes the needed fix to get static ffmpeg builds to work again.