### PR TITLE
Modify windows-build.yml to use ffmpeg 7.0

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
 
-      ffmpeg_ver: "6.0"
+      ffmpeg_ver: "7.0"
       ffmpeg_path: "C:/ffmpeg"
       vsynth_ver: "R66"
       vsynth_path: "C:/Program Files/Vapoursynth"


### PR DESCRIPTION
Av1an prerelease windows binary doesn't support ffmpeg 7.0 because it wasn't build with ffmpeg 7.0