### PR TITLE
Add support for vmaf-subsample

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -368,6 +368,7 @@ impl Av1anContext {
             temp_res.as_str(),
             tq.vmaf_scaler.as_str(),
             1,
+            1,
             tq.vmaf_filter.as_deref(),
             tq.vmaf_threads,
           ) {

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -25,6 +25,7 @@ pub struct TargetQuality {
   pub vmaf_threads: usize,
   pub model: Option<PathBuf>,
   pub probing_rate: usize,
+  pub probing_subsample: usize,
   pub probes: u32,
   pub target: f64,
   pub min_q: u32,
@@ -252,6 +253,7 @@ impl TargetQuality {
       &self.vmaf_res,
       &self.vmaf_scaler,
       self.probing_rate,
+      self.probing_subsample,
       self.vmaf_filter.as_deref(),
       self.vmaf_threads,
     )?;

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -122,6 +122,7 @@ pub fn plot(
   res: &str,
   scaler: &str,
   sample_rate: usize,
+  subsample: usize,
   filter: Option<&str>,
   threads: usize,
 ) -> Result<(), Box<EncoderCrash>> {
@@ -156,6 +157,7 @@ pub fn plot(
     res,
     scaler,
     sample_rate,
+    subsample,
     filter,
     threads,
   )?;
@@ -172,6 +174,7 @@ pub fn run_vmaf(
   res: &str,
   scaler: &str,
   sample_rate: usize,
+  subsample: usize,
   vmaf_filter: Option<&str>,
   threads: usize,
 ) -> Result<(), Box<EncoderCrash>> {
@@ -193,16 +196,18 @@ pub fn run_vmaf(
 
   let vmaf = if let Some(model) = model {
     format!(
-      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:model_path={}:n_threads={}",
+      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:model_path={}:n_threads={}:n_subsample={}",
       ffmpeg::escape_path_in_filter(stat_file),
       ffmpeg::escape_path_in_filter(&model),
-      threads
+      threads,
+      subsample,
     )
   } else {
     format!(
-      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:n_threads={}",
+      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:n_threads={}:n_subsample={}",
       ffmpeg::escape_path_in_filter(stat_file),
-      threads
+      threads,
+      subsample,
     )
   };
 

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -514,6 +514,10 @@ pub struct CliOpts {
   #[clap(long, default_value_t = 1, help_heading = "Target Quality")]
   pub probing_rate: u32,
 
+  /// VMAF subsample for probes to speedup VMAF calculation
+  #[clap(long, default_value_t = 1, help_heading = "Target Quality")]
+  pub probing_subsample: usize,
+
   /// Use encoding settings for probes specified by --video-params rather than faster, less accurate settings
   ///
   /// Note that this always performs encoding in one-pass mode, regardless of --passes.
@@ -572,6 +576,7 @@ impl CliOpts {
         video_params: video_params.clone(),
         probe_slow: self.probe_slow,
         probing_rate: adapt_probing_rate(self.probing_rate as usize),
+        probing_subsample: self.probing_subsample,
       }
     })
   }


### PR DESCRIPTION
Add vmaf-subsample as an alternative to probing-rate as it is more accurate while still providing a speed benefit compared to without it 
Closes #806

Looks like probe-rate 3 in this example is useless as it messes up the quality so bad it just uses 8 crf which was my min while subsample doesnt seem to run into any issues with setting it a bit to high.


Testing on a 30 second 1080p clip with little motion
Target quality of 96 using x265 fast with extra-split 240 comes out to 7 scenes

# default
real    3m34.966s
user    24m37.871s
sys     2m58.700s

![default](https://github.com/master-of-zen/Av1an/assets/4695527/9de88fbc-411d-430d-a375-d1ce2fe3c41c)

# probe 2
real    1m45.946s
user    11m48.243s
sys     1m41.285s

![probing-rate_2](https://github.com/master-of-zen/Av1an/assets/4695527/85e5e35c-3ab9-4dc6-99e4-3b759a4031b8)

# probe 3
real    1m44.766s
user    10m12.201s
sys     1m30.548s

![probing-rate_3](https://github.com/master-of-zen/Av1an/assets/4695527/4e45dbb8-710d-4f93-8398-a724a47082ee)

# subsample 3
real    2m35.967s
user    17m47.618s
sys     2m25.497s

![vmaf-subsample_3](https://github.com/master-of-zen/Av1an/assets/4695527/7e036f1c-e2e5-490d-9f8e-b9fceb28f4f7)

# subsample 9
real    2m8.224s
user    14m7.415s
sys     1m50.762s

![vmaf-subsample_9](https://github.com/master-of-zen/Av1an/assets/4695527/9daae2c9-eb7a-4b12-9a12-c39eee6374c6)