### PR TITLE
Fix rustc 1.71 clippy lints

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -13,7 +13,6 @@
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::wildcard_imports)]
-#![allow(clippy::drop_ref)]
 #![allow(clippy::unsafe_derive_deserialize)]
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::use_self)]

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -42,11 +42,8 @@ impl TargetQuality {
     let mut vmaf_cq = vec![];
     let frames = chunk.frames();
 
-    let mut q_list = vec![];
-
     // Make middle probe
     let middle_point = (self.min_q + self.max_q) / 2;
-    q_list.push(middle_point);
     let last_q = middle_point;
 
     let mut score =
@@ -65,8 +62,6 @@ impl TargetQuality {
     } else {
       self.max_q
     };
-
-    q_list.push(next_q);
 
     // Edge case check
     score = read_weighted_vmaf(self.vmaf_probe(chunk, next_q as usize)?, VMAF_PERCENTILE).unwrap();
@@ -118,7 +113,6 @@ impl TargetQuality {
         break;
       }
 
-      q_list.push(new_point as u32);
       score = read_weighted_vmaf(self.vmaf_probe(chunk, new_point)?, VMAF_PERCENTILE).unwrap();
       vmaf_cq.push((score, new_point as u32));
 


### PR DESCRIPTION
- Remove an allow for a lint that was merged into core
- Remove a vec which was written to but never read