### PR TITLE
Fix clippy issues and stop it from breaking with every Rust update

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -733,14 +733,13 @@ impl Av1anContext {
     let zones = self.parse_zones()?;
 
     // Create a new input with the generated VapourSynth script for Scene Detection
-    let input = if let Some(ref vs_script) = self.vs_script {
-      Input::VapourSynth {
+    let input = self.vs_script.as_ref().map_or_else(
+      || self.args.input.clone(),
+      |vs_script| Input::VapourSynth {
         path: vs_script.clone(),
         vspipe_args: Vec::new(),
-      }
-    } else {
-      self.args.input.clone()
-    };
+      },
+    );
 
     Ok(match self.args.split_method {
       SplitMethod::AvScenechange => av_scenechange_detect(

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -820,6 +820,7 @@ impl Encoder {
     }
   }
 
+  #[allow(clippy::too_many_arguments)]
   /// Constructs tuple of commands for target quality probing
   pub fn probe_cmd(
     self,

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -1,22 +1,3 @@
-#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::wildcard_imports)]
-#![allow(clippy::unsafe_derive_deserialize)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::use_self)]
-
 #[macro_use]
 extern crate log;
 
@@ -123,10 +104,7 @@ impl Input {
         ffmpeg::num_frames(path.as_path()).map_err(|_| anyhow::anyhow!(FAIL_MSG))?
       }
       path => vapoursynth::num_frames(
-        vs_script_path
-          .as_ref()
-          .map(|p| p.as_path())
-          .unwrap_or(path.as_path()),
+        vs_script_path.as_deref().unwrap_or(path.as_path()),
         self.as_vspipe_args_map()?,
       )
       .map_err(|_| anyhow::anyhow!(FAIL_MSG))?,

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -16,6 +16,7 @@ use crate::scenes::Scene;
 use crate::{into_smallvec, progress_bar, Encoder, Input, ScenecutMethod, Verbosity};
 
 #[tracing::instrument]
+#[allow(clippy::too_many_arguments)]
 pub fn av_scenechange_detect(
   input: &Input,
   encoder: Encoder,
@@ -73,7 +74,7 @@ pub fn av_scenechange_detect(
 }
 
 /// Detect scene changes using rav1e scene detector.
-#[allow(clippy::option_if_let_else)]
+#[allow(clippy::too_many_arguments)]
 pub fn scene_detect(
   input: &Input,
   encoder: Encoder,

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -114,6 +114,7 @@ pub fn validate_libvmaf() -> anyhow::Result<()> {
   Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn plot(
   encoded: &Path,
   reference: &Input,
@@ -174,6 +175,7 @@ pub fn plot(
   Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_vmaf(
   encoded: &Path,
   reference_pipe_cmd: &[impl AsRef<OsStr>],


### PR DESCRIPTION
The lints in `nursery` and `pedantic` are not intended to be stable, and many of them will be added or changed with each Rust update. This makes it annoying to maintain the package, because CI will begin failing every 6 weeks when a new Rust version releases. This cleans up this version's new pedantic lints, and then removes our overrides that enable the unstable lints.

It looks like this was already done in the `av1an` package a while ago, but we never did it for `av1an-core`.