### PR TITLE
fix: seed VSSCRIPT_PATH from Windows registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "vergen-git2",
+ "winreg",
 ]
 
 [[package]]

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -29,6 +29,9 @@ tracing = { workspace = true }
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.55.0"
+
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "3.0.6"
 

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -72,6 +72,8 @@ fn seed_vsscript_path_from_registry() {
         };
 
         if !path.is_empty() && Path::new(&path).exists() {
+            // SAFETY: This runs during startup before Av1an initializes worker threads,
+            // so mutating the process environment here cannot race with other threads.
             unsafe {
                 env::set_var(VSSCRIPT_PATH_VARIABLE, path);
             }

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     fmt::Write as FmtWrite,
     io::{self, Write as IoWrite},
     panic,
@@ -43,7 +44,47 @@ use crate::logging::{init_logging, DEFAULT_LOG_LEVEL};
 
 mod logging;
 
+#[cfg(windows)]
+fn seed_vsscript_path_from_registry() {
+    use std::path::Path;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    const VSSCRIPT_PATH_VARIABLE: &str = "VSSCRIPT_PATH";
+    const VAPOURSYNTH_SUBKEY: &str = "SOFTWARE\\VapourSynth";
+    const VSSCRIPT_DLL_VALUE: &str = "VSScriptDLL";
+
+    if env::var_os(VSSCRIPT_PATH_VARIABLE).is_some_and(|value| !value.is_empty()) {
+        return;
+    }
+
+    let roots = [
+        RegKey::predef(HKEY_CURRENT_USER),
+        RegKey::predef(HKEY_LOCAL_MACHINE),
+    ];
+
+    for root in roots {
+        let Ok(key) = root.open_subkey(VAPOURSYNTH_SUBKEY) else {
+            continue;
+        };
+        let Ok(path) = key.get_value::<String, _>(VSSCRIPT_DLL_VALUE) else {
+            continue;
+        };
+
+        if !path.is_empty() && Path::new(&path).exists() {
+            unsafe {
+                env::set_var(VSSCRIPT_PATH_VARIABLE, path);
+            }
+            return;
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn seed_vsscript_path_from_registry() {}
+
 fn main() -> anyhow::Result<()> {
+    seed_vsscript_path_from_registry();
     let orig_hook = panic::take_hook();
     // Catch panics in child threads
     panic::set_hook(Box::new(move |panic_info| {


### PR DESCRIPTION
## Summary

On Windows, Av1an currently relies on one of these being true before VSScript can be loaded:

- `VSSCRIPT_PATH` is already set
- `vapoursynth.exe` is available on `PATH`

That misses a common installation state where VapourSynth is installed correctly, the `VSScriptDLL` registry value exists, but neither of the two discovery paths above is available to Av1an yet. In that case startup can fail with `VSScript API not available`.

This change adds a Windows-only fallback at process startup:

- if `VSSCRIPT_PATH` is missing or empty, read `VSScriptDLL` from `HKCU\\SOFTWARE\\VapourSynth` and `HKLM\\SOFTWARE\\VapourSynth`
- if the referenced DLL exists, seed `VSSCRIPT_PATH` before Av1an touches the VapourSynth bindings

## Why here

The existing `vapoursynth` Rust crate already honors `VSSCRIPT_PATH`; the missing piece is that Av1an does not currently populate it from the standard Windows VapourSynth installation metadata.

## Verification

Locally verified on Windows by:

1. Removing `VSSCRIPT_PATH` from the process environment
2. Removing the VapourSynth/Python entries from `PATH`
3. Running `av1an --version`

Before this patch, startup panicked with `VSScript API not available`.
After this patch, Av1an starts normally and detects VapourSynth through the registry-backed fallback.

I also ran `cargo build -p av1an` successfully.

Note: `cargo test -p av1an` still has pre-existing Windows `vpy` path escaping failures on `master` (for example `encode_test_vpy_input`), and this patch does not touch that area.