### PR TITLE
Replace atty crate with fn is_terminal from std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,17 +147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,7 +252,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "arrayvec",
- "atty",
  "av-format",
  "av-ivf",
  "av-scenechange",
@@ -807,15 +795,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1081,7 +1060,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys",
@@ -1198,7 +1177,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ version = "0.4.1"
 dependencies = [
  "ansi_term",
  "anyhow",
- "atty",
  "av1an-core",
  "clap",
  "ffmpeg-the-third",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -17,7 +17,6 @@ license = "GPL-3.0"
 [dependencies]
 log = "0.4.14"
 arrayvec = "0.7.2"
-atty = "0.2.14"
 av-format = "0.7.0"
 av-ivf = "0.5.0"
 av1-grain = { version = "0.2.1", default-features = false, features = [

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command, Stdio};
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};
@@ -258,7 +258,7 @@ impl Av1anContext {
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 
-      if atty::is(atty::Stream::Stderr) {
+      if std::io::stderr().is_terminal() {
         eprintln!(
           "{}{} {} {}{} {} {}{} {}\n{}: {}",
           Color::Green.bold().paint("Q"),

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::process::{Command, Stdio};
 use std::thread;
 
@@ -28,7 +28,7 @@ pub fn av_scenechange_detect(
   zones: &[Scene],
 ) -> anyhow::Result<(Vec<Scene>, usize)> {
   if verbosity != Verbosity::Quiet {
-    if atty::is(atty::Stream::Stderr) {
+    if std::io::stderr().is_terminal() {
       eprintln!("{}", Style::default().bold().paint("Scene detection"));
     } else {
       eprintln!("Scene detection");

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -18,7 +18,6 @@ name = "av1an"
 path = "src/main.rs"
 
 [dependencies]
-atty = "0.2.14"
 clap = { version = "4.0.32", features = ["derive"] }
 shlex = "1.3.0"
 path_abs = "0.5.1"

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::thread::available_parallelism;
@@ -824,7 +824,7 @@ impl LogWriter for StderrLogger {
       return Ok(());
     }
 
-    let style = if atty::is(atty::Stream::Stderr) {
+    let style = if io::stderr().is_terminal() {
       match record.level() {
         Level::Error => Style::default().fg(Color::Fixed(196)).bold(),
         Level::Warn => Style::default().fg(Color::Fixed(208)).bold(),


### PR DESCRIPTION
[`is_terminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal) is stable since 1.70 (MSRV is also 1.70).

The [atty crate](https://crates.io/crates/atty) is also unmaintained and has an [unfixed security issue](https://github.com/softprops/atty/issues/50)