### PR TITLE
Action: Test target-quality is working correctly.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,14 @@ jobs:
           target/ci/av1an -i tt_sif.y4m -e x264 --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --preset ultrafast" --chunk-method select
           du -h tt_sif.mkv
 
+      - name: Testing target-quality
+        run: |
+          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -v " --preset ultrafast" --target-quality 95 -o "95.mkv" --log-file 95
+          target/ci/av1an -i tt_sif.y4m -e x265 --pix-format yuv420p -c mkvmerge --sc-method fast -y -v " --preset ultrafast" --target-quality 80 -o "80.mkv" --log-file 80
+          du -h 95.mkv 80.mkv
+          # compare the size of the two files to make sure 95.mkv is larger than 80.mkv
+          if [ $(stat -c%s "95.mkv") -gt $(stat -c%s "80.mkv") ]; then echo "Target quality is working correctly"; else echo "95.mkv is smaller than 80.mkv"; cat 95.log 80.log; exit 1; fi
+
       - name: Testing target-quality aom
         run: |
           target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p --sc-method fast -y -o "tt_sif.mkv" -v " --cpu-used=10 --rt --threads=4" --target-quality 95


### PR DESCRIPTION
Addresses #719 

Adds a test to make sure target-quality is actually working by encoding at a target of 95 and 80 and then comparing to make sure the 95 version is bigger than the 80. In the event that it does fail it will also cat the log files to make sure so the developers can see what is happening and adjust the test or fix the issue if there is one. 

In this case we can see that there is no vmaf comparison happening and av1an is just doing a normal chunk encoding thus the two 95 and 80 are exactly the same size and is validated by the logs.