### PR TITLE
Update ffmpeg to 7.1 for the windows workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ jobs:
 
     env:
       CARGO_INCREMENTAL: 0
-      ffmpeg_ver: "7.0.2"
+      ffmpeg_ver: "7.1"
       ffmpeg_path: "C:/ffmpeg"
       vsynth_ver: "R70"
       vsynth_path: "C:/Program Files/Vapoursynth"


### PR DESCRIPTION
Update ffmpeg to 7.1 in the windows workflow file since now ffmpeg 7.1 is officially supported