### PR TITLE
Remove assertion that prevents resuming if all chunks are finished

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -97,8 +97,6 @@ impl Display for EncoderCrash {
 impl<'a> Broker<'a> {
   /// Main encoding loop. set_thread_affinity may be ignored if the value is invalid.
   pub fn encoding_loop(self, tx: Sender<()>, set_thread_affinity: Option<usize>) {
-    assert!(!self.chunk_queue.is_empty());
-
     if !self.chunk_queue.is_empty() {
       let (sender, receiver) = crossbeam_channel::bounded(self.chunk_queue.len());
 


### PR DESCRIPTION
There is an edge case where a user may want to resume an encode after all chunks have completed. This is typically because all chunks finished encoding, but concatenation failed. This change removes an assertion which prevented that edge case from progressing. The assertion does not seem to be necessary, as the entire contents of this function are already wrapped in an `if` using the same condition as the assertion.