### PR TITLE
append to log file

### DIFF
--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -899,7 +899,8 @@ pub fn run() -> anyhow::Result<()> {
   for arg in args {
     // Change log file
     let new_log_file = FileSpec::try_from(PathAbs::new(&arg.log_file)?)?;
-    let _ = &logger.reset_flw(&flexi_logger::writers::FileLogWriter::builder(new_log_file))?;
+    let _ =
+      &logger.reset_flw(&flexi_logger::writers::FileLogWriter::builder(new_log_file).append())?;
 
     Av1anContext::new(arg)?.encode_file()?;
   }


### PR DESCRIPTION
When resuming, append to the log file instead of clearing its old contents.

I tested with and without resume.