### PR TITLE
Remove tokio dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "affinity"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,26 +282,10 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.12",
- "tokio",
  "tracing",
  "vapoursynth",
  "which",
  "y4m",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -793,14 +762,8 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -960,17 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,26 +1047,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "nix"
@@ -1258,15 +1190,6 @@ checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
 dependencies = [
  "libc",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1558,12 +1481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,15 +1617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,16 +1639,6 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
-name = "socket2"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1944,37 +1842,6 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tokio"
-version = "1.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
-dependencies = [
- "backtrace",
- "bytes",
- "io-uring",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "slab",
- "socket2",
- "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2192,12 +2059,6 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -2419,15 +2280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -69,7 +69,6 @@ vapoursynth = { version = "0.4.0", features = [
 colored = "3.0.0"
 ctrlc = "3.4.7"
 regex = "1.11.1"
-tokio = { version = "1.46", features = ["full"] }
 
 # TODO: https://github.com/elast0ny/affinity/issues/2
 # update this when macos support is implemented

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -1,19 +1,18 @@
 use std::{
     borrow::Cow,
     cmp::{self, Reverse},
-    convert::TryInto,
     ffi::OsString,
     fs::{self, File},
-    io::Write,
+    io::{BufRead, BufReader, Write},
     iter,
     path::{Path, PathBuf},
-    process::{exit, Stdio},
+    process::{exit, ChildStderr, Command, Stdio},
     sync::{
         atomic::{self, AtomicBool, AtomicUsize},
         mpsc,
         Arc,
     },
-    thread::available_parallelism,
+    thread::{self, available_parallelism},
 };
 
 use anyhow::Context;
@@ -22,11 +21,8 @@ use av_decoders::VapoursynthDecoder;
 use colored::*;
 use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
+use parking_lot::Mutex;
 use rand::{prelude::SliceRandom, rng};
-use tokio::{
-    io::{AsyncBufReadExt, BufReader},
-    process::ChildStderr,
-};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -566,12 +562,10 @@ impl Av1anContext {
             enc_cmd = chunk.encoder.man_command(enc_cmd, per_shot_target_quality_cq as usize);
         }
 
-        let rt = tokio::runtime::Builder::new_current_thread().enable_io().build().unwrap();
-
         let (source_pipe_stderr, ffmpeg_pipe_stderr, enc_output, enc_stderr, frame) =
-            rt.block_on(async {
+            thread::scope(|scope| {
                 let mut source_pipe = if let [source, args @ ..] = &*chunk.source_cmd {
-                    let mut command = tokio::process::Command::new(source);
+                    let mut command = Command::new(source);
                     for arg in chunk.input.as_vspipe_args_vec().unwrap() {
                         command.args(["-a", &arg]);
                     }
@@ -585,9 +579,7 @@ impl Av1anContext {
                     unreachable!()
                 };
 
-                let source_pipe_stdout: Stdio =
-                    source_pipe.stdout.take().unwrap().try_into().unwrap();
-
+                let source_pipe_stdout: Stdio = source_pipe.stdout.take().unwrap().into();
                 let source_pipe_stderr = source_pipe.stderr.take().unwrap();
 
                 // converts the pixel format
@@ -598,7 +590,7 @@ impl Av1anContext {
                     );
 
                     let mut ffmpeg_pipe = if let [ffmpeg, args @ ..] = &*ffmpeg_pipe {
-                        tokio::process::Command::new(ffmpeg)
+                        Command::new(ffmpeg)
                             .args(args)
                             .stdin(pipe_from)
                             .stdout(Stdio::piped())
@@ -609,8 +601,7 @@ impl Av1anContext {
                         unreachable!()
                     };
 
-                    let ffmpeg_pipe_stdout: Stdio =
-                        ffmpeg_pipe.stdout.take().unwrap().try_into().unwrap();
+                    let ffmpeg_pipe_stdout: Stdio = ffmpeg_pipe.stdout.take().unwrap().into();
                     let ffmpeg_pipe_stderr = ffmpeg_pipe.stderr.take().unwrap();
                     (
                         ffmpeg_pipe_stdout,
@@ -645,41 +636,38 @@ impl Av1anContext {
                         create_ffmpeg_pipe(source_pipe_stdout, source_pipe_stderr)
                     };
 
-                let mut source_reader = BufReader::new(source_pipe_stderr).lines();
-                let ffmpeg_reader =
-                    ffmpeg_pipe_stderr.take().map(|stderr| BufReader::new(stderr).lines());
+                let source_reader = BufReader::new(source_pipe_stderr);
+                let ffmpeg_reader = ffmpeg_pipe_stderr.take().map(BufReader::new);
 
-                let pipe_stderr = Arc::new(parking_lot::Mutex::new(String::with_capacity(128)));
+                let pipe_stderr = Arc::new(Mutex::new(String::with_capacity(128)));
                 let p_stdr2 = Arc::clone(&pipe_stderr);
 
                 let ffmpeg_stderr = if ffmpeg_reader.is_some() {
-                    Some(Arc::new(parking_lot::Mutex::new(String::with_capacity(
-                        128,
-                    ))))
+                    Some(Arc::new(Mutex::new(String::with_capacity(128))))
                 } else {
                     None
                 };
 
                 let f_stdr2 = ffmpeg_stderr.clone();
 
-                tokio::spawn(async move {
-                    while let Some(line) = source_reader.next_line().await.unwrap() {
-                        p_stdr2.lock().push_str(&line);
+                scope.spawn(move || {
+                    for line in source_reader.lines() {
+                        p_stdr2.lock().push_str(&line.unwrap());
                         p_stdr2.lock().push('\n');
                     }
                 });
-                if let Some(mut ffmpeg_reader) = ffmpeg_reader {
+                if let Some(ffmpeg_reader) = ffmpeg_reader {
                     let f_stdr2 = f_stdr2.unwrap();
-                    tokio::spawn(async move {
-                        while let Some(line) = ffmpeg_reader.next_line().await.unwrap() {
-                            f_stdr2.lock().push_str(&line);
+                    scope.spawn(move || {
+                        for line in ffmpeg_reader.lines() {
+                            f_stdr2.lock().push_str(&line.unwrap());
                             f_stdr2.lock().push('\n');
                         }
                     });
                 }
 
                 let mut enc_pipe = if let [encoder, args @ ..] = &*enc_cmd {
-                    tokio::process::Command::new(encoder)
+                    Command::new(encoder)
                         .args(args)
                         .stdin(y4m_pipe)
                         .stdout(Stdio::piped())
@@ -697,7 +685,7 @@ impl Av1anContext {
                 let mut buf = Vec::with_capacity(128);
                 let mut enc_stderr = String::with_capacity(128);
 
-                while let Ok(read) = reader.read_until(b'\r', &mut buf).await {
+                while let Ok(read) = reader.read_until(b'\r', &mut buf) {
                     if read == 0 {
                         break;
                     }
@@ -728,7 +716,7 @@ impl Av1anContext {
                     buf.clear();
                 }
 
-                let enc_output = enc_pipe.wait_with_output().await.unwrap();
+                let enc_output = enc_pipe.wait_with_output().unwrap();
 
                 let source_pipe_stderr = pipe_stderr.lock().clone();
                 let ffmpeg_pipe_stderr = ffmpeg_stderr.map(|x| x.lock().clone());


### PR DESCRIPTION
We were not particularly using tokio's features in any way that couldn't be satified by basic threads, nor do we have anywhere near the level of concurrency which would result in benefitting from an async architecture, so we can remove this rather heavy dependency from the codebase, which reduced the time to compile a full release build by about 10%.