### PR TITLE
Implement pipeless scene detection for basic video inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,11 +213,12 @@ dependencies = [
 
 [[package]]
 name = "av-scenechange"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470112491badcebb8f4af5788fb04e535b2b4ed46640bdb473732d4ebbaa7c59"
+checksum = "a5fa17f98b2134d5459bbf2e69b297b1be2047a3f617af34fad7ecca362c6cb5"
 dependencies = [
  "anyhow",
+ "ffmpeg-the-third",
  "rav1e",
  "vapoursynth",
  "y4m",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -40,7 +40,8 @@ crossbeam-channel = "0.5.1"
 crossbeam-utils = "0.8.5"
 textwrap = "0.16.0"
 path_abs = "0.5.1"
-av-scenechange = { version = "0.11.0", default-features = false, features = [
+av-scenechange = { version = "0.12.0", default-features = false, features = [
+  "ffmpeg",
   "vapoursynth",
 ] }
 y4m = "0.8.0"


### PR DESCRIPTION
This provides similar speedups as https://github.com/master-of-zen/Av1an/pull/844, but applies to video inputs not using Vapoursynth. For the time being, this still does not affect inputs using ffmpeg filters. This also does not yet use the padding implementation redzic mentioned to provide additional copy-avoidance. Those changes will hopefully come in future PRs.