### PR TITLE
Fix "Received a packet for an attachment stream" error when encoding certain files.

### DIFF
--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -166,7 +166,7 @@ pub fn encode_audio<S: AsRef<OsStr>>(
 
     encode_audio.args(["-y", "-hide_banner", "-loglevel", "error"]);
     encode_audio.args(["-i", input.to_str().unwrap()]);
-    encode_audio.args(["-map_metadata", "0",]);
+    encode_audio.args(["-map_metadata", "0"]);
     encode_audio.args(["-map", "0", "-c", "copy", "-vn", "-dn"]);
 
     encode_audio.args(audio_params);

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -170,16 +170,12 @@ pub fn encode_audio<S: AsRef<OsStr>>(
     encode_audio.args([
       "-map_metadata",
       "0",
-      "-vn",
-      "-dn",
       "-map",
       "0",
-      "-map",
-      "-0:a",
+      "-vn",
+      "-dn",
       "-c",
       "copy",
-      "-map",
-      "0:a",
     ]);
 
     encode_audio.args(audio_params);

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -164,19 +164,10 @@ pub fn encode_audio<S: AsRef<OsStr>>(
     encode_audio.stdout(Stdio::piped());
     encode_audio.stderr(Stdio::piped());
 
-    encode_audio.args(["-y", "-hide_banner", "-loglevel", "error", "-i"]);
-    encode_audio.arg(input);
-
-    encode_audio.args([
-      "-map_metadata",
-      "0",
-      "-map",
-      "0",
-      "-vn",
-      "-dn",
-      "-c",
-      "copy",
-    ]);
+    encode_audio.args(["-y", "-hide_banner", "-loglevel", "error"]);
+    encode_audio.args(["-i", input.to_str().unwrap()]);
+    encode_audio.args(["-map_metadata", "0",]);
+    encode_audio.args(["-map", "0", "-c", "copy", "-vn", "-dn"]);
 
     encode_audio.args(audio_params);
     encode_audio.arg(&audio_file);


### PR DESCRIPTION
I ran into an issue encoding certain mkv-files with multiple audio, subtitle and attachments, and managed to track down the issue to the way Av1an handles encoding audio; There's a lot of mapping weirdness done in [`ffmpeg.rs`](https://github.com/master-of-zen/Av1an/blob/master/av1an-core/src/ffmpeg.rs)'s `encode_audio` function:
https://github.com/master-of-zen/Av1an/blob/605bad6773025ceae938d48862e9cf99685d1d98/av1an-core/src/ffmpeg.rs#L166-L187
-that ends up giving me the following error when encoding, right after Scene detection:
```
[matroska @ 0x560b67fa86c0] Received a packet for an attachment stream.
[aost#0:6/copy @ 0x560b67ba16c0] Error submitting a packet to the muxer: Invalid argument
[out#0/matroska @ 0x560b67b935c0] Error muxing a packet
```

As such, I've trimmed out many of the repeated mapping-statements to streamline the parameters. I don't know if there was a particular reason this was done the way it was before, but as far as I can tell, this works just the same way without any of the odd errors I've been encountering.