### PR TITLE
Add support for passing variables to the vspipe python environment

### DIFF
--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -101,7 +101,9 @@ mod tests {
     let ch = Chunk {
       temp: "none".to_owned(),
       index: 1,
-      input: Input::Video("test.mkv".into()),
+      input: Input::Video {
+        path: "test.mkv".into()
+      },
       vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
@@ -122,7 +124,9 @@ mod tests {
     let ch = Chunk {
       temp: "none".to_owned(),
       index: 10000,
-      input: Input::Video("test.mkv".into()),
+      input: Input::Video {
+        path: "test.mkv".into()
+      },
       vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
@@ -144,7 +148,9 @@ mod tests {
     let ch = Chunk {
       temp: "d".to_owned(),
       index: 1,
-      input: Input::Video("test.mkv".into()),
+      input: Input::Video {
+        path: "test.mkv".into()
+      },
       vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -60,7 +60,7 @@ impl Chunk {
       let grain_table = Path::new(&self.temp).join(format!("iso{iso_setting}-grain.tbl"));
       if !grain_table.exists() {
         debug!("Generating grain table at ISO {}", iso_setting);
-        let (mut width, mut height) = self.input.resolution(self.vspipe_args.clone())?;
+        let (mut width, mut height) = self.input.resolution()?;
         if self.noise_size.0.is_some() {
           width = self.noise_size.0.unwrap();
         }
@@ -69,7 +69,7 @@ impl Chunk {
         }
         let transfer_function = self
           .input
-          .transfer_function_params_adjusted(&self.video_params, self.vspipe_args.clone())?;
+          .transfer_function_params_adjusted(&self.video_params)?;
         let params = generate_photon_noise_params(
           0,
           u64::MAX,

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -101,7 +101,7 @@ mod tests {
       temp: "none".to_owned(),
       index: 1,
       input: Input::Video {
-        path: "test.mkv".into()
+        path: "test.mkv".into(),
       },
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
@@ -123,7 +123,7 @@ mod tests {
       temp: "none".to_owned(),
       index: 10000,
       input: Input::Video {
-        path: "test.mkv".into()
+        path: "test.mkv".into(),
       },
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
@@ -146,7 +146,7 @@ mod tests {
       temp: "d".to_owned(),
       index: 1,
       input: Input::Video {
-        path: "test.mkv".into()
+        path: "test.mkv".into(),
       },
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -13,7 +13,6 @@ pub struct Chunk {
   pub temp: String,
   pub index: usize,
   pub input: Input,
-  pub vspipe_args: Vec<String>,
   pub source_cmd: Vec<OsString>,
   pub output_ext: String,
   pub start_frame: usize,
@@ -104,7 +103,6 @@ mod tests {
       input: Input::Video {
         path: "test.mkv".into()
       },
-      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,
@@ -127,7 +125,6 @@ mod tests {
       input: Input::Video {
         path: "test.mkv".into()
       },
-      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,
@@ -151,7 +148,6 @@ mod tests {
       input: Input::Video {
         path: "test.mkv".into()
       },
-      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -13,6 +13,7 @@ pub struct Chunk {
   pub temp: String,
   pub index: usize,
   pub input: Input,
+  pub vspipe_args: Vec<String>,
   pub source_cmd: Vec<OsString>,
   pub output_ext: String,
   pub start_frame: usize,
@@ -59,7 +60,7 @@ impl Chunk {
       let grain_table = Path::new(&self.temp).join(format!("iso{iso_setting}-grain.tbl"));
       if !grain_table.exists() {
         debug!("Generating grain table at ISO {}", iso_setting);
-        let (mut width, mut height) = self.input.resolution()?;
+        let (mut width, mut height) = self.input.resolution(self.vspipe_args.clone())?;
         if self.noise_size.0.is_some() {
           width = self.noise_size.0.unwrap();
         }
@@ -68,7 +69,7 @@ impl Chunk {
         }
         let transfer_function = self
           .input
-          .transfer_function_params_adjusted(&self.video_params)?;
+          .transfer_function_params_adjusted(&self.video_params, self.vspipe_args.clone())?;
         let params = generate_photon_noise_params(
           0,
           u64::MAX,
@@ -101,6 +102,7 @@ mod tests {
       temp: "none".to_owned(),
       index: 1,
       input: Input::Video("test.mkv".into()),
+      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,
@@ -121,6 +123,7 @@ mod tests {
       temp: "none".to_owned(),
       index: 10000,
       input: Input::Video("test.mkv".into()),
+      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,
@@ -142,6 +145,7 @@ mod tests {
       temp: "d".to_owned(),
       index: 1,
       input: Input::Video("test.mkv".into()),
+      vspipe_args: vec![],
       source_cmd: vec!["".into()],
       output_ext: "ivf".to_owned(),
       start_frame: 0,

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -151,8 +151,8 @@ impl Av1anContext {
             && !self.args.resume
         {
           self.vs_script = Some(match &self.args.input {
-            Input::VapourSynth(path, _) => path.clone(),
-            Input::Video(path) => create_vs_file(&self.args.temp, path, self.args.chunk_method)?,
+            Input::VapourSynth { path, .. } => path.clone(),
+            Input::Video{ path } => create_vs_file(&self.args.temp, path, self.args.chunk_method)?,
           });
 
           let vs_script = self.vs_script.clone().unwrap();
@@ -671,7 +671,7 @@ impl Av1anContext {
 
   fn create_encoding_queue(&mut self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
     let mut chunks = match &self.args.input {
-      Input::Video(_) => match self.args.chunk_method {
+      Input::Video { .. } => match self.args.chunk_method {
         ChunkMethod::FFMS2
         | ChunkMethod::LSMASH
         | ChunkMethod::DGDECNV
@@ -683,7 +683,7 @@ impl Av1anContext {
         ChunkMethod::Select => self.create_video_queue_select(scenes),
         ChunkMethod::Segment => self.create_video_queue_segment(scenes)?,
       },
-      Input::VapourSynth(vs_script, _) => self.create_video_queue_vs(scenes, vs_script.as_path()),
+      Input::VapourSynth { path, .. } => self.create_video_queue_vs(scenes, path.as_path()),
     };
 
     match self.args.chunk_order {
@@ -884,7 +884,9 @@ impl Av1anContext {
     let mut chunk = Chunk {
       temp: self.args.temp.clone(),
       index,
-      input: Input::Video(src_path.to_path_buf()),
+      input: Input::Video {
+        path: src_path.to_path_buf()
+      },
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),
       vspipe_args: self.args.input.as_vspipe_args_vec()?,
@@ -938,7 +940,10 @@ impl Av1anContext {
     let mut chunk = Chunk {
       temp: self.args.temp.clone(),
       index,
-      input: Input::VapourSynth(vs_script.to_path_buf(), self.args.input.as_vspipe_args_vec()?),
+      input: Input::VapourSynth {
+        path: vs_script.to_path_buf(),
+        vspipe_args: self.args.input.as_vspipe_args_vec()?
+      },
       source_cmd: vspipe_cmd_gen,
       vspipe_args: self.args.input.as_vspipe_args_vec()?,
       output_ext: output_ext.to_owned(),
@@ -1138,7 +1143,9 @@ impl Av1anContext {
 
     let mut chunk = Chunk {
       temp: self.args.temp.clone(),
-      input: Input::Video(PathBuf::from(file)),
+      input: Input::Video {
+        path: PathBuf::from(file)
+      },
       vspipe_args: self.args.input.as_vspipe_args_vec()?,
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -460,8 +460,11 @@ impl Av1anContext {
     let (source_pipe_stderr, ffmpeg_pipe_stderr, enc_output, enc_stderr, frame) =
       rt.block_on(async {
         let mut source_pipe = if let [source, args @ ..] = &*chunk.source_cmd {
-          tokio::process::Command::new(source)
-            .args(args)
+          let mut command = tokio::process::Command::new(source);
+          for arg in chunk.input.as_vspipe_args_vec().unwrap() {
+            command.args(["-a", &arg]);
+          }
+          command.args(args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -711,7 +711,6 @@ impl Av1anContext {
       SplitMethod::AvScenechange => av_scenechange_detect(
         &self.args.input,
         self.args.encoder,
-        self.args.input.as_vspipe_args_vec()?,
         self.frames,
         self.args.min_scene_len,
         self.args.verbosity,
@@ -889,7 +888,6 @@ impl Av1anContext {
       },
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),
-      vspipe_args: self.args.input.as_vspipe_args_vec()?,
       start_frame,
       end_frame,
       frame_rate,
@@ -945,7 +943,6 @@ impl Av1anContext {
         vspipe_args: self.args.input.as_vspipe_args_vec()?
       },
       source_cmd: vspipe_cmd_gen,
-      vspipe_args: self.args.input.as_vspipe_args_vec()?,
       output_ext: output_ext.to_owned(),
       start_frame: scene.start_frame,
       end_frame: scene.end_frame,
@@ -1146,7 +1143,6 @@ impl Av1anContext {
       input: Input::Video {
         path: PathBuf::from(file)
       },
-      vspipe_args: self.args.input.as_vspipe_args_vec()?,
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),
       index,

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -464,7 +464,8 @@ impl Av1anContext {
           for arg in chunk.input.as_vspipe_args_vec().unwrap() {
             command.args(["-a", &arg]);
           }
-          command.args(args)
+          command
+            .args(args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -887,7 +888,7 @@ impl Av1anContext {
       temp: self.args.temp.clone(),
       index,
       input: Input::Video {
-        path: src_path.to_path_buf()
+        path: src_path.to_path_buf(),
       },
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),
@@ -943,7 +944,7 @@ impl Av1anContext {
       index,
       input: Input::VapourSynth {
         path: vs_script.to_path_buf(),
-        vspipe_args: self.args.input.as_vspipe_args_vec()?
+        vspipe_args: self.args.input.as_vspipe_args_vec()?,
       },
       source_cmd: vspipe_cmd_gen,
       output_ext: output_ext.to_owned(),
@@ -1144,7 +1145,7 @@ impl Av1anContext {
     let mut chunk = Chunk {
       temp: self.args.temp.clone(),
       input: Input::Video {
-        path: PathBuf::from(file)
+        path: PathBuf::from(file),
       },
       source_cmd: ffmpeg_gen_cmd,
       output_ext: output_ext.to_owned(),

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -65,16 +65,21 @@ pub mod vmaf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Input {
-  VapourSynth(PathBuf, Vec<String>),
-  Video(PathBuf),
+  VapourSynth {
+    path: PathBuf,
+    vspipe_args: Vec<String>
+  },
+  Video {
+    path: PathBuf
+  },
 }
 
 impl Input {
   /// Returns a reference to the inner path, panicking if the input is not an `Input::Video`.
   pub fn as_video_path(&self) -> &Path {
     match &self {
-      Input::Video(path) => path.as_ref(),
-      Input::VapourSynth(_, _) => {
+      Input::Video { path } => path.as_ref(),
+      Input::VapourSynth { .. } => {
         panic!("called `Input::as_video_path()` on an `Input::VapourSynth` variant")
       }
     }
@@ -83,8 +88,8 @@ impl Input {
   /// Returns a reference to the inner path, panicking if the input is not an `Input::VapourSynth`.
   pub fn as_vapoursynth_path(&self) -> &Path {
     match &self {
-      Input::VapourSynth(path, _) => path.as_ref(),
-      Input::Video(_) => {
+      Input::VapourSynth { path, .. } => path.as_ref(),
+      Input::Video { .. } => {
         panic!("called `Input::as_vapoursynth_path()` on an `Input::Video` variant")
       }
     }
@@ -98,25 +103,25 @@ impl Input {
   /// input type!
   pub fn as_path(&self) -> &Path {
     match &self {
-      Input::Video(path) | Input::VapourSynth(path, _) => path.as_ref(),
+      Input::Video { path } | Input::VapourSynth { path, .. } => path.as_ref(),
     }
   }
 
   pub const fn is_video(&self) -> bool {
-    matches!(&self, Input::Video(_))
+    matches!(&self, Input::Video { .. })
   }
 
   pub const fn is_vapoursynth(&self) -> bool {
-    matches!(&self, Input::VapourSynth(_, _))
+    matches!(&self, Input::VapourSynth { .. })
   }
 
   pub fn frames(&self) -> anyhow::Result<usize> {
     const FAIL_MSG: &str = "Failed to get number of frames for input video";
     Ok(match &self {
-      Input::Video(path) => {
+      Input::Video { path } => {
         ffmpeg::num_frames(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::VapourSynth(path, _) => {
+      Input::VapourSynth { path, .. } => {
         vapoursynth::num_frames(path.as_path(), self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
     })
@@ -125,10 +130,10 @@ impl Input {
   pub fn frame_rate(&self) -> anyhow::Result<f64> {
     const FAIL_MSG: &str = "Failed to get frame rate for input video";
     Ok(match &self {
-      Input::Video(path) => {
+      Input::Video { path } => {
         crate::ffmpeg::frame_rate(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::VapourSynth(path, _) => {
+      Input::VapourSynth { path, .. } => {
         vapoursynth::frame_rate(path.as_path(), self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
     })
@@ -137,11 +142,11 @@ impl Input {
   pub fn resolution(&self) -> anyhow::Result<(u32, u32)> {
     const FAIL_MSG: &str = "Failed to get resolution for input video";
     Ok(match self {
-      Input::VapourSynth(video, _) => {
-        crate::vapoursynth::resolution(video, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth { path, .. } => {
+        crate::vapoursynth::resolution(path, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::Video(video) => {
-        crate::ffmpeg::resolution(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::Video { path } => {
+        crate::ffmpeg::resolution(path).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
     })
   }
@@ -149,11 +154,11 @@ impl Input {
   pub fn pixel_format(&self) -> anyhow::Result<String> {
     const FAIL_MSG: &str = "Failed to get resolution for input video";
     Ok(match self {
-      Input::VapourSynth(video, _) => {
-        crate::vapoursynth::pixel_format(video, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth { path, .. } => {
+        crate::vapoursynth::pixel_format(path, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::Video(video) => {
-        let fmt = crate::ffmpeg::get_pixel_format(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?;
+      Input::Video { path } => {
+        let fmt = crate::ffmpeg::get_pixel_format(path).map_err(|_| anyhow::anyhow!(FAIL_MSG))?;
         format!("{fmt:?}")
       }
     })
@@ -162,16 +167,16 @@ impl Input {
   fn transfer_function(&self) -> anyhow::Result<TransferFunction> {
     const FAIL_MSG: &str = "Failed to get transfer characteristics for input video";
     Ok(match self {
-      Input::VapourSynth(video, _) => {
-        match crate::vapoursynth::transfer_characteristics(video, self.as_vspipe_args_map()?)
+      Input::VapourSynth { path, .. } => {
+        match crate::vapoursynth::transfer_characteristics(path, self.as_vspipe_args_map()?)
           .map_err(|_| anyhow::anyhow!(FAIL_MSG))?
         {
           16 => TransferFunction::SMPTE2084,
           _ => TransferFunction::BT1886,
         }
       }
-      Input::Video(video) => {
-        match crate::ffmpeg::transfer_characteristics(video)
+      Input::Video { path } => {
+        match crate::ffmpeg::transfer_characteristics(path)
           .map_err(|_| anyhow::anyhow!(FAIL_MSG))?
         {
           TransferCharacteristic::SMPTE2084 => TransferFunction::SMPTE2084,
@@ -224,11 +229,11 @@ impl Input {
   }
 
   /// Returns the vector of arguments passed to the vspipe python environment
-  /// /// If the input is not a vapoursynth script, the vector will be empty.
+  /// If the input is not a vapoursynth script, the vector will be empty.
   pub fn as_vspipe_args_vec(&self) -> Result<Vec<String>, anyhow::Error> {
     match self {
-      Input::VapourSynth(_, vspipe_args) => Ok(vspipe_args.to_owned()),
-      Input::Video(_) => Ok(vec![])
+      Input::VapourSynth { vspipe_args, .. } => Ok(vspipe_args.to_owned()),
+      Input::Video { .. } => Ok(vec![])
     }
   }
 
@@ -253,12 +258,19 @@ impl<P: AsRef<Path> + Into<PathBuf>> From<(P, Vec<String>)> for Input {
   fn from((path, vspipe_args): (P, Vec<String>)) -> Self {
     if let Some(ext) = path.as_ref().extension() {
       if ext == "py" || ext == "vpy" {
-        Self::VapourSynth(path.into(), vspipe_args)
+        Self::VapourSynth {
+          path: path.into(),
+          vspipe_args
+        }
       } else {
-        Self::Video(path.into())
+        Self::Video {
+          path: path.into()
+        }
       }
     } else {
-      Self::Video(path.into())
+      Self::Video {
+        path: path.into()
+      }
     }
   }
 }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -33,13 +33,15 @@ use std::thread::available_parallelism;
 use std::time::Instant;
 
 use ::ffmpeg::color::TransferCharacteristic;
-use anyhow::Context;
+use anyhow::{bail, Context};
 use av1_grain::TransferFunction;
 use chunk::Chunk;
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
+use ::vapoursynth::api::API;
+use ::vapoursynth::map::OwnedMap;
 
 use crate::encoder::Encoder;
 use crate::progress_bar::finish_progress_bar;
@@ -63,7 +65,7 @@ pub mod vmaf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Input {
-  VapourSynth(PathBuf),
+  VapourSynth(PathBuf, Vec<String>),
   Video(PathBuf),
 }
 
@@ -72,7 +74,7 @@ impl Input {
   pub fn as_video_path(&self) -> &Path {
     match &self {
       Input::Video(path) => path.as_ref(),
-      Input::VapourSynth(_) => {
+      Input::VapourSynth(_, _) => {
         panic!("called `Input::as_video_path()` on an `Input::VapourSynth` variant")
       }
     }
@@ -81,7 +83,7 @@ impl Input {
   /// Returns a reference to the inner path, panicking if the input is not an `Input::VapourSynth`.
   pub fn as_vapoursynth_path(&self) -> &Path {
     match &self {
-      Input::VapourSynth(path) => path.as_ref(),
+      Input::VapourSynth(path, _) => path.as_ref(),
       Input::Video(_) => {
         panic!("called `Input::as_vapoursynth_path()` on an `Input::Video` variant")
       }
@@ -96,7 +98,7 @@ impl Input {
   /// input type!
   pub fn as_path(&self) -> &Path {
     match &self {
-      Input::Video(path) | Input::VapourSynth(path) => path.as_ref(),
+      Input::Video(path) | Input::VapourSynth(path, _) => path.as_ref(),
     }
   }
 
@@ -105,38 +107,38 @@ impl Input {
   }
 
   pub const fn is_vapoursynth(&self) -> bool {
-    matches!(&self, Input::VapourSynth(_))
+    matches!(&self, Input::VapourSynth(_, _))
   }
 
-  pub fn frames(&self, vspipe_args: Vec<String>) -> anyhow::Result<usize> {
+  pub fn frames(&self) -> anyhow::Result<usize> {
     const FAIL_MSG: &str = "Failed to get number of frames for input video";
     Ok(match &self {
       Input::Video(path) => {
         ffmpeg::num_frames(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::VapourSynth(path) => {
-        vapoursynth::num_frames(path.as_path(), vspipe_args).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth(path, _) => {
+        vapoursynth::num_frames(path.as_path(), self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
     })
   }
 
-  pub fn frame_rate(&self, vspipe_args: Vec<String>) -> anyhow::Result<f64> {
+  pub fn frame_rate(&self) -> anyhow::Result<f64> {
     const FAIL_MSG: &str = "Failed to get frame rate for input video";
     Ok(match &self {
       Input::Video(path) => {
         crate::ffmpeg::frame_rate(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
-      Input::VapourSynth(path) => {
-        vapoursynth::frame_rate(path.as_path(), vspipe_args).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth(path, _) => {
+        vapoursynth::frame_rate(path.as_path(), self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
     })
   }
 
-  pub fn resolution(&self, vspipe_args: Vec<String>) -> anyhow::Result<(u32, u32)> {
+  pub fn resolution(&self) -> anyhow::Result<(u32, u32)> {
     const FAIL_MSG: &str = "Failed to get resolution for input video";
     Ok(match self {
-      Input::VapourSynth(video) => {
-        crate::vapoursynth::resolution(video, vspipe_args).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth(video, _) => {
+        crate::vapoursynth::resolution(video, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
       Input::Video(video) => {
         crate::ffmpeg::resolution(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
@@ -144,11 +146,11 @@ impl Input {
     })
   }
 
-  pub fn pixel_format(&self, vspipe_args: Vec<String>) -> anyhow::Result<String> {
+  pub fn pixel_format(&self) -> anyhow::Result<String> {
     const FAIL_MSG: &str = "Failed to get resolution for input video";
     Ok(match self {
-      Input::VapourSynth(video) => {
-        crate::vapoursynth::pixel_format(video, vspipe_args).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
+      Input::VapourSynth(video, _) => {
+        crate::vapoursynth::pixel_format(video, self.as_vspipe_args_map()?).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
       Input::Video(video) => {
         let fmt = crate::ffmpeg::get_pixel_format(video).map_err(|_| anyhow::anyhow!(FAIL_MSG))?;
@@ -157,11 +159,11 @@ impl Input {
     })
   }
 
-  fn transfer_function(&self, vspipe_args: Vec<String>) -> anyhow::Result<TransferFunction> {
+  fn transfer_function(&self) -> anyhow::Result<TransferFunction> {
     const FAIL_MSG: &str = "Failed to get transfer characteristics for input video";
     Ok(match self {
-      Input::VapourSynth(video) => {
-        match crate::vapoursynth::transfer_characteristics(video, vspipe_args)
+      Input::VapourSynth(video, _) => {
+        match crate::vapoursynth::transfer_characteristics(video, self.as_vspipe_args_map()?)
           .map_err(|_| anyhow::anyhow!(FAIL_MSG))?
         {
           16 => TransferFunction::SMPTE2084,
@@ -182,7 +184,6 @@ impl Input {
   pub fn transfer_function_params_adjusted(
     &self,
     enc_params: &[String],
-    vspipe_args: Vec<String>
   ) -> anyhow::Result<TransferFunction> {
     if enc_params.iter().any(|p| {
       let p = p.to_ascii_lowercase();
@@ -202,15 +203,15 @@ impl Input {
     }) {
       return Ok(TransferFunction::BT1886);
     }
-    self.transfer_function(vspipe_args)
+    self.transfer_function()
   }
 
   /// Calculates tiles from resolution
   /// Don't convert tiles to encoder specific representation
   /// Default video without tiling is 1,1
   /// Return number of horizontal and vertical tiles
-  pub fn calculate_tiles(&self, vspipe_args: Vec<String>) -> (u32, u32) {
-    match self.resolution(vspipe_args) {
+  pub fn calculate_tiles(&self) -> (u32, u32) {
+    match self.resolution() {
       Ok((h, v)) => {
         // tile range 0-1440 pixels
         let horizontal = max((h - 1) / 720, 1);
@@ -221,14 +222,38 @@ impl Input {
       _ => (1, 1),
     }
   }
+
+  /// Returns the vector of arguments passed to the vspipe python environment
+  /// /// If the input is not a vapoursynth script, the vector will be empty.
+  pub fn as_vspipe_args_vec(&self) -> Result<Vec<String>, anyhow::Error> {
+    match self {
+      Input::VapourSynth(_, vspipe_args) => Ok(vspipe_args.to_owned()),
+      Input::Video(_) => Ok(vec![])
+    }
+  }
+
+  /// Creates and returns an OwnedMap of the arguments passed to the vspipe python environment
+  /// If the input is not a vapoursynth script, the map will be empty.
+  pub fn as_vspipe_args_map(&self) -> Result<OwnedMap<'static>, anyhow::Error> {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in self.as_vspipe_args_vec()? {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.set_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      };
+    }
+
+    Ok(args_map)
+  }
 }
 
-impl<P: AsRef<Path> + Into<PathBuf>> From<P> for Input {
+impl<P: AsRef<Path> + Into<PathBuf>> From<(P, Vec<String>)> for Input {
   #[allow(clippy::option_if_let_else)]
-  fn from(path: P) -> Self {
+  fn from((path, vspipe_args): (P, Vec<String>)) -> Self {
     if let Some(ext) = path.as_ref().extension() {
       if ext == "py" || ext == "vpy" {
-        Self::VapourSynth(path.into())
+        Self::VapourSynth(path.into(), vspipe_args)
       } else {
         Self::Video(path.into())
       }

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -235,7 +235,8 @@ fn build_decoder(
 
       if !filters.is_empty() || !vspipe_args.is_empty() {
         let mut command = Command::new("vspipe");
-        command.arg("-c")
+        command
+          .arg("-c")
           .arg("y4m")
           .arg(path)
           .arg("-")
@@ -246,10 +247,7 @@ fn build_decoder(
         for arg in vspipe_args {
           command.args(["-a", &arg]);
         }
-        let vspipe = command
-          .spawn()?
-          .stdout
-          .unwrap();
+        let vspipe = command.spawn()?.stdout.unwrap();
         Decoder::Y4m(y4m::Decoder::new(
           Command::new("ffmpeg")
             .stdin(vspipe)

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -234,7 +234,7 @@ fn build_decoder(
   };
 
   let decoder = match input {
-    Input::VapourSynth(path, _) => {
+    Input::VapourSynth { path, .. } => {
       bit_depth = crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?)?;
 
       if !filters.is_empty() || !vspipe_args.is_empty() {
@@ -270,7 +270,7 @@ fn build_decoder(
         Decoder::Vapoursynth(VapoursynthDecoder::new(path.as_ref())?)
       }
     }
-    Input::Video(path) => {
+    Input::Video { path } => {
       let input_pix_format = crate::ffmpeg::get_pixel_format(path.as_ref())
         .unwrap_or_else(|e| panic!("FFmpeg failed to get pixel format for input video: {e:?}"));
       bit_depth = encoder.get_format_bit_depth(sc_pix_format.unwrap_or(input_pix_format))?;

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -38,9 +38,8 @@ pub fn av_scenechange_detect(
   }
 
   let input2 = input.clone();
-  let vspipe_args2 = vspipe_args.clone();
   let frame_thread = thread::spawn(move || {
-    let frames = input2.frames(vspipe_args2).unwrap();
+    let frames = input2.frames().unwrap();
     if verbosity != Verbosity::Quiet {
       progress_bar::convert_to_progress(0);
       progress_bar::set_len(frames as u64);
@@ -235,8 +234,8 @@ fn build_decoder(
   };
 
   let decoder = match input {
-    Input::VapourSynth(path) => {
-      bit_depth = crate::vapoursynth::bit_depth(path.as_ref(), vspipe_args.clone())?;
+    Input::VapourSynth(path, _) => {
+      bit_depth = crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?)?;
 
       if !filters.is_empty() || !vspipe_args.is_empty() {
         let mut command = Command::new("vspipe");

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -18,7 +18,6 @@ use crate::{into_smallvec, progress_bar, Encoder, Input, ScenecutMethod, Verbosi
 pub fn av_scenechange_detect(
   input: &Input,
   encoder: Encoder,
-  vspipe_args: Vec<String>,
   total_frames: usize,
   min_scene_len: usize,
   verbosity: Verbosity,
@@ -50,7 +49,6 @@ pub fn av_scenechange_detect(
   let scenes = scene_detect(
     input,
     encoder,
-    vspipe_args,
     total_frames,
     if verbosity == Verbosity::Quiet {
       None
@@ -79,7 +77,6 @@ pub fn av_scenechange_detect(
 pub fn scene_detect(
   input: &Input,
   encoder: Encoder,
-  vspipe_args: Vec<String>,
   total_frames: usize,
   callback: Option<&dyn Fn(usize)>,
   min_scene_len: usize,
@@ -92,7 +89,6 @@ pub fn scene_detect(
   let (mut decoder, bit_depth) = build_decoder(
     input,
     encoder,
-    vspipe_args,
     sc_scaler,
     sc_pix_format,
     sc_downscale_height,
@@ -210,7 +206,6 @@ pub fn scene_detect(
 fn build_decoder(
   input: &Input,
   encoder: Encoder,
-  vspipe_args: Vec<String>,
   sc_scaler: &str,
   sc_pix_format: Option<Pixel>,
   sc_downscale_height: Option<usize>,
@@ -236,6 +231,7 @@ fn build_decoder(
   let decoder = match input {
     Input::VapourSynth { path, .. } => {
       bit_depth = crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?)?;
+      let vspipe_args = input.as_vspipe_args_vec()?;
 
       if !filters.is_empty() || !vspipe_args.is_empty() {
         let mut command = Command::new("vspipe");

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -261,7 +261,6 @@ fn get_test_args() -> Av1anContext {
     force: false,
     passes: 2,
     video_params: into_vec!["--cq-level=40", "--cpu-used=0", "--aq-mode=1"],
-    vspipe_args: vec![],
     output_file: String::new(),
     audio_params: Vec::new(),
     chunk_method: ChunkMethod::LSMASH,

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -261,6 +261,7 @@ fn get_test_args() -> Av1anContext {
     force: false,
     passes: 2,
     video_params: into_vec!["--cq-level=40", "--cpu-used=0", "--aq-mode=1"],
+    vspipe_args: vec![],
     output_file: String::new(),
     audio_params: Vec::new(),
     chunk_method: ChunkMethod::LSMASH,

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -278,7 +278,9 @@ fn get_test_args() -> Av1anContext {
     input_pix_format: InputPixelFormat::FFmpeg {
       format: Pixel::YUV420P10LE,
     },
-    input: Input::Video(PathBuf::new()),
+    input: Input::Video {
+      path: PathBuf::new()
+    },
     output_pix_format: PixelFormat {
       format: Pixel::YUV420P10LE,
       bit_depth: 10,

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -279,7 +279,7 @@ fn get_test_args() -> Av1anContext {
       format: Pixel::YUV420P10LE,
     },
     input: Input::Video {
-      path: PathBuf::new()
+      path: PathBuf::new(),
     },
     output_pix_format: PixelFormat {
       format: Pixel::YUV420P10LE,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -40,7 +40,6 @@ pub struct EncodeArgs {
   pub chunk_method: ChunkMethod,
   pub chunk_order: ChunkOrdering,
   pub scaler: String,
-  pub vspipe_args: Vec<String>,
   pub scenes: Option<PathBuf>,
   pub split_method: SplitMethod,
   pub sc_pix_format: Option<Pixel>,
@@ -176,7 +175,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     if self.video_params.is_empty() {
       self.video_params = self
         .encoder
-        .get_default_arguments(self.input.calculate_tiles(self.vspipe_args.clone()));
+        .get_default_arguments(self.input.calculate_tiles());
     }
 
     if let Some(strength) = self.photon_noise {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -40,6 +40,7 @@ pub struct EncodeArgs {
   pub chunk_method: ChunkMethod,
   pub chunk_order: ChunkOrdering,
   pub scaler: String,
+  pub vspipe_args: Vec<String>,
   pub scenes: Option<PathBuf>,
   pub split_method: SplitMethod,
   pub sc_pix_format: Option<Pixel>,
@@ -175,7 +176,7 @@ properly into a mkv file. Specify mkvmerge as the concatenation method by settin
     if self.video_params.is_empty() {
       self.video_params = self
         .encoder
-        .get_default_arguments(self.input.calculate_tiles());
+        .get_default_arguments(self.input.calculate_tiles(self.vspipe_args.clone()));
     }
 
     if let Some(strength) = self.photon_noise {

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -34,6 +34,7 @@ pub struct TargetQuality {
   pub temp: String,
   pub workers: usize,
   pub video_params: Vec<String>,
+  pub vspipe_args: Vec<String>,
   pub probe_slow: bool,
 }
 
@@ -247,6 +248,7 @@ impl TargetQuality {
     vmaf::run_vmaf(
       &probe_name,
       chunk.source_cmd.as_slice(),
+      self.vspipe_args.clone(),
       &fl_path,
       self.model.as_ref(),
       &self.vmaf_res,

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -262,24 +262,13 @@ pub fn create_vs_file(
   Ok(load_script_path)
 }
 
-pub fn num_frames(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usize> {
+pub fn num_frames(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<usize> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment
@@ -289,24 +278,13 @@ pub fn num_frames(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usi
   get_num_frames(&environment)
 }
 
-pub fn bit_depth(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usize> {
+pub fn bit_depth(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<usize> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment
@@ -316,24 +294,13 @@ pub fn bit_depth(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usiz
   get_bit_depth(&environment)
 }
 
-pub fn frame_rate(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<f64> {
+pub fn frame_rate(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<f64> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment
@@ -343,24 +310,13 @@ pub fn frame_rate(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<f64
   get_frame_rate(&environment)
 }
 
-pub fn resolution(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<(u32, u32)> {
+pub fn resolution(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<(u32, u32)> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment
@@ -371,24 +327,13 @@ pub fn resolution(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<(u3
 }
 
 /// Transfer characteristics as specified in ITU-T H.265 Table E.4.
-pub fn transfer_characteristics(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<u8> {
+pub fn transfer_characteristics(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<u8> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment
@@ -398,24 +343,13 @@ pub fn transfer_characteristics(source: &Path, vspipe_args: Vec<String>) -> anyh
   get_transfer(&environment)
 }
 
-pub fn pixel_format(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<String> {
+pub fn pixel_format(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<String> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
 
-  if !vspipe_args.is_empty() {
-    let mut args_map = OwnedMap::new(API::get().unwrap());
-
-    for arg in vspipe_args {
-      let split: Vec<&str> = arg.split_terminator('=').collect();
-      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
-        bail!("Failed to split vspipe arguments");
-      }
-    }
-
-    if environment.set_variables(&args_map).is_err() {
-      bail!("Failed to set vspipe arguments");
-    };
-  }
+  if environment.set_variables(&vspipe_args_map).is_err() {
+    bail!("Failed to set vspipe arguments");
+  };
 
   // Evaluate the script.
   environment

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -262,9 +262,24 @@ pub fn create_vs_file(
   Ok(load_script_path)
 }
 
-pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
+pub fn num_frames(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usize> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment
@@ -274,9 +289,24 @@ pub fn num_frames(source: &Path) -> anyhow::Result<usize> {
   get_num_frames(&environment)
 }
 
-pub fn bit_depth(source: &Path) -> anyhow::Result<usize> {
+pub fn bit_depth(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<usize> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment
@@ -286,9 +316,24 @@ pub fn bit_depth(source: &Path) -> anyhow::Result<usize> {
   get_bit_depth(&environment)
 }
 
-pub fn frame_rate(source: &Path) -> anyhow::Result<f64> {
+pub fn frame_rate(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<f64> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment
@@ -298,9 +343,24 @@ pub fn frame_rate(source: &Path) -> anyhow::Result<f64> {
   get_frame_rate(&environment)
 }
 
-pub fn resolution(source: &Path) -> anyhow::Result<(u32, u32)> {
+pub fn resolution(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<(u32, u32)> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment
@@ -311,9 +371,24 @@ pub fn resolution(source: &Path) -> anyhow::Result<(u32, u32)> {
 }
 
 /// Transfer characteristics as specified in ITU-T H.265 Table E.4.
-pub fn transfer_characteristics(source: &Path) -> anyhow::Result<u8> {
+pub fn transfer_characteristics(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<u8> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment
@@ -323,9 +398,24 @@ pub fn transfer_characteristics(source: &Path) -> anyhow::Result<u8> {
   get_transfer(&environment)
 }
 
-pub fn pixel_format(source: &Path) -> anyhow::Result<String> {
+pub fn pixel_format(source: &Path, vspipe_args: Vec<String>) -> anyhow::Result<String> {
   // Create a new VSScript environment.
   let mut environment = Environment::new().unwrap();
+
+  if !vspipe_args.is_empty() {
+    let mut args_map = OwnedMap::new(API::get().unwrap());
+
+    for arg in vspipe_args {
+      let split: Vec<&str> = arg.split_terminator('=').collect();
+      if args_map.append_data(split[0], split[1].as_bytes()).is_err() {
+        bail!("Failed to split vspipe arguments");
+      }
+    }
+
+    if environment.set_variables(&args_map).is_err() {
+      bail!("Failed to set vspipe arguments");
+    };
+  }
 
   // Evaluate the script.
   environment

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -148,11 +148,14 @@ pub fn plot(
           "-"
         ]
       )
-    },
-    Input::VapourSynth { ref path, vspipe_args: args } => {
+    }
+    Input::VapourSynth {
+      ref path,
+      vspipe_args: args,
+    } => {
       vspipe_args = args.to_owned();
       ref_smallvec!(OsStr, 8, ["vspipe", "-c", "y4m", path, "-"])
-    },
+    }
   };
 
   run_vmaf(

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -132,7 +132,7 @@ pub fn plot(
   println!(":: VMAF Run");
 
   let pipe_cmd: SmallVec<[&OsStr; 8]> = match reference {
-    Input::Video(ref path) => {
+    Input::Video { ref path } => {
       vspipe_args = vec![];
       ref_smallvec!(
         OsStr,
@@ -149,8 +149,8 @@ pub fn plot(
         ]
       )
     },
-    Input::VapourSynth(ref path, vspipe_args_) => {
-      vspipe_args = vspipe_args_.to_owned();
+    Input::VapourSynth { ref path, vspipe_args: args } => {
+      vspipe_args = args.to_owned();
       ref_smallvec!(OsStr, 8, ["vspipe", "-c", "y4m", path, "-"])
     },
   };

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -199,13 +199,12 @@ pub struct CliOpts {
   /// defining the width of the lanczos scaler.
   #[clap(long, default_value = "bicubic")]
   pub scaler: String,
-  
+
   /// Pass python argument(s) to the script environment
-  /// 
   /// --vspipe-args "message=fluffy kittens" "head=empty"
   #[clap(long, num_args(0..))]
   pub vspipe_args: Vec<String>,
-  
+
   /// File location for scenes
   #[clap(short, long, help_heading = "Scene Detection")]
   pub scenes: Option<PathBuf>,
@@ -731,9 +730,10 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
             })?,
           },
           Input::VapourSynth { path, .. } => InputPixelFormat::VapourSynth {
-            bit_depth: crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?).with_context(|| {
-              format!("VapourSynth failed to get bit depth for input video {path:?}")
-            })?,
+            bit_depth: crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?)
+              .with_context(|| {
+                format!("VapourSynth failed to get bit depth for input video {path:?}")
+              })?,
           },
         }
       },

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -725,12 +725,12 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
       min_scene_len: args.min_scene_len,
       input_pix_format: {
         match &input {
-          Input::Video(path) => InputPixelFormat::FFmpeg {
+          Input::Video { path } => InputPixelFormat::FFmpeg {
             format: ffmpeg::get_pixel_format(path.as_ref()).with_context(|| {
               format!("FFmpeg failed to get pixel format for input video {path:?}")
             })?,
           },
-          Input::VapourSynth(path, _) => InputPixelFormat::VapourSynth {
+          Input::VapourSynth { path, .. } => InputPixelFormat::VapourSynth {
             bit_depth: crate::vapoursynth::bit_depth(path.as_ref(), input.as_vspipe_args_map()?).with_context(|| {
               format!("VapourSynth failed to get bit depth for input video {path:?}")
             })?,

--- a/site/src/Cli/general.md
+++ b/site/src/Cli/general.md
@@ -80,6 +80,11 @@
 		Valid scalers are based on the scalers available in ffmpeg, including lanczos[1-9] with [1-9]
         defining the width of the lanczos scaler.
 
+	--vspipe-args <VSPIPE_ARGS>
+		Pass python argument(s) to the script environment
+
+		Example: --vspipe-args "message=fluffy kittens" "head=empty"
+
 -h, --help
 		Print help information
 


### PR DESCRIPTION
This adds support to use the `--arg key=value` argument through av1an.

Usage:
`av1an -i script.vpy --vspipe-args "source=video.mp4"`
`av1an -i script.vpy --vspipe-args "deinterlace=True" "source=video.mp4"`

The `Vec<String>` containing the input is saved in the `Vapoursynth` variant/struct of `Input`.

Changes are welcome.
Completes #528 .