### PR TITLE
Fix cargo lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "av1an"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "av1an-core"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "affinity",
  "ansi_term",


### PR DESCRIPTION
Some packagers such as Arch's use `--locked` when building, which requires the Cargo.lock file to be up to date or else the package will fail to build.