### PR TITLE
libvmaf: Use model='path=...' instead of model_path=...

### DIFF
--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -204,7 +204,7 @@ pub fn run_vmaf(
 
   let vmaf = if let Some(model) = model {
     format!(
-      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:model_path={}:n_threads={}",
+      "[distorted][ref]libvmaf=log_fmt='json':eof_action=endall:log_path={}:model='path={}':n_threads={}",
       ffmpeg::escape_path_in_filter(stat_file),
       ffmpeg::escape_path_in_filter(&model),
       threads


### PR DESCRIPTION
Closes #856.
Closes #821.

I only have a slow laptop at the moment. Can someone else please test this change?

This is a quick bandaid over `--vmaf-path` not working in FFmpeg 7. It probably can't handle paths with a `'`, but I'm not sure.

See #659 and #724 and #806 for proper solutions instead of this.