### PR TITLE
Add DGDecNV and BestSource chunk method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Prerequisites:
 Optional:
 
 - [L-SMASH](https://github.com/AkarinVS/L-SMASH-Works) VapourSynth plugin for better chunking (recommended)
+- [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) Vapoursynth plugin for very fast and accurate chunking, `dgindexnv` executable needs to be present in system path and an NVIDIA GPU with CUVID 
 - [ffms2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
-- [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) Vapoursynth plugin, `dgindexnv` executable present in system path, and an NVIDIA GPU for very fast chunking
+- [bestsource](https://github.com/vapoursynth/bestsource) Vapoursynth plugin for slow but accurate chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF scores and to use [target quality mode](docs/TargetQuality.md)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Optional:
 
 - [L-SMASH](https://github.com/AkarinVS/L-SMASH-Works) VapourSynth plugin for better chunking (recommended)
 - [ffms2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
+- [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) Vapoursynth plugin, `dgindexnv` executable present in system path, and an NVIDIA GPU for very fast chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF scores and to use [target quality mode](docs/TargetQuality.md)
 

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -148,7 +148,7 @@ impl Av1anContext {
         // generated when vspipe is first called), so it's not worth adding all the extra complexity.
         if (self.args.input.is_vapoursynth()
             || (self.args.input.is_video()
-            && matches!(self.args.chunk_method, ChunkMethod::LSMASH | ChunkMethod::FFMS2)))
+            && matches!(self.args.chunk_method, ChunkMethod::LSMASH | ChunkMethod::FFMS2 | ChunkMethod::DGDECNV | ChunkMethod::BESTSOURCE)))
             && !self.args.resume
         {
           self.vs_script = Some(match &self.args.input {
@@ -671,7 +671,7 @@ impl Av1anContext {
   fn create_encoding_queue(&mut self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
     let mut chunks = match &self.args.input {
       Input::Video(_) => match self.args.chunk_method {
-        ChunkMethod::FFMS2 | ChunkMethod::LSMASH => {
+        ChunkMethod::FFMS2 | ChunkMethod::LSMASH | ChunkMethod::DGDECNV | ChunkMethod::BESTSOURCE => {
           let vs_script = self.vs_script.as_ref().unwrap().as_path();
           self.create_video_queue_vs(scenes, vs_script)
         }

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -671,7 +671,10 @@ impl Av1anContext {
   fn create_encoding_queue(&mut self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
     let mut chunks = match &self.args.input {
       Input::Video(_) => match self.args.chunk_method {
-        ChunkMethod::FFMS2 | ChunkMethod::LSMASH | ChunkMethod::DGDECNV | ChunkMethod::BESTSOURCE => {
+        ChunkMethod::FFMS2
+        | ChunkMethod::LSMASH
+        | ChunkMethod::DGDECNV
+        | ChunkMethod::BESTSOURCE => {
           let vs_script = self.vs_script.as_ref().unwrap().as_path();
           self.create_video_queue_vs(scenes, vs_script)
         }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -305,6 +305,10 @@ pub enum ChunkMethod {
   FFMS2,
   #[strum(serialize = "lsmash")]
   LSMASH,
+  #[strum(serialize = "dgdecnv")]
+  DGDECNV,
+  #[strum(serialize = "bestsource")]
+  BESTSOURCE,
 }
 
 #[derive(

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -13,7 +13,9 @@ use crate::concat::ConcatMethod;
 use crate::encoder::Encoder;
 use crate::parse::valid_params;
 use crate::target_quality::TargetQuality;
-use crate::vapoursynth::{is_ffms2_installed, is_lsmash_installed, is_dgdecnv_installed, is_bestsource_installed};
+use crate::vapoursynth::{
+  is_bestsource_installed, is_dgdecnv_installed, is_ffms2_installed, is_lsmash_installed,
+};
 use crate::vmaf::validate_libvmaf;
 use crate::{ChunkMethod, ChunkOrdering, Input, ScenecutMethod, SplitMethod, Verbosity};
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -13,7 +13,7 @@ use crate::concat::ConcatMethod;
 use crate::encoder::Encoder;
 use crate::parse::valid_params;
 use crate::target_quality::TargetQuality;
-use crate::vapoursynth::{is_ffms2_installed, is_lsmash_installed};
+use crate::vapoursynth::{is_ffms2_installed, is_lsmash_installed, is_dgdecnv_installed, is_bestsource_installed};
 use crate::vmaf::validate_libvmaf;
 use crate::{ChunkMethod, ChunkOrdering, Input, ScenecutMethod, SplitMethod, Verbosity};
 
@@ -123,6 +123,18 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       ensure!(
         is_ffms2_installed(),
         "FFMS2 is not installed, but it was specified as the chunk method"
+      );
+    }
+    if self.chunk_method == ChunkMethod::DGDECNV && which::which("dgindexnv").is_err() {
+      ensure!(
+        is_dgdecnv_installed(),
+        "Either DGDecNV is not installed or DGIndexNV is not in system path, but it was specified as the chunk method"
+      );
+    }
+    if self.chunk_method == ChunkMethod::BESTSOURCE {
+      ensure!(
+        is_bestsource_installed(),
+        "BestSource is not installed, but it was specified as the chunk method"
       );
     }
     if self.chunk_method == ChunkMethod::Select {

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -61,12 +61,12 @@ pub fn is_bestsource_installed() -> bool {
 }
 
 pub fn best_available_chunk_method() -> ChunkMethod {
-  if is_dgdecnv_installed() {
-    ChunkMethod::DGDECNV
-  } else if is_lsmash_installed() {
+  if is_lsmash_installed() {
     ChunkMethod::LSMASH
   } else if is_ffms2_installed() {
     ChunkMethod::FFMS2
+  } else if is_dgdecnv_installed() {
+    ChunkMethod::DGDECNV
   } else if is_bestsource_installed() {
     ChunkMethod::BESTSOURCE
   } else {

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -6,12 +6,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail};
 use once_cell::sync::Lazy;
 use path_abs::PathAbs;
+use std::process::Command;
 use vapoursynth::prelude::*;
 use vapoursynth::video_info::VideoInfo;
-use std::process::Command;
 
 use super::ChunkMethod;
-
 
 static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
   let environment = Environment::new().expect("Failed to initialize VapourSynth environment");
@@ -66,9 +65,9 @@ pub fn best_available_chunk_method() -> ChunkMethod {
     ChunkMethod::DGDECNV
   } else if is_lsmash_installed() {
     ChunkMethod::LSMASH
-  } else if is_ffms2_installed(){
+  } else if is_ffms2_installed() {
     ChunkMethod::FFMS2
-  } else if is_bestsource_installed(){
+  } else if is_bestsource_installed() {
     ChunkMethod::BESTSOURCE
   } else {
     ChunkMethod::Hybrid
@@ -201,75 +200,69 @@ pub fn create_vs_file(
   let mut load_script = File::create(&load_script_path)?;
 
   let cache_file = PathAbs::new(temp.join("split").join(format!(
-      "cache.{}",
-      match chunk_method {
-          ChunkMethod::FFMS2 => "ffindex",
-          ChunkMethod::LSMASH => "lwi",
-          ChunkMethod::DGDECNV => "dgi",
-          ChunkMethod::BESTSOURCE => "json",
-          _ => return Err(anyhow!("invalid chunk method")),
-      }
+    "cache.{}",
+    match chunk_method {
+      ChunkMethod::FFMS2 => "ffindex",
+      ChunkMethod::LSMASH => "lwi",
+      ChunkMethod::DGDECNV => "dgi",
+      ChunkMethod::BESTSOURCE => "json",
+      _ => return Err(anyhow!("invalid chunk method")),
+    }
   )))?;
 
   if chunk_method == ChunkMethod::DGDECNV {
+    // Run dgindexnv to generate the .dgi index file
+    let dgindexnv_output = temp.join("split").join("index.dgi");
 
-      // Run dgindexnv to generate the .dgi index file
-      let dgindexnv_output = temp.join("split").join("index.dgi");
+    Command::new("dgindexnv")
+      .arg("-h")
+      .arg("-i")
+      .arg(source)
+      .arg("-o")
+      .arg(&dgindexnv_output)
+      .output()?;
 
-      Command::new("dgindexnv")
-          .arg("-h")
-          .arg("-i")
-          .arg(source)
-          .arg("-o")
-          .arg(&dgindexnv_output)
-          .output()?;
-      
-      let dgindex_path = dgindexnv_output
-      .canonicalize()?;
-      load_script.write_all(
-          format!(
-              "from vapoursynth import core\n\
-              core.max_cache_size=1024\n\
-            core.dgdecodenv.DGSource(source={:?}).set_output()",
-              dgindex_path
-          )
-          .as_bytes(),
-      )?;
-    }
-  else if chunk_method == ChunkMethod::BESTSOURCE {
+    let dgindex_path = dgindexnv_output.canonicalize()?;
     load_script.write_all(
       format!(
-          "from vapoursynth import core\n\
-          core.max_cache_size=1024\n\
-        core.bs.VideoSource({:?}, cachepath={:?}).set_output()",
-          source,
-          cache_file
+        "from vapoursynth import core\n\
+              core.max_cache_size=1024\n\
+            core.dgdecodenv.DGSource(source={:?}).set_output()",
+        dgindex_path
       )
       .as_bytes(),
-  )?;
-  }
-  else {
-      load_script.write_all(
-          // TODO should probably check if the syntax for rust strings and escaping utf and stuff like that is the same as in python
-          format!(
-            "from vapoursynth import core\n\
+    )?;
+  } else if chunk_method == ChunkMethod::BESTSOURCE {
+    load_script.write_all(
+      format!(
+        "from vapoursynth import core\n\
+          core.max_cache_size=1024\n\
+        core.bs.VideoSource({:?}, cachepath={:?}).set_output()",
+        source, cache_file
+      )
+      .as_bytes(),
+    )?;
+  } else {
+    load_script.write_all(
+      // TODO should probably check if the syntax for rust strings and escaping utf and stuff like that is the same as in python
+      format!(
+        "from vapoursynth import core\n\
             core.max_cache_size=1024\n\
       core.{}({:?}, cachefile={:?}).set_output()",
-            match chunk_method {
-              ChunkMethod::FFMS2 => "ffms2.Source",
-              ChunkMethod::LSMASH => "lsmas.LWLibavSource",
-              _ => unreachable!(),
-              },
-              source,
-              cache_file
-          )
-          .as_bytes(),
-      )?;
+        match chunk_method {
+          ChunkMethod::FFMS2 => "ffms2.Source",
+          ChunkMethod::LSMASH => "lsmas.LWLibavSource",
+          _ => unreachable!(),
+        },
+        source,
+        cache_file
+      )
+      .as_bytes(),
+    )?;
   }
 
   Ok(load_script_path)
 }
-
 
 pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
   // Create a new VSScript environment.

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -8,8 +8,10 @@ use once_cell::sync::Lazy;
 use path_abs::PathAbs;
 use vapoursynth::prelude::*;
 use vapoursynth::video_info::VideoInfo;
+use std::process::Command;
 
 use super::ChunkMethod;
+
 
 static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
   let environment = Environment::new().expect("Failed to initialize VapourSynth environment");
@@ -45,11 +47,29 @@ pub fn is_ffms2_installed() -> bool {
   *FFMS2_PRESENT
 }
 
+pub fn is_dgdecnv_installed() -> bool {
+  static DGDECNV_PRESENT: Lazy<bool> =
+    Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.dgdecodenv"));
+
+  *DGDECNV_PRESENT
+}
+
+pub fn is_bestsource_installed() -> bool {
+  static BESTSOURCE_PRESENT: Lazy<bool> =
+    Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.bestsource"));
+
+  *BESTSOURCE_PRESENT
+}
+
 pub fn best_available_chunk_method() -> ChunkMethod {
-  if is_lsmash_installed() {
+  if is_dgdecnv_installed() {
+    ChunkMethod::DGDECNV
+  } else if is_lsmash_installed() {
     ChunkMethod::LSMASH
-  } else if is_ffms2_installed() {
+  } else if is_ffms2_installed(){
     ChunkMethod::FFMS2
+  } else if is_bestsource_installed(){
+    ChunkMethod::BESTSOURCE
   } else {
     ChunkMethod::Hybrid
   }
@@ -181,33 +201,74 @@ pub fn create_vs_file(
   let mut load_script = File::create(&load_script_path)?;
 
   let cache_file = PathAbs::new(temp.join("split").join(format!(
-    "cache.{}",
-    match chunk_method {
-      ChunkMethod::FFMS2 => "ffindex",
-      ChunkMethod::LSMASH => "lwi",
-      _ => return Err(anyhow!("invalid chunk method")),
-    }
+      "cache.{}",
+      match chunk_method {
+          ChunkMethod::FFMS2 => "ffindex",
+          ChunkMethod::LSMASH => "lwi",
+          ChunkMethod::DGDECNV => "dgi",
+          ChunkMethod::BESTSOURCE => "json",
+          _ => return Err(anyhow!("invalid chunk method")),
+      }
   )))?;
 
-  load_script.write_all(
-    // TODO should probably check if the syntax for rust strings and escaping utf and stuff like that is the same as in python
-    format!(
-      "from vapoursynth import core\n\
-      core.max_cache_size=1024\n\
-core.{}({:?}, cachefile={:?}).set_output()",
-      match chunk_method {
-        ChunkMethod::FFMS2 => "ffms2.Source",
-        ChunkMethod::LSMASH => "lsmas.LWLibavSource",
-        _ => unreachable!(),
-      },
-      source,
-      cache_file
-    )
-    .as_bytes(),
+  if chunk_method == ChunkMethod::DGDECNV {
+
+      // Run dgindexnv to generate the .dgi index file
+      let dgindexnv_output = temp.join("split").join("index.dgi");
+
+      Command::new("dgindexnv")
+          .arg("-h")
+          .arg("-i")
+          .arg(source)
+          .arg("-o")
+          .arg(&dgindexnv_output)
+          .output()?;
+      
+      let dgindex_path = dgindexnv_output
+      .canonicalize()?;
+      load_script.write_all(
+          format!(
+              "from vapoursynth import core\n\
+              core.max_cache_size=1024\n\
+            core.dgdecodenv.DGSource(source={:?}).set_output()",
+              dgindex_path
+          )
+          .as_bytes(),
+      )?;
+    }
+  else if chunk_method == ChunkMethod::BESTSOURCE {
+    load_script.write_all(
+      format!(
+          "from vapoursynth import core\n\
+          core.max_cache_size=1024\n\
+        core.bs.VideoSource({:?}, cachepath={:?}).set_output()",
+          source,
+          cache_file
+      )
+      .as_bytes(),
   )?;
+  }
+  else {
+      load_script.write_all(
+          format!(
+            "from vapoursynth import core\n\
+            core.max_cache_size=1024\n\
+      core.{}({:?}, cachefile={:?}).set_output()",
+            match chunk_method {
+              ChunkMethod::FFMS2 => "ffms2.Source",
+              ChunkMethod::LSMASH => "lsmas.LWLibavSource",
+              _ => unreachable!(),
+              },
+              source,
+              cache_file
+          )
+          .as_bytes(),
+      )?;
+  }
 
   Ok(load_script_path)
 }
+
 
 pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
   // Create a new VSScript environment.

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -250,6 +250,7 @@ pub fn create_vs_file(
   }
   else {
       load_script.write_all(
+          // TODO should probably check if the syntax for rust strings and escaping utf and stuff like that is the same as in python
           format!(
             "from vapoursynth import core\n\
             core.max_cache_size=1024\n\

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -43,9 +43,13 @@ fn version() -> &'static str {
       "\
 * VapourSynth Plugins
   systems.innocent.lsmas : {}
-  com.vapoursynth.ffms2  : {}",
+  com.vapoursynth.ffms2  : {}
+  com.vapoursynth.dgdecodenv : {}
+  com.vapoursynth.bestsource : {}",
       isfound(vapoursynth::is_lsmash_installed()),
-      isfound(vapoursynth::is_ffms2_installed())
+      isfound(vapoursynth::is_ffms2_installed()),
+      isfound(vapoursynth::is_dgdecnv_installed()),
+      isfound(vapoursynth::is_bestsource_installed())
     )
   }
 
@@ -332,6 +336,14 @@ pub struct CliOpts {
   /// cause artifacts in the piped output). Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to be
   /// installed.
   ///
+  /// dgdecnv - Very fast and accurate, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
+	///	Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
+  /// to be installed. 
+  /// 
+  /// bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv 
+  /// if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin 
+  /// to be installed.
+  /// 
   /// Methods that only require ffmpeg:
   ///
   /// hybrid - Uses a combination of segment and select. Usually accurate but requires intermediate files (which can be large). Avoids
@@ -344,7 +356,7 @@ pub struct CliOpts {
   /// segment - Create chunks based on keyframes in the source. Not frame exact, as it can only split on keyframes in the source.
   /// Requires intermediate files (which can be large).
   ///
-  /// Default: lsmash (if available), otherwise ffms2 (if available), otherwise hybrid.
+  /// Default: DGDecNV (if available), lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
   #[clap(short = 'm', long, help_heading = "Encoding")]
   pub chunk_method: Option<ChunkMethod>,
 

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -336,14 +336,14 @@ pub struct CliOpts {
   /// cause artifacts in the piped output). Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to be
   /// installed.
   ///
-  /// dgdecnv - Very fast and accurate, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
-	///	Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
-  /// to be installed. 
-  /// 
-  /// bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv 
-  /// if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin 
+  /// dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
+  ///	Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
   /// to be installed.
-  /// 
+  ///
+  /// bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv
+  /// if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin
+  /// to be installed.
+  ///
   /// Methods that only require ffmpeg:
   ///
   /// hybrid - Uses a combination of segment and select. Usually accurate but requires intermediate files (which can be large). Avoids

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -340,8 +340,7 @@ pub struct CliOpts {
   ///	Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
   /// to be installed.
   ///
-  /// bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv
-  /// if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin
+  /// bestsource - Very slow but accurate. Linearly decodes input files, very slow. Does not require intermediate files, requires the BestSource vapoursynth plugin
   /// to be installed.
   ///
   /// Methods that only require ffmpeg:
@@ -356,7 +355,7 @@ pub struct CliOpts {
   /// segment - Create chunks based on keyframes in the source. Not frame exact, as it can only split on keyframes in the source.
   /// Requires intermediate files (which can be large).
   ///
-  /// Default: DGDecNV (if available), lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
+  /// Default: lsmash (if available), otherwise ffms2 (if available), otherwise DGDecNV (if available), otherwise bestsource (if available), otherwise hybrid.
   #[clap(short = 'm', long, help_heading = "Encoding")]
   pub chunk_method: Option<ChunkMethod>,
 

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -337,7 +337,7 @@ pub struct CliOpts {
   /// installed.
   ///
   /// dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
-  ///	Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
+  /// Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
   /// to be installed.
   ///
   /// bestsource - Very slow but accurate. Linearly decodes input files, very slow. Does not require intermediate files, requires the BestSource vapoursynth plugin

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -239,7 +239,7 @@
 		Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to
 		be installed.
 
-        dgdecnv - Very fast and accurate, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
+        dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
 	    Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
         to be installed.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -243,8 +243,7 @@
 	    Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
         to be installed.
 
-	    bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv 
-        if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin 
+	    bestsource - Very slow but accurate. Linearly decodes input files. Does not require intermediate files, requires the BestSource vapoursynth plugin 
         to be installed.
 		
 		Methods that only require ffmpeg:
@@ -261,7 +260,7 @@
 		segment - Create chunks based on keyframes in the source. Not frame exact, as it can
 		only split on keyframes in the source. Requires intermediate files (which can be large).
 		
-		Default: DGDecNV (if available), lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
+		Default: lsmash (if available), otherwise ffms2 (if available), otherwise DGDecNV (if available), otherwise bestsource (if available), otherwise hybrid.
 		
 		[possible values: segment, select, ffms2, lsmash, dgdecnv, bestsource, hybrid]
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -238,6 +238,14 @@
 		bugs that are not present in lsmash (that can cause artifacts in the piped output).
 		Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to
 		be installed.
+
+        dgdecnv - Very fast and accurate, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
+	    Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
+        to be installed.
+
+	    bestsource - Slow but accurate. Linearly decodes input files with a few tricks to make it faster. Good alternative to dgdecnv 
+        if you don't have an NVIDIA GPU with CUVID. Does not require intermediate files, requires the BestSource vapoursynth plugin 
+        to be installed.
 		
 		Methods that only require ffmpeg:
 		
@@ -253,9 +261,9 @@
 		segment - Create chunks based on keyframes in the source. Not frame exact, as it can
 		only split on keyframes in the source. Requires intermediate files (which can be large).
 		
-		Default: lsmash (if available), otherwise ffms2 (if available), otherwise hybrid.
+		Default: DGDecNV (if available), lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
 		
-		[possible values: segment, select, ffms2, lsmash, hybrid]
+		[possible values: segment, select, ffms2, lsmash, dgdecnv, bestsource, hybrid]
 
 	--chunk-order <CHUNK_ORDER>
 		The order in which av1an will encode chunks


### PR DESCRIPTION
As the title suggests, adds two new chunking methods to Av1an.

The docs is a bit general and could be worked on a bit since I don't really want to say anything that could be misinformation about the technical details. The current chunk method order now is: DGDecNV > lsmash > ffms2 > bestsource > hybrid

[DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) requires an external program called "dgindexnv" to index the video first, though its [already bundled](https://www.rationalqm.us/dgdecnv/binaries/) with the binaries and plugins itself provided, and as the name suggests, it requires an NVIDIA GPU. Which also requires PureVideo, but that's ancient technology so everyone should have it anyway. And only decodes AVC/HEVC/MPG/VC-1.

BestSource is similar to select, its slow but should decode everything

 
and from my observation and testing, both methods successfully "resolve" #745 
here's a test clip where gray frames keep appearing: [https://cdn.discordapp.com/attachments/587033245061873759/1126937326333997076/CutJJBA1-7.mkv](https://cdn.discordapp.com/attachments/587033245061873759/1126937326333997076/CutJJBA1-7.mkv)

