### PR TITLE
Action: Tag latest, update versions, add docker-publish checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,10 +238,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -253,7 +253,7 @@ jobs:
 
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
@@ -270,30 +270,51 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  # Job to output if docker-publish should run or not based on if DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are set
+  publish-check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.publish_check.outputs.should_publish }}
+    steps:
+      - name: Check for DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
+        id: publish_check
+        run: |
+          if [ -z ${{ secrets.DOCKERHUB_USERNAME }} ] || [ -z ${{ secrets.DOCKERHUB_TOKEN }} ]; then
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
 
   docker-publish:
-    needs: [all-tests, docker]
+    needs: [all-tests, docker, publish-check]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: needs.publish-check.outputs.should_publish == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+
+        uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/av1an # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/av1an
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -308,7 +329,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Addresses #733 

This will update the latest tag on dockerhub when a release is published, it will also create sha images on all branches and will create a branch specific release for testing new features 
Adds version tags with major/major.minor tags
Updates the github action versions
Adds docker-publish step that will check for the dockerhub username and token secrets so docker-publish will only run if those are present
