### PR TITLE
Fix 8-bit encode when probing rate is 1

### DIFF
--- a/av1an-core/src/encoder/mod.rs
+++ b/av1an-core/src/encoder/mod.rs
@@ -973,12 +973,18 @@ impl Encoder {
         vmaf_threads: usize,
         custom_video_params: Option<Vec<String>>,
     ) -> (Option<Vec<String>>, Vec<Cow<'static, str>>) {
-        let pipe = (probing_rate > 1).then(|| {
-            compose_ffmpeg_pipe(
-                ["-vf", format!("select=not(mod(n\\,{probing_rate}))").as_str(), "-vsync", "0"],
-                pix_fmt,
-            )
-        });
+        let filters = if probing_rate > 1 {
+            vec![
+                "-vf".to_string(),
+                format!("select=not(mod(n\\,{probing_rate}))"),
+                "-vsync".to_string(),
+                "0".to_string(),
+            ]
+        } else {
+            Vec::new()
+        };
+
+        let pipe = Some(compose_ffmpeg_pipe(filters, pix_fmt));
 
         let extension = match self {
             Encoder::x264 => "264",


### PR DESCRIPTION
When the target quality feature is used, and the probing rate is 1, the encode (and the probing) is 8bit, even though Av1an's default is 10bit (yuv420p10le)
This PR fixes this issue by running compose_ffmpeg_pipe regardless of the probe rate
Now the encode is 10bit when the target quality feature is used even when the probing rate is 1

ffmpeg adds about 200MB of memory per worker
Ideally we should be using VapourSynth for this for less overhead