### PR TITLE
Fix new svt-av1 versions 2.x.x being treated as old svt-av1

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -83,7 +83,7 @@ pub static USE_OLD_SVT_AV1: Lazy<bool> = Lazy::new(|| {
   if let Some((major, minor, _)) = parse_svt_av1_version(&version.stdout) {
     match major {
       0 => minor < 9,
-      1.. => false,
+      _ => false,
     }
   } else {
     // assume an old version of SVT-AV1 if the version failed to parse, as


### PR DESCRIPTION
Invalid use of `1..` in a match function, as it has no upper bound. Replaced with a wildcard pattern to simply catch all remaining patterns, which I think should work fine here.