### PR TITLE
Upgrade `ffmpeg-the-third` and its transitive dependencies to fix static builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "1.0.0+ffmpeg-5.1.2"
+version = "1.0.2+ffmpeg-5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e277227232a15bced1b4c9c1a7b56d5f4aadfd6dd15697c530f0c28c8bc625"
+checksum = "aba6e39e3bb60cc687e4be01ad5eefa1e42505f0b220c267e0e2c3d83280f642"
 dependencies = [
  "bindgen",
  "cc",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -63,7 +63,7 @@ features = ["const_generics", "const_new", "union"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-the-third"
-version = "1.1.1"
+version = "1.1.2"
 features = ["serialize"]
 
 [dependencies.plotters]

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -40,7 +40,7 @@ features = ["git", "build", "rustc", "cargo"]
 
 [dependencies.ffmpeg]
 package = "ffmpeg-the-third"
-version = "1.1.1"
+version = "1.1.2"
 features = ["serialize"]
 
 [features]


### PR DESCRIPTION
The recent updates to the ffmpeg dependencies broke the `ffmpeg_static` feature to request linking against a static build of ffmpeg due to an upstream change in how the ffmpeg repo tagged releases [0].

v1.0.2 of the transitive ffmpeg-sys-the-third dependency includes the needed fix to get static ffmpeg builds to work again (at all) as well as to get static builds working on clang 16 [1].

\[0]: https://github.com/shssoichiro/ffmpeg-the-third/pull/3
\[1]: https://github.com/shssoichiro/ffmpeg-the-third/pull/5