### PR TITLE
Update compile docs

### DIFF
--- a/site/src/compiling.md
+++ b/site/src/compiling.md
@@ -51,6 +51,8 @@ If you want to build the binary yourself, you will need the following dependenci
 - Create a new environment variable named `VAPOURSYNTH_LIB_DIR` and set it to the directory path where you extracted `VapourSynth64-Portable-R68.zip`, appending `\sdk\lib64` to the path.
   - (For example, set `VAPOURSYNTH_LIB_DIR` to `C:\Users\Username\Downloads\VapourSynth64-Portable-R68\sdk\lib64`)
 
+Then, either clone the repository by running
+
 ```sh
 git clone https://github.com/master-of-zen/Av1an
 ```

--- a/site/src/compiling.md
+++ b/site/src/compiling.md
@@ -37,14 +37,19 @@ If you want to build the binary yourself, you will need the following dependenci
 
 - [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) - this is a dependency for Rust
 - [The Rust toolchain](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)
-- [Python](https://www.python.org/) (version 3.8 or 3.10) - this is a dependency for VapourSynth. Recommended to install for all users
-- [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases/download/R58/VapourSynth64-R58.exe)
-- [NASM](https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-installer-x64.exe)
-- [FFmpeg](https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-full_build-shared.7z) (thanks to [gyan](https://github.com/GyanD) for providing these builds)
+- [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip)
+- [NASM](https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-installer-x64.exe)
+- [FFmpeg](https://github.com/GyanD/codexffmpeg/releases/download/7.0/ffmpeg-7.0-full_build-shared.7z) (thanks to [gyan](https://github.com/GyanD) for providing these builds)
 
-Extract the file `ffmpeg-5.0.1-full_build-shared.7z` to a directory, then create a new environment variable called `FFMPEG_DIR` (this can be done with with the "Edit environment variables for your account" function available in the control panel), and set it to the directory that you extracted the original file to (for example, set it to `C:\Users\Username\Downloads\ffmpeg-5.0.1-full_build-shared`).
-
-Then, either clone the repository by running
+### FFmpeg setup:
+- Extract the file `ffmpeg-7.0-full_build-shared.7z` to a directory.
+- Create a new environment variable named `FFMPEG_DIR` and set it to the directory path where you extracted `ffmpeg-7.0-full_build-shared.7z`.
+  - (For example, set `FFMPEG_DIR` to `C:\Users\Username\Downloads\ffmpeg-7.0-full_build-shared`)
+	
+### VapourSynth setup:
+- Extract the file `VapourSynth64-Portable-R68.zip` to a directory.
+- Create a new environment variable named `VAPOURSYNTH_LIB_DIR` and set it to the directory path where you extracted `VapourSynth64-Portable-R68.zip`, appending `\sdk\lib64` to the path.
+  - (For example, set `VAPOURSYNTH_LIB_DIR` to `C:\Users\Username\Downloads\VapourSynth64-Portable-R68\sdk\lib64`)
 
 ```sh
 git clone https://github.com/master-of-zen/Av1an
@@ -54,4 +59,4 @@ Or download and extract the [source code](https://github.com/master-of-zen/Av1an
 
 Open a command prompt or PowerShell window inside the cloned repository/extracted ZIP folder and run the command `cargo build --release`. If this command executes successfully with no errors, `av1an.exe` will be in the folder `target\release`.
 
-To use `av1an.exe`, copy all the `.dll` files from `ffmpeg-5.0.1-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.
+To use `av1an.exe`, copy all the `.dll` files from `ffmpeg-7.0-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.


### PR DESCRIPTION
Updating it since its out of date
Python is not needed if vapoursynth is portable