### PR TITLE
fix(av1an-core): fix path-handling in vapoursynth script

### DIFF
--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -247,13 +247,13 @@ pub fn create_vs_file(
       format!(
         "from vapoursynth import core\n\
             core.max_cache_size=1024\n\
-      core.{}({:?}, cachefile={:?}).set_output()",
+      core.{}(r\"{}\", cachefile={:?}).set_output()",
         match chunk_method {
           ChunkMethod::FFMS2 => "ffms2.Source",
           ChunkMethod::LSMASH => "lsmas.LWLibavSource",
           _ => unreachable!(),
         },
-        source,
+        source.display(),
         cache_file
       )
       .as_bytes(),


### PR DESCRIPTION
- Use `Display` trait instead of `Debug` for path formatting to preserve Unicode characters
- Wrap source path with r"" raw string literal in Python template
- Platform-safe escaping for Windows backslash characters
- Improve handling of special characters (\n, \t, etc.) in file paths

This should fix #920