### PR TITLE
Windows build and compiling.md changes

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,10 +10,9 @@ jobs:
 
     env:
       CARGO_INCREMENTAL: 0
-
-      ffmpeg_ver: "7.0"
+      ffmpeg_ver: "7.0.2"
       ffmpeg_path: "C:/ffmpeg"
-      vsynth_ver: "R69"
+      vsynth_ver: "R70"
       vsynth_path: "C:/Program Files/Vapoursynth"
 
     steps:
@@ -42,7 +41,17 @@ jobs:
           Expand-Archive "$tempFile" "$env:vsynth_path"
 
       - uses: actions/checkout@v4
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v${{ env.ffmpeg_ver }}-rust"
+
+      - name: Get latest commit
+        id: get_commit
+        shell: pwsh
+        run: |
+          $commit = git log -1 --pretty=format:"%h: %s (%an)"
+          echo "message=$commit" >> $env:GITHUB_OUTPUT
 
       - name: Av1an build
         run: cargo build --release
@@ -52,6 +61,8 @@ jobs:
         with:
           prerelease: true
           tag_name: latest
+          body: |
+            Commit:
+            ${{ steps.get_commit.outputs.message }}
           files: target/release/av1an.exe
           fail_on_unmatched_files: true
-

--- a/site/src/compiling.md
+++ b/site/src/compiling.md
@@ -6,11 +6,11 @@ You can natively build Av1an on Linux and Windows. Cross-compilation is not supp
 
 To compile Av1an from source, you need the following dependencies:
 
-- [Rust](https://www.rust-lang.org/) (version 1.70.0 or higher)
-- [NASM](https://www.nasm.us/)
-- [clang/LLVM](https://llvm.org/)
-- [FFmpeg](https://ffmpeg.org/)
-- [VapourSynth](https://www.vapoursynth.com/)
+- [Rust](https://www.rust-lang.org) (version 1.70.0 or higher)
+- [NASM](https://www.nasm.us)
+- [clang/LLVM](https://llvm.org)
+- [FFmpeg](https://ffmpeg.org)
+- [VapourSynth](https://www.vapoursynth.com)
 
 On Arch Linux, you can install these dependencies by running
 
@@ -35,21 +35,22 @@ If you just want a current build of Av1an that is newer than the last official r
 
 If you want to build the binary yourself, you will need the following dependencies:
 
-- [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) - this is a dependency for Rust
+- [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools) - this is a dependency for Rust
 - [The Rust toolchain](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)
 - [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases/latest) (download the portable version; the installed version could also work)
-- [NASM](https://nasm.us/)
-- [FFmpeg](https://github.com/GyanD/codexffmpeg/releases/download/7.0/ffmpeg-7.0-full_build-shared.7z) (thanks to [gyan](https://github.com/GyanD) for providing these builds)
+- [NASM](https://nasm.us)
+- [FFmpeg](https://github.com/GyanD/codexffmpeg/releases/download/7.0.2/ffmpeg-7.0.2-full_build-shared.7z) (thanks to [gyan](https://github.com/GyanD) for providing these builds)
+- [LLVM](https://releases.llvm.org)
 
 ### FFmpeg setup:
-- Extract the file `ffmpeg-7.0-full_build-shared.7z` to a directory.
-- Create a new environment variable named `FFMPEG_DIR` and set it to the directory path where you extracted `ffmpeg-7.0-full_build-shared.7z`.
-  - (For example, set `FFMPEG_DIR` to `C:\Users\Username\Downloads\ffmpeg-7.0-full_build-shared`)
+- Extract the file `ffmpeg-7.0.2-full_build-shared.7z` to a directory.
+- Create a new environment variable named `FFMPEG_DIR` and set it to the directory path where you extracted `ffmpeg-7.0.2-full_build-shared.7z`.
+  - (For example, set `FFMPEG_DIR` to `C:\Users\Username\Downloads\ffmpeg-7.0.2-full_build-shared`)
 	
 ### VapourSynth setup:
 - Extract the contents of the portable VapourSynth zip file to a directory.
 - Create a new environment variable named `VAPOURSYNTH_LIB_DIR` and set it to the directory path where you extracted the file, appending `\sdk\lib64` to the path.
-  - (For example, set `VAPOURSYNTH_LIB_DIR` to `C:\Users\Username\Downloads\VapourSynth64-Portable-R69\sdk\lib64`)
+  - (For example, set `VAPOURSYNTH_LIB_DIR` to `C:\Users\Username\Downloads\VapourSynth64-Portable-R70\sdk\lib64`)
 
 Then, either clone the repository by running
 
@@ -61,4 +62,4 @@ Or download and extract the [source code](https://github.com/master-of-zen/Av1an
 
 Open a command prompt or PowerShell window inside the cloned repository/extracted ZIP folder and run the command `cargo build --release`. If this command executes successfully with no errors, `av1an.exe` will be in the folder `target\release`.
 
-To use `av1an.exe`, copy all the `.dll` files from `ffmpeg-7.0-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.
+To use `av1an.exe`, copy all the `.dll` files from `ffmpeg-7.0.2-full_build-shared\bin` to the same directory as `av1an.exe`, and ensure that `ffmpeg.exe` is in a folder accessible via the `PATH` environment variable.


### PR DESCRIPTION
I updated FFmpeg and VapourSynth in windows-build.yml
Made it so that updating FFmpeg doesn't cause the workflow to fail
I also fixed the release description not updating for the latest build (See [this](https://github.com/Uranite/Av1an/releases/tag/latest) for example)

I added LLVM to the compiling guide for Windows, because as it turns out, LLVM is required
Closes #840 