### PR TITLE
Fix Scene Detection frames mismatch causes invalid frame access crashes

### DIFF
--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -39,7 +39,7 @@ pub fn av_scenechange_detect(
 
   let input2 = input.clone();
   let frame_thread = thread::spawn(move || {
-    let frames = input2.frames().unwrap();
+    let frames = input2.frames(None).unwrap();
     if verbosity != Verbosity::Quiet {
       progress_bar::convert_to_progress(0);
       progress_bar::set_len(frames as u64);

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -47,6 +47,7 @@ pub fn av_scenechange_detect(
     frames
   });
 
+  let frames = frame_thread.join().unwrap();
   let scenes = scene_detect(
     input,
     encoder,
@@ -65,8 +66,6 @@ pub fn av_scenechange_detect(
     sc_downscale_height,
     zones,
   )?;
-
-  let frames = frame_thread.join().unwrap();
 
   progress_bar::finish_progress_bar();
 


### PR DESCRIPTION
Scene Detection currently uses FFmpeg, even when the chunking method used later encodes the video with a VapourSynth script. This leads to a mismatch in the frame count and crashes on the offending chunk. Scene Detection should instead use the same decoding method as Av1an does when encoding chunks in order to avoid this mismatch.

Additionally, when testing this fix I discovered a race condition that fails scene detection when retrieving the frame count in a thread. I don't fully understand why this occurs but moving the resolution of that thread *before* scene detection starts resolves that race condition.

This issue can be replicated by improperly cutting a lossless clip and using that as the input while specifying a chunking method that generates/uses a VapourSynth script.

As a workaround, users can instead input a VapourSynth script instead of the clip itself and the Scene Detection should perform the same function as this PR.

Thank you,
\- Boats M.