### PR TITLE
Move audio size to progress bar OnceCell

### DIFF
--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -29,6 +29,15 @@ const INDICATIF_SPINNER_TEMPLATE: &str = if cfg!(windows) {
 };
 
 static PROGRESS_BAR: OnceCell<ProgressBar> = OnceCell::new();
+static AUDIO_BYTES: OnceCell<u64> = OnceCell::new();
+
+pub fn set_audio_size(val: u64) {
+  AUDIO_BYTES.get_or_init(|| val);
+}
+
+pub fn get_audio_size() -> u64 {
+  *AUDIO_BYTES.get().unwrap_or(&0u64)
+}
 
 pub fn get_progress_bar() -> Option<&'static ProgressBar> {
   PROGRESS_BAR.get()
@@ -273,12 +282,7 @@ pub fn finish_multi_progress_bar() {
   }
 }
 
-pub fn update_progress_bar_estimates(
-  frame_rate: f64,
-  total_frames: usize,
-  verbosity: Verbosity,
-  audio_size: u64,
-) {
+pub fn update_progress_bar_estimates(frame_rate: f64, total_frames: usize, verbosity: Verbosity) {
   let completed_frames: usize = get_done()
     .done
     .iter()
@@ -292,7 +296,10 @@ pub fn update_progress_bar_estimates(
   let seconds_completed = completed_frames as f64 / frame_rate;
   let kbps = total_size as f64 * 8. / 1000. / seconds_completed;
   let progress = completed_frames as f64 / total_frames as f64;
-  let est_size = total_size as f64 / progress + audio_size as f64;
+
+  let audio_size_byte = get_audio_size();
+
+  let est_size = total_size as f64 / progress + audio_size_byte as f64;
   if verbosity == Verbosity::Normal {
     update_bar_info(kbps, HumanBytes(est_size as u64));
   } else if verbosity == Verbosity::Verbose {


### PR DESCRIPTION
This removes passing of audio_byte through functions and instead use functions from progress bar module to set and get static audio size bytes