### PR TITLE
Fix vmaf flag check with target-quality

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -360,17 +360,19 @@ impl Av1anContext {
           temp_res = tq.vmaf_res.to_string();
         }
 
-        if let Err(e) = vmaf::plot(
-          self.args.output_file.as_ref(),
-          &self.args.input,
-          tq.model.as_deref(),
-          temp_res.as_str(),
-          tq.vmaf_scaler.as_str(),
-          1,
-          tq.vmaf_filter.as_deref(),
-          tq.vmaf_threads,
-        ) {
-          error!("VMAF calculation failed with error: {}", e);
+        if self.args.vmaf {
+          if let Err(e) = vmaf::plot(
+            self.args.output_file.as_ref(),
+            &self.args.input,
+            tq.model.as_deref(),
+            temp_res.as_str(),
+            tq.vmaf_scaler.as_str(),
+            1,
+            tq.vmaf_filter.as_deref(),
+            tq.vmaf_threads,
+          ) {
+            error!("VMAF calculation failed with error: {}", e);
+          }
         }
       }
 

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -291,6 +291,7 @@ fn get_test_args() -> Av1anContext {
     sc_downscale_height: None,
     force_keyframes: Vec::new(),
     target_quality: None,
+    vmaf: false,
     verbosity: Verbosity::Normal,
     workers: 1,
     set_thread_affinity: None,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -77,6 +77,7 @@ pub struct EncodeArgs {
 
   pub concat: ConcatMethod,
   pub target_quality: Option<TargetQuality>,
+  pub vmaf: bool,
 }
 
 impl EncodeArgs {

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -742,6 +742,7 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
         args.force_keyframes.as_deref().unwrap_or(""),
       )?,
       target_quality: args.target_quality_params(temp, video_params, output_pix_format.format),
+      vmaf: args.vmaf,
       verbosity: if args.quiet {
         Verbosity::Quiet
       } else if args.verbose {


### PR DESCRIPTION
Fixes issue where vmaf plot was always ran if target-quality was set, this does not allow you to run vmaf plot without target-quality as it seems like vmaf plot was designed around target-quality at some point so --vmaf without --target-quality will do nothing. Decoupling the two seems like it will be a lot of work so I am adding this for now as it atleast closes #790 and the decoupling can happen later