### PR TITLE
ignore encoder pix_fmt check for scene detection

### DIFF
--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -357,6 +357,40 @@ impl FFPixelFormat {
             ),
         })
     }
+
+    #[inline]
+    pub fn get_format_bit_depth_usize(&self) -> usize {
+        match self {
+            FFPixelFormat::GBRP => 8,
+            FFPixelFormat::GBRP10LE => 10,
+            FFPixelFormat::GBRP12L => 12,
+            FFPixelFormat::GBRP12LE => 12,
+            FFPixelFormat::GRAY10LE => 10,
+            FFPixelFormat::GRAY12L => 12,
+            FFPixelFormat::GRAY12LE => 12,
+            FFPixelFormat::GRAY8 => 8,
+            FFPixelFormat::NV12 => 8,
+            FFPixelFormat::NV16 => 8,
+            FFPixelFormat::NV20LE => 10,
+            FFPixelFormat::NV21 => 8,
+            FFPixelFormat::YUV420P => 8,
+            FFPixelFormat::YUV420P10LE => 10,
+            FFPixelFormat::YUV420P12LE => 12,
+            FFPixelFormat::YUV422P => 8,
+            FFPixelFormat::YUV422P10LE => 10,
+            FFPixelFormat::YUV422P12LE => 12,
+            FFPixelFormat::YUV440P => 8,
+            FFPixelFormat::YUV440P10LE => 10,
+            FFPixelFormat::YUV440P12LE => 12,
+            FFPixelFormat::YUV444P => 8,
+            FFPixelFormat::YUV444P10LE => 10,
+            FFPixelFormat::YUV444P12LE => 12,
+            FFPixelFormat::YUVA420P => 8,
+            FFPixelFormat::YUVJ420P => 8,
+            FFPixelFormat::YUVJ422P => 8,
+            FFPixelFormat::YUVJ444P => 8,
+        }
+    }
 }
 
 impl FromStr for FFPixelFormat {

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -234,9 +234,9 @@ fn build_decoder(
     let sc_downscale_height =
         sc_downscale_height.filter(|&downscale_height| downscale_height < input_height as usize);
     let bit_depth = if let Some(sc_pix_format) = sc_pix_format {
-        encoder.get_format_bit_depth(sc_pix_format)?
+        sc_pix_format.get_format_bit_depth_usize()
     } else if let Ok(input_pix_format) = clip_info.format_info.as_pixel_format() {
-        encoder.get_format_bit_depth(input_pix_format)?
+        input_pix_format.get_format_bit_depth_usize()
     } else {
         clip_info.format_info.as_bit_depth()?
     };

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -1057,7 +1057,7 @@ pub fn parse_cli(args: &CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
             temp: temp.clone(),
             force: args.force,
             no_defaults: args.no_defaults,
-            passes: args.passes.map_or_else(|| args.encoder.get_default_pass(), |passes| passes),
+            passes: args.passes.unwrap_or_else(|| args.encoder.get_default_pass()),
             video_params: video_params.clone(),
             output_file: if let Some(path) = args.output_file.as_ref() {
                 let path = PathAbs::new(path)?;


### PR DESCRIPTION
`--sc-pix-format` is subject to encoder supported format check making it impossible to use different pixel format than the one that encoder support`. This pr map format to bitdepth directly bypass encoder supported format check in scene detection.

Fixed #539, Fixed #781