### PR TITLE
Parse `nb_frames` from ffprobe as string

### DIFF
--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -49,7 +49,7 @@ struct FfProbeStreamInfo {
     pub pix_fmt:        String,
     pub color_transfer: Option<String>,
     pub avg_frame_rate: String,
-    pub nb_frames:      Option<usize>,
+    pub nb_frames:      Option<String>,
 }
 
 #[inline]
@@ -82,9 +82,9 @@ pub fn get_clip_info(source: &Path) -> anyhow::Result<ClipInfo> {
             Some("smpte2084") => av1_grain::TransferFunction::SMPTE2084,
             _ => av1_grain::TransferFunction::BT1886,
         },
-        num_frames:               match stream_info.nb_frames {
-            Some(nb_frames) => nb_frames,
-            None => get_num_frames(source)?,
+        num_frames:               match stream_info.nb_frames.as_deref().map(str::parse) {
+            Some(Ok(nb_frames)) => nb_frames,
+            _ => get_num_frames(source)?,
         },
     })
 }


### PR DESCRIPTION
This bug makes it impossible to use an MP4 file as input, but MKV files and WebM files work as expected.

Closes #1124 