### PR TITLE
Remove vapoursynth-plugin-lsmashsource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM archlinux:base-devel AS base
 RUN pacman -Syu --noconfirm
 
 # Install dependancies needed by all steps including runtime step
-RUN pacman -S --noconfirm --needed aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vapoursynth-plugin-lsmashsource vmaf
+RUN pacman -S --noconfirm --needed aom ffmpeg vapoursynth ffms2 libvpx mkvtoolnix-cli svt-av1 vmaf
 
 
 FROM base AS build-base


### PR DESCRIPTION
Plugin doesn't exist on Arch repo anymore.

Fix https://github.com/master-of-zen/Av1an/issues/850