### PR TITLE
Remove support for DgDecNv

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Prerequisites:
 Optional:
 
 - [L-SMASH](https://github.com/AkarinVS/L-SMASH-Works) VapourSynth plugin for better chunking (recommended)
-- [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) Vapoursynth plugin for very fast and accurate chunking, `dgindexnv` executable needs to be present in system path and an NVIDIA GPU with CUVID 
 - [ffms2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
 - [bestsource](https://github.com/vapoursynth/bestsource) Vapoursynth plugin for slow but accurate chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -147,7 +147,7 @@ impl Av1anContext {
         // generated when vspipe is first called), so it's not worth adding all the extra complexity.
         if (self.args.input.is_vapoursynth()
             || (self.args.input.is_video()
-            && matches!(self.args.chunk_method, ChunkMethod::LSMASH | ChunkMethod::FFMS2 | ChunkMethod::DGDECNV | ChunkMethod::BESTSOURCE)))
+            && matches!(self.args.chunk_method, ChunkMethod::LSMASH | ChunkMethod::FFMS2 | ChunkMethod::BESTSOURCE)))
             && !self.args.resume
         {
           self.vs_script = Some(match &self.args.input {
@@ -665,10 +665,7 @@ impl Av1anContext {
   fn create_encoding_queue(&mut self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
     let mut chunks = match &self.args.input {
       Input::Video(_) => match self.args.chunk_method {
-        ChunkMethod::FFMS2
-        | ChunkMethod::LSMASH
-        | ChunkMethod::DGDECNV
-        | ChunkMethod::BESTSOURCE => {
+        ChunkMethod::FFMS2 | ChunkMethod::LSMASH | ChunkMethod::BESTSOURCE => {
           let vs_script = self.vs_script.as_ref().unwrap().as_path();
           self.create_video_queue_vs(scenes, vs_script)
         }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -305,8 +305,6 @@ pub enum ChunkMethod {
   FFMS2,
   #[strum(serialize = "lsmash")]
   LSMASH,
-  #[strum(serialize = "dgdecnv")]
-  DGDECNV,
   #[strum(serialize = "bestsource")]
   BESTSOURCE,
 }

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -13,9 +13,7 @@ use crate::concat::ConcatMethod;
 use crate::encoder::Encoder;
 use crate::parse::valid_params;
 use crate::target_quality::TargetQuality;
-use crate::vapoursynth::{
-  is_bestsource_installed, is_dgdecnv_installed, is_ffms2_installed, is_lsmash_installed,
-};
+use crate::vapoursynth::{is_bestsource_installed, is_ffms2_installed, is_lsmash_installed};
 use crate::vmaf::validate_libvmaf;
 use crate::{ChunkMethod, ChunkOrdering, Input, ScenecutMethod, SplitMethod, Verbosity};
 
@@ -125,12 +123,6 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       ensure!(
         is_ffms2_installed(),
         "FFMS2 is not installed, but it was specified as the chunk method"
-      );
-    }
-    if self.chunk_method == ChunkMethod::DGDECNV && which::which("dgindexnv").is_err() {
-      ensure!(
-        is_dgdecnv_installed(),
-        "Either DGDecNV is not installed or DGIndexNV is not in system path, but it was specified as the chunk method"
       );
     }
     if self.chunk_method == ChunkMethod::BESTSOURCE {

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -44,11 +44,9 @@ fn version() -> &'static str {
 * VapourSynth Plugins
   systems.innocent.lsmas : {}
   com.vapoursynth.ffms2  : {}
-  com.vapoursynth.dgdecodenv : {}
   com.vapoursynth.bestsource : {}",
       isfound(vapoursynth::is_lsmash_installed()),
       isfound(vapoursynth::is_ffms2_installed()),
-      isfound(vapoursynth::is_dgdecnv_installed()),
       isfound(vapoursynth::is_bestsource_installed())
     )
   }
@@ -336,10 +334,6 @@ pub struct CliOpts {
   /// cause artifacts in the piped output). Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to be
   /// installed.
   ///
-  /// dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
-  /// Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
-  /// to be installed.
-  ///
   /// bestsource - Very slow but accurate. Linearly decodes input files, very slow. Does not require intermediate files, requires the BestSource vapoursynth plugin
   /// to be installed.
   ///
@@ -355,7 +349,7 @@ pub struct CliOpts {
   /// segment - Create chunks based on keyframes in the source. Not frame exact, as it can only split on keyframes in the source.
   /// Requires intermediate files (which can be large).
   ///
-  /// Default: lsmash (if available), otherwise ffms2 (if available), otherwise DGDecNV (if available), otherwise bestsource (if available), otherwise hybrid.
+  /// Default: lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
   #[clap(short = 'm', long, help_heading = "Encoding")]
   pub chunk_method: Option<ChunkMethod>,
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -239,10 +239,6 @@
 		Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to
 		be installed.
 
-        dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
-	    Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin 
-        to be installed.
-
 	    bestsource - Very slow but accurate. Linearly decodes input files. Does not require intermediate files, requires the BestSource vapoursynth plugin 
         to be installed.
 		
@@ -260,9 +256,9 @@
 		segment - Create chunks based on keyframes in the source. Not frame exact, as it can
 		only split on keyframes in the source. Requires intermediate files (which can be large).
 		
-		Default: lsmash (if available), otherwise ffms2 (if available), otherwise DGDecNV (if available), otherwise bestsource (if available), otherwise hybrid.
+		Default: lsmash (if available), otherwise ffms2 (if available), otherwise bestsource (if available), otherwise hybrid.
 		
-		[possible values: segment, select, ffms2, lsmash, dgdecnv, bestsource, hybrid]
+		[possible values: segment, select, ffms2, lsmash, bestsource, hybrid]
 
 	--chunk-order <CHUNK_ORDER>
 		The order in which av1an will encode chunks


### PR DESCRIPTION
Even though av1an does not distribute any binaries or libraries of DgDecNv, Donald A Graft, the author of DgDecNv, believes us to be in violation of the license.

Therefore, this commit removes DgDecNv support.