### PR TITLE
Improve setting default encode parameters

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command, Stdio};
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};
@@ -12,6 +12,7 @@ use std::sync::{mpsc, Arc};
 use std::thread::available_parallelism;
 use std::{cmp, fs, iter, thread};
 
+use ansi_term::{Color, Style};
 use anyhow::{bail, Context};
 use av1_grain::TransferFunction;
 use crossbeam_utils;
@@ -263,14 +264,36 @@ impl Av1anContext {
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 
-      info!(
-        "Queue {} Workers {} Passes {} Encoder {}\nParams: {}",
-        chunk_queue.len(),
-        self.args.workers,
-        self.args.passes,
-        self.args.encoder,
-        self.args.video_params.join(" ")
-      );
+      if std::io::stderr().is_terminal() {
+        eprintln!(
+          "{}{} {} {}{} {} {}{} {} {}{} {}\n{}: {}",
+          Color::Green.bold().paint("Q"),
+          Color::Green.paint("ueue"),
+          Color::Green.bold().paint(format!("{}", chunk_queue.len())),
+          Color::Blue.bold().paint("W"),
+          Color::Blue.paint("orkers"),
+          Color::Blue.bold().paint(format!("{}", self.args.workers)),
+          Color::Purple.bold().paint("E"),
+          Color::Purple.paint("ncoder"),
+          Color::Purple.bold().paint(format!("{}", self.args.encoder)),
+          Color::Purple.bold().paint("P"),
+          Color::Purple.paint("asses"),
+          Color::Purple.bold().paint(format!("{}", self.args.passes)),
+          Style::default().bold().paint("Params"),
+          Style::default()
+            .dimmed()
+            .paint(self.args.video_params.join(" "))
+        );
+      } else {
+        eprintln!(
+          "Queue {} Workers {} Encoder {} Passes {}\nParams: {}",
+          chunk_queue.len(),
+          self.args.workers,
+          self.args.encoder,
+          self.args.passes,
+          self.args.video_params.join(" ")
+        );
+      }
 
       if self.args.verbosity == Verbosity::Normal {
         init_progress_bar(self.frames as u64, initial_frames as u64);

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -432,19 +432,15 @@ impl Av1anContext {
     let video_params = chunk.video_params.clone();
 
     let mut enc_cmd = if chunk.passes == 1 {
-      chunk
-        .encoder
-        .compose_1_1_pass(video_params, chunk.output())
+      chunk.encoder.compose_1_1_pass(video_params, chunk.output())
     } else if current_pass == 1 {
       chunk
         .encoder
         .compose_1_2_pass(video_params, fpf_file.to_str().unwrap())
     } else {
-      chunk.encoder.compose_2_2_pass(
-        video_params,
-        fpf_file.to_str().unwrap(),
-        chunk.output(),
-      )
+      chunk
+        .encoder
+        .compose_2_2_pass(video_params, fpf_file.to_str().unwrap(), chunk.output())
     };
 
     if let Some(per_shot_target_quality_cq) = chunk.tq_cq {

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{IsTerminal, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command, Stdio};
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -260,7 +260,7 @@ impl Av1anContext {
       };
 
       if self.args.workers == 0 {
-        self.args.workers = determine_workers(self.args.encoder) as usize;
+        self.args.workers = determine_workers(self.args.encoder, self.args.input.calculate_tiles(), res) as usize;
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -453,17 +453,16 @@ impl Av1anContext {
     let mut enc_cmd = if chunk.passes == 1 {
       chunk
         .encoder
-        .compose_1_1_pass(video_params, chunk.output(), chunk.frames())
+        .compose_1_1_pass(video_params, chunk.output())
     } else if current_pass == 1 {
       chunk
         .encoder
-        .compose_1_2_pass(video_params, fpf_file.to_str().unwrap(), chunk.frames())
+        .compose_1_2_pass(video_params, fpf_file.to_str().unwrap())
     } else {
       chunk.encoder.compose_2_2_pass(
         video_params,
         fpf_file.to_str().unwrap(),
         chunk.output(),
-        chunk.frames(),
       )
     };
 

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -12,7 +12,6 @@ use std::sync::{mpsc, Arc};
 use std::thread::available_parallelism;
 use std::{cmp, fs, iter, thread};
 
-use ansi_term::{Color, Style};
 use anyhow::{bail, Context};
 use av1_grain::TransferFunction;
 use crossbeam_utils;
@@ -264,32 +263,14 @@ impl Av1anContext {
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 
-      if std::io::stderr().is_terminal() {
-        eprintln!(
-          "{}{} {} {}{} {} {}{} {}\n{}: {}",
-          Color::Green.bold().paint("Q"),
-          Color::Green.paint("ueue"),
-          Color::Green.bold().paint(format!("{}", chunk_queue.len())),
-          Color::Blue.bold().paint("W"),
-          Color::Blue.paint("orkers"),
-          Color::Blue.bold().paint(format!("{}", self.args.workers)),
-          Color::Purple.bold().paint("P"),
-          Color::Purple.paint("asses"),
-          Color::Purple.bold().paint(format!("{}", self.args.passes)),
-          Style::default().bold().paint("Params"),
-          Style::default()
-            .dimmed()
-            .paint(self.args.video_params.join(" "))
-        );
-      } else {
-        eprintln!(
-          "Queue {} Workers {} Passes {}\nParams: {}",
-          chunk_queue.len(),
-          self.args.workers,
-          self.args.passes,
-          self.args.video_params.join(" ")
-        );
-      }
+      info!(
+        "Queue {} Workers {} Passes {} Encoder {}\nParams: {}",
+        chunk_queue.len(),
+        self.args.workers,
+        self.args.passes,
+        self.args.encoder,
+        self.args.video_params.join(" ")
+      );
 
       if self.args.verbosity == Verbosity::Normal {
         init_progress_bar(self.frames as u64, initial_frames as u64);

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -259,7 +259,7 @@ impl Av1anContext {
       };
 
       if self.args.workers == 0 {
-        self.args.workers = determine_workers(self.args.encoder, self.args.input.calculate_tiles(), res) as usize;
+        self.args.workers = determine_workers(&self.args) as usize;
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -398,7 +398,7 @@ impl Encoder {
       }
       Encoder::svt_av1 => {
         let defaults =
-          into_vec!["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25",];
+          into_vec!["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"];
         if cols > 1 || rows > 1 {
           let columns = ilog2(cols);
           let rows = ilog2(rows);

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -105,7 +105,6 @@ impl Encoder {
     self,
     params: Vec<String>,
     output: String,
-    frame_count: usize,
   ) -> Vec<String> {
     match self {
       Self::aom => chain!(
@@ -115,7 +114,7 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array!["rav1e", "-", "-y", "--limit", frame_count.to_string()],
+        into_array!["rav1e", "-", "-y"],
         params,
         into_array!["--output", output]
       )
@@ -140,15 +139,13 @@ impl Encoder {
           "error",
           "--demuxer",
           "y4m",
-          "--frames",
-          frame_count.to_string()
         ],
         params,
         into_array!["-", "-o", output]
       )
       .collect(),
       Self::x265 => chain!(
-        into_array!["x265", "--y4m", "--frames", frame_count.to_string()],
+        into_array!["x265", "--y4m"],
         params,
         into_array!["--input", "-", "-o", output]
       )
@@ -157,7 +154,7 @@ impl Encoder {
   }
 
   /// Composes 1st pass command for 2 pass encoding
-  pub fn compose_1_2_pass(self, params: Vec<String>, fpf: &str, frame_count: usize) -> Vec<String> {
+  pub fn compose_1_2_pass(self, params: Vec<String>, fpf: &str) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=2", "--pass=1"],
@@ -171,8 +168,6 @@ impl Encoder {
           "-",
           "-y",
           "--quiet",
-          "--limit",
-          frame_count.to_string()
         ],
         params,
         into_array!["--first-pass", format!("{fpf}.stat"), "--output", NULL]
@@ -208,8 +203,6 @@ impl Encoder {
           "1",
           "--demuxer",
           "y4m",
-          "--frames",
-          frame_count.to_string()
         ],
         params,
         into_array!["--stats", format!("{fpf}.log"), "-", "-o", NULL]
@@ -224,8 +217,6 @@ impl Encoder {
           "--pass",
           "1",
           "--y4m",
-          "--frames",
-          frame_count.to_string()
         ],
         params,
         into_array![
@@ -249,7 +240,6 @@ impl Encoder {
     params: Vec<String>,
     fpf: &str,
     output: String,
-    frame_count: usize,
   ) -> Vec<String> {
     match self {
       Self::aom => chain!(
@@ -264,8 +254,6 @@ impl Encoder {
           "-",
           "-y",
           "--quiet",
-          "--limit",
-          frame_count.to_string()
         ],
         params,
         into_array!["--second-pass", format!("{fpf}.stat"), "--output", output]
@@ -308,8 +296,6 @@ impl Encoder {
           "2",
           "--demuxer",
           "y4m",
-          "--frames",
-          frame_count.to_string()
         ],
         params,
         into_array!["--stats", format!("{fpf}.log"), "-", "-o", output]
@@ -324,8 +310,6 @@ impl Encoder {
           "--pass",
           "2",
           "--y4m",
-          "--frames",
-          frame_count.to_string()
         ],
         params,
         into_array![

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -442,7 +442,7 @@ impl Encoder {
         "--scenecut", "0",
       ],
       Encoder::x265 => into_vec![
-        "-p", "slow",
+        "--preset", "slow",
         "--crf", "25",
         "-D", "10",
         "--level-idc", "5.0",

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -368,8 +368,12 @@ impl Encoder {
         }
       }
       Encoder::rav1e => {
-        let defaults: Vec<String> =
-          into_vec!["--speed", "6", "--quantizer", "100", "--keyint", "0"];
+        let defaults: Vec<String> = into_vec![
+          "--speed", "6",
+          "--quantizer", "100",
+          "--keyint", "0",
+          "--no-scene-detection",
+        ];
 
         if cols > 1 || rows > 1 {
           let tiles: Vec<String> = into_vec!["--tiles", format!("{}", cols * rows)];
@@ -409,7 +413,13 @@ impl Encoder {
         }
       }
       Encoder::svt_av1 => {
-        let defaults = into_vec!["--preset", "4", "--keyint", "0", "--rc", "0", "--crf", "25"];
+        let defaults = into_vec![
+          "--preset", "4",
+          "--keyint", "0",
+          "--scd", "0",
+          "--rc", "0",
+          "--crf", "25",
+        ];
         if cols > 1 || rows > 1 {
           let columns = ilog2(cols);
           let rows = ilog2(rows);
@@ -425,18 +435,19 @@ impl Encoder {
           defaults
         }
       }
-      Encoder::x264 => into_vec!["--preset", "slow", "--crf", "25", "--keyint", "infinite"],
+      Encoder::x264 => into_vec![
+        "--preset", "slow",
+        "--crf", "25",
+        "--keyint", "infinite",
+        "--scenecut", "0",
+      ],
       Encoder::x265 => into_vec![
-        "-p",
-        "slow",
-        "--crf",
-        "25",
-        "-D",
-        "10",
-        "--level-idc",
-        "5.0",
-        "--keyint",
-        "-1",
+        "-p", "slow",
+        "--crf", "25",
+        "-D", "10",
+        "--level-idc", "5.0",
+        "--keyint", "-1",
+        "--scenecut", "0",
       ],
     }
   }

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -367,6 +367,7 @@ impl Encoder {
           "--cpu-used=6",
           "--end-usage=q",
           "--cq-level=30",
+          "--disable-kf",
         ];
 
         if cols > 1 || rows > 1 {
@@ -384,7 +385,7 @@ impl Encoder {
       }
       Encoder::rav1e => {
         let defaults: Vec<String> =
-          into_vec!["--speed", "6", "--quantizer", "100", "--no-scene-detection"];
+          into_vec!["--speed", "6", "--quantizer", "100", "--keyint", "0"];
 
         if cols > 1 || rows > 1 {
           let tiles: Vec<String> = into_vec!["--tiles", format!("{}", cols * rows)];
@@ -407,6 +408,7 @@ impl Encoder {
           "--cq-level=30",
           "--row-mt=1",
           "--auto-alt-ref=6",
+          "--disable-kf",
         ];
 
         if cols > 1 || rows > 1 {
@@ -423,7 +425,7 @@ impl Encoder {
         }
       }
       Encoder::svt_av1 => {
-        let defaults = into_vec!["--preset", "4", "--keyint", "240", "--rc", "0", "--crf", "25"];
+        let defaults = into_vec!["--preset", "4", "--keyint", "0", "--rc", "0", "--crf", "25"];
         if cols > 1 || rows > 1 {
           let columns = ilog2(cols);
           let rows = ilog2(rows);
@@ -439,7 +441,7 @@ impl Encoder {
           defaults
         }
       }
-      Encoder::x264 => into_vec!["--preset", "slow", "--crf", "25"],
+      Encoder::x264 => into_vec!["--preset", "slow", "--crf", "25", "--keyint", "infinite"],
       Encoder::x265 => into_vec![
         "-p",
         "slow",
@@ -448,7 +450,9 @@ impl Encoder {
         "-D",
         "10",
         "--level-idc",
-        "5.0"
+        "5.0",
+        "--keyint",
+        "-1",
       ],
     }
   }

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -101,11 +101,7 @@ impl Display for Encoder {
 
 impl Encoder {
   /// Composes 1st pass command for 1 pass encoding
-  pub fn compose_1_1_pass(
-    self,
-    params: Vec<String>,
-    output: String,
-  ) -> Vec<String> {
+  pub fn compose_1_1_pass(self, params: Vec<String>, output: String) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=1"],
@@ -163,12 +159,7 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array![
-          "rav1e",
-          "-",
-          "-y",
-          "--quiet",
-        ],
+        into_array!["rav1e", "-", "-y", "--quiet",],
         params,
         into_array!["--first-pass", format!("{fpf}.stat"), "--output", NULL]
       )
@@ -235,12 +226,7 @@ impl Encoder {
   }
 
   /// Composes 2st pass command for 2 pass encoding
-  pub fn compose_2_2_pass(
-    self,
-    params: Vec<String>,
-    fpf: &str,
-    output: String,
-  ) -> Vec<String> {
+  pub fn compose_2_2_pass(self, params: Vec<String>, fpf: &str, output: String) -> Vec<String> {
     match self {
       Self::aom => chain!(
         into_array!["aomenc", "--passes=2", "--pass=2"],
@@ -249,12 +235,7 @@ impl Encoder {
       )
       .collect(),
       Self::rav1e => chain!(
-        into_array![
-          "rav1e",
-          "-",
-          "-y",
-          "--quiet",
-        ],
+        into_array!["rav1e", "-", "-y", "--quiet",],
         params,
         into_array!["--second-pass", format!("{fpf}.stat"), "--output", output]
       )
@@ -369,9 +350,12 @@ impl Encoder {
       }
       Encoder::rav1e => {
         let defaults: Vec<String> = into_vec![
-          "--speed", "6",
-          "--quantizer", "100",
-          "--keyint", "0",
+          "--speed",
+          "6",
+          "--quantizer",
+          "100",
+          "--keyint",
+          "0",
           "--no-scene-detection",
         ];
 
@@ -413,13 +397,8 @@ impl Encoder {
         }
       }
       Encoder::svt_av1 => {
-        let defaults = into_vec![
-          "--preset", "4",
-          "--keyint", "0",
-          "--scd", "0",
-          "--rc", "0",
-          "--crf", "25",
-        ];
+        let defaults =
+          into_vec!["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25",];
         if cols > 1 || rows > 1 {
           let columns = ilog2(cols);
           let rows = ilog2(rows);
@@ -436,18 +415,28 @@ impl Encoder {
         }
       }
       Encoder::x264 => into_vec![
-        "--preset", "slow",
-        "--crf", "25",
-        "--keyint", "infinite",
-        "--scenecut", "0",
+        "--preset",
+        "slow",
+        "--crf",
+        "25",
+        "--keyint",
+        "infinite",
+        "--scenecut",
+        "0",
       ],
       Encoder::x265 => into_vec![
-        "--preset", "slow",
-        "--crf", "25",
-        "-D", "10",
-        "--level-idc", "5.0",
-        "--keyint", "-1",
-        "--scenecut", "0",
+        "--preset",
+        "slow",
+        "--crf",
+        "25",
+        "-D",
+        "10",
+        "--level-idc",
+        "5.0",
+        "--keyint",
+        "-1",
+        "--scenecut",
+        "0",
       ],
     }
   }

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -463,7 +463,7 @@ impl Encoder {
   pub const fn help_command(self) -> [&'static str; 2] {
     match self {
       Self::aom => ["aomenc", "--help"],
-      Self::rav1e => ["rav1e", "--fullhelp"],
+      Self::rav1e => ["rav1e", "--help"],
       Self::vpx => ["vpxenc", "--help"],
       Self::svt_av1 => ["SvtAv1EncApp", "--help"],
       Self::x264 => ["x264", "--fullhelp"],

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -26,8 +26,8 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
 
 use crate::encoder::Encoder;
-use crate::settings::{EncodeArgs};
 use crate::progress_bar::finish_progress_bar;
+use crate::settings::EncodeArgs;
 
 pub mod broker;
 pub mod chunk;

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -351,7 +351,7 @@ pub enum ChunkOrdering {
 #[must_use]
 pub fn determine_workers(args: &EncodeArgs) -> u64 {
   let res = args.input.resolution().unwrap();
-  let tiles = args.input.calculate_tiles();
+  let tiles = args.tiles;
   let megapixels = (res.0 * res.1) as f64 / 1e6;
   // encoder memory and chunk_method memory usage scales with resolution (megapixels),
   // approximately linearly. Expressed as GB/Megapixel

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -296,6 +296,8 @@ fn get_test_args() -> Av1anContext {
     vmaf: false,
     verbosity: Verbosity::Normal,
     workers: 1,
+    tiles: (1, 1),
+    tile_auto: false,
     set_thread_affinity: None,
     zones: None,
     scaler: String::new(),

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -259,6 +259,7 @@ fn get_test_args() -> Av1anContext {
     ffmpeg_filter_args: Vec::new(),
     temp: String::new(),
     force: false,
+    no_defaults: false,
     passes: 2,
     video_params: into_vec!["--cq-level=40", "--cpu-used=0", "--aq-mode=1"],
     output_file: String::new(),

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -56,6 +56,7 @@ pub struct EncodeArgs {
 
   pub passes: u8,
   pub video_params: Vec<String>,
+  pub tiles: (u32, u32), // tile (cols, rows) count; log2 will be applied later for specific encoders
   pub encoder: Encoder,
   pub workers: usize,
   pub set_thread_affinity: Option<usize>,
@@ -75,6 +76,7 @@ pub struct EncodeArgs {
   pub resume: bool,
   pub keep: bool,
   pub force: bool,
+  pub tile_auto: bool,
 
   pub concat: ConcatMethod,
   pub target_quality: Option<TargetQuality>,
@@ -177,13 +179,17 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       );
     }
 
+    if self.tile_auto {
+        self.tiles = self.input.calculate_tiles();
+    }
+
     if !self.force {
       if self.video_params.is_empty() {
-        self.video_params = self.encoder.get_default_arguments(self.input.calculate_tiles());
+        self.video_params = self.encoder.get_default_arguments(self.tiles);
       } else {
         // merge video_params with defaults, overriding defaults
         // TODO: consider using hashmap to store program arguments instead of string vector
-        let default_video_params = self.encoder.get_default_arguments(self.input.calculate_tiles());
+        let default_video_params = self.encoder.get_default_arguments(self.tiles);
         let mut skip = false;
         let mut _default_params: Vec<String> = Vec::new();
         for param in default_video_params {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -6,7 +6,7 @@ use std::process::{exit, Command};
 
 use anyhow::{bail, ensure};
 use ffmpeg::format::Pixel;
-use itertools::{Itertools, chain};
+use itertools::{chain, Itertools};
 use serde::{Deserialize, Serialize};
 
 use crate::concat::ConcatMethod;
@@ -180,7 +180,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     }
 
     if self.tile_auto {
-        self.tiles = self.input.calculate_tiles();
+      self.tiles = self.input.calculate_tiles();
     }
 
     if !self.force {
@@ -196,8 +196,12 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
           if skip && !(param.starts_with("-") && param != "-1") {
             skip = false;
             continue;
-          } else { skip = false; }
-          if (param.starts_with("-") && param != "-1") && self.video_params.iter().any(|x| *x == param){
+          } else {
+            skip = false;
+          }
+          if (param.starts_with("-") && param != "-1")
+            && self.video_params.iter().any(|x| *x == param)
+          {
             skip = true;
             continue;
           } else {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -76,6 +76,7 @@ pub struct EncodeArgs {
   pub resume: bool,
   pub keep: bool,
   pub force: bool,
+  pub no_defaults: bool,
   pub tile_auto: bool,
 
   pub concat: ConcatMethod,
@@ -183,7 +184,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
       self.tiles = self.input.calculate_tiles();
     }
 
-    if !self.force {
+    if !self.no_defaults {
       if self.video_params.is_empty() {
         self.video_params = self.encoder.get_default_arguments(self.tiles);
       } else {

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -302,6 +302,12 @@ pub struct CliOpts {
   #[clap(short, long, value_parser = value_parser!(u8).range(1..=2), help_heading = "Encoding")]
   pub passes: Option<u8>,
 
+  /// Estimate tile count from source
+  ///
+  /// Worker estimation will consider tile count accordingly.
+  #[clap(long, help_heading = "Encoding")]
+  pub tile_auto: bool,
+
   /// Audio encoding parameters (ffmpeg syntax)
   ///
   /// If not specified, "-c:a copy" is used.
@@ -768,6 +774,8 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         Verbosity::Normal
       },
       workers: args.workers,
+      tiles: (1, 1),  // default value; will be adjusted if tile_auto set
+      tile_auto: args.tile_auto,
       set_thread_affinity: args.set_thread_affinity,
       zones: args.zones.clone(),
       scaler: {

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -168,7 +168,8 @@ pub struct CliOpts {
   #[clap(short, long)]
   pub keep: bool,
 
-  /// Do not check if the encoder arguments specified by -v/--video-params are valid
+  /// Do not check if the encoder arguments specified by -v/--video-params are valid.
+  /// And do not include Av1an's default set of encoder parameters.
   #[clap(long)]
   pub force: bool,
 
@@ -285,7 +286,8 @@ pub struct CliOpts {
   /// These parameters are for the encoder binary directly, so the ffmpeg syntax cannot be used.
   /// For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary takes this
   /// value with double dashes, as in "--crf <crf>". See the --help output of each encoder for
-  /// a list of valid options.
+  /// a list of valid options. This list of parameters will be merged into Av1an's default set
+  /// of encoder parameters, except if --force is set.
   #[clap(short, long, allow_hyphen_values = true, help_heading = "Encoding")]
   pub video_params: Option<String>,
 

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -169,9 +169,12 @@ pub struct CliOpts {
   pub keep: bool,
 
   /// Do not check if the encoder arguments specified by -v/--video-params are valid.
-  /// And do not include Av1an's default set of encoder parameters.
   #[clap(long)]
   pub force: bool,
+
+  /// Do not include Av1an's default set of encoder parameters.
+  #[clap(long)]
+  pub no_defaults: bool,
 
   /// Overwrite output file, without confirmation
   #[clap(short = 'y')]
@@ -287,7 +290,7 @@ pub struct CliOpts {
   /// For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary takes this
   /// value with double dashes, as in "--crf <crf>". See the --help output of each encoder for
   /// a list of valid options. This list of parameters will be merged into Av1an's default set
-  /// of encoder parameters, except if --force is set.
+  /// of encoder parameters.
   #[clap(short, long, allow_hyphen_values = true, help_heading = "Encoding")]
   pub video_params: Option<String>,
 
@@ -677,6 +680,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
       },
       temp: temp.clone(),
       force: args.force,
+      no_defaults: args.no_defaults,
       passes: if let Some(passes) = args.passes {
         passes
       } else {

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -774,7 +774,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         Verbosity::Normal
       },
       workers: args.workers,
-      tiles: (1, 1),  // default value; will be adjusted if tile_auto set
+      tiles: (1, 1), // default value; will be adjusted if tile_auto set
       tile_auto: args.tile_auto,
       set_thread_affinity: args.set_thread_affinity,
       zones: args.zones.clone(),

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -597,8 +597,8 @@ fn confirm(prompt: &str) -> io::Result<bool> {
 
     match buf.as_str().trim() {
       // allows enter to continue
-      "y" | "Y" | "" => break Ok(true),
-      "n" | "N" => break Ok(false),
+      "y" | "Y" => break Ok(true),
+      "n" | "N" | "" => break Ok(false),
       other => {
         println!("Sorry, response {other:?} is not understood.");
         buf.clear();
@@ -791,7 +791,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         if path.exists()
           && (args.never_overwrite
             || !confirm(&format!(
-              "Output file {path:?} exists. Do you want to overwrite it? [Y/n]: "
+              "Output file {path:?} exists. Do you want to overwrite it? [y/N]: "
             ))?)
         {
           println!("Not overwriting, aborting.");
@@ -803,7 +803,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         if path.exists()
           && (args.never_overwrite
             || !confirm(&format!(
-              "Default output file {path:?} exists. Do you want to overwrite it? [Y/n]: "
+              "Default output file {path:?} exists. Do you want to overwrite it? [y/N]: "
             ))?)
         {
           println!("Not overwriting, aborting.");

--- a/site/src/Cli/encoding.md
+++ b/site/src/Cli/encoding.md
@@ -13,7 +13,8 @@
 		These parameters are for the encoder binary directly, so the ffmpeg syntax cannot be
 		used. For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary
 		takes this value with double dashes, as in "--crf <crf>". See the --help output of each
-		encoder for a list of valid options.
+		encoder for a list of valid options. This list of parameters will be merged into
+		Av1an's default set of encoder parameters, except if --force is set.
 
 -p, --passes <PASSES>
 		Number of encoder passes

--- a/site/src/Cli/encoding.md
+++ b/site/src/Cli/encoding.md
@@ -29,6 +29,9 @@
 
 		[possible values: 1, 2]
 
+--tile-auto
+		Estimate tile count based on resolution, and set encoder parameters, if applicable.
+
 -a, --audio-params <AUDIO_PARAMS>
 		Audio encoding parameters (ffmpeg syntax)
 

--- a/site/src/Cli/encoding.md
+++ b/site/src/Cli/encoding.md
@@ -14,7 +14,7 @@
 		used. For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary
 		takes this value with double dashes, as in "--crf <crf>". See the --help output of each
 		encoder for a list of valid options. This list of parameters will be merged into
-		Av1an's default set of encoder parameters, except if --force is set.
+		Av1an's default set of encoder parameters.
 
 -p, --passes <PASSES>
 		Number of encoder passes

--- a/site/src/Cli/general.md
+++ b/site/src/Cli/general.md
@@ -48,7 +48,8 @@
 		Do not delete the temporary folder after encoding has finished
 
 	--force
-		Do not check if the encoder arguments specified by -v/--video-params are valid
+		Do not check if the encoder arguments specified by -v/--video-params are valid.
+		And do not include Av1an's default set of encoder parameters.
 
 -y
 		Overwrite output file, without confirmation

--- a/site/src/Cli/general.md
+++ b/site/src/Cli/general.md
@@ -49,7 +49,9 @@
 
 	--force
 		Do not check if the encoder arguments specified by -v/--video-params are valid.
-		And do not include Av1an's default set of encoder parameters.
+
+	--no-defaults
+		Do not include Av1an's default set of encoder parameters.
 
 -y
 		Overwrite output file, without confirmation


### PR DESCRIPTION
This improves upon setting default encoding parameters. The gist of this pull request is improving the tile and worker estimation, and keeping those values when setting video-params. My main use-case for this is that I sometimes have batches of mixed resolution videos (e.g. 1080p and 4k) that I want to encode with the same settings -- and not have to go through one by one to specify tile count.

Some of the commits are loosely related, and I wasn't sure if I should make separate pull requests for them, so they are included here. I am a beginner with rust, so please correct me if the formatting is bad, or if there is a better way to implement the changes.