### PR TITLE
Add a comment to the format method to clarify this refers to the video format

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -492,6 +492,7 @@ impl Encoder {
     }
   }
 
+  /// Get the name of the video format associated with the encoder
   pub const fn format(self) -> &'static str {
     match self {
       Self::aom | Self::rav1e | Self::svt_av1 => "av1",


### PR DESCRIPTION
Because at least one user thought `format` was being used as a verb in this method name, and I can see how that can be somewhat confusing.