### PR TITLE
Fix compatibility with x265 4.0

### DIFF
--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -149,7 +149,7 @@ impl Encoder {
       Self::x265 => chain!(
         into_array!["x265", "--y4m", "--frames", frame_count.to_string()],
         params,
-        into_array!["-", "-o", output]
+        into_array!["--input", "-", "-o", output]
       )
       .collect(),
     }
@@ -232,6 +232,7 @@ impl Encoder {
           format!("{fpf}.log"),
           "--analysis-reuse-file",
           format!("{fpf}_analysis.dat"),
+          "--input",
           "-",
           "-o",
           NULL
@@ -331,6 +332,7 @@ impl Encoder {
           format!("{fpf}.log"),
           "--analysis-reuse-file",
           format!("{fpf}_analysis.dat"),
+          "--input",
           "-",
           "-o",
           output


### PR DESCRIPTION
x265 version 4.0 introduced an undocumented breaking change to the CLI where passing the input without the `--input` flag is no longer supported. Therefore, we need to update av1an accordingly. The `--input` syntax is also supported by x265 3.x, so this change is backwards compatible.