### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "av1an-core"
 version = "0.4.1"
-rust-version = "1.63"
+rust-version = "1.70"
 edition = "2021"
 authors = ["Zen <master_of_zen@protonmail.com>"]
 description = """

--- a/av1an-core/src/parse.rs
+++ b/av1an-core/src/parse.rs
@@ -158,10 +158,7 @@ pub unsafe fn parse_aom_vpx_frames_sse41(s: &[u8]) -> Option<u64> {
   };
 
   let ascending = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-  let num_digits = match first_space_index.checked_sub(first_digit_index) {
-    Some(nd) => nd,
-    None => return None,
-  };
+  let num_digits = first_space_index.checked_sub(first_digit_index)?;
 
   let dynamic_mask = _mm_cmplt_epi8(ascending, _mm_set1_epi8(num_digits as i8));
 

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/master-of-zen/Av1an"
 keywords = ["video"]
 categories = ["command-line-utilities"]
 license = "GPL-3.0"
-rust-version = "1.63"
+rust-version = "1.70"
 edition = "2021"
 readme = "../README.md"
 

--- a/site/src/compiling.md
+++ b/site/src/compiling.md
@@ -6,7 +6,7 @@ You can natively build Av1an on Linux and Windows. Cross-compilation is not supp
 
 To compile Av1an from source, you need the following dependencies:
 
-- [Rust](https://www.rust-lang.org/) (version 1.63.0 or higher)
+- [Rust](https://www.rust-lang.org/) (version 1.70.0 or higher)
 - [NASM](https://www.nasm.us/)
 - [clang/LLVM](https://llvm.org/)
 - [FFmpeg](https://ffmpeg.org/)


### PR DESCRIPTION
This is already the actual MSRV, but it was not updated in the Cargo config files, so this change is needed to fix CI.