### PR TITLE
Remove once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,6 @@ dependencies = [
  "clap",
  "ffmpeg-the-third",
  "flexi_logger",
- "once_cell",
  "path_abs",
  "shlex",
  "thiserror",

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -25,7 +25,6 @@ path_abs = "0.5.1"
 anyhow = "1.0.42"
 av1an-core = { path = "../av1an-core", version = "0.4.1" }
 thiserror = "1.0.30"
-once_cell = "1.8.0"
 ansi_term = "0.12.1"
 
 [dependencies.flexi_logger]

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
+use std::sync::OnceLock;
 use std::thread::available_parallelism;
 use std::{panic, process};
 
@@ -21,7 +22,6 @@ use av1an_core::{
 use clap::{value_parser, Parser};
 use flexi_logger::writers::LogWriter;
 use flexi_logger::{FileSpec, Level, LevelFilter, LogSpecBuilder, Logger};
-use once_cell::sync::OnceCell;
 use path_abs::{PathAbs, PathInfo};
 
 fn main() -> anyhow::Result<()> {
@@ -53,7 +53,7 @@ fn version() -> &'static str {
     )
   }
 
-  static INSTANCE: OnceCell<String> = OnceCell::new();
+  static INSTANCE: OnceLock<String> = OnceLock::new();
   INSTANCE.get_or_init(|| {
     match (
       option_env!("VERGEN_GIT_SHA"),


### PR DESCRIPTION
[`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) was stabilized in 1.70 (MSRV is also 1.70).