### PR TITLE
Add Fritsch–Carlson and generalized pchip from xav; use pchip for 6th+ probes

### DIFF
--- a/av1an-core/src/interpol.rs
+++ b/av1an-core/src/interpol.rs
@@ -115,87 +115,121 @@ pub fn natural_cubic_spline(x: &[f64], y: &[f64], xi: f64) -> Option<f64> {
     Some(b_coeff.mul_add(dx, a_coeff) + c_coeff.mul_add(dx.powi(2), d_coeff * dx.powi(3)))
 }
 
-pub fn pchip_interpolate(x: &[f64; 4], y: &[f64; 4], xi: f64) -> Option<f64> {
-    // Check strictly increasing
-    for i in 0..3 {
+pub fn fritsch_carlson(x: &[f64], y: &[f64], xi: f64) -> Option<f64> {
+    let n = x.len();
+    if n != 3 || n != y.len() || xi < x[0] || xi > x[n - 1] {
+        return None;
+    }
+
+    if x.windows(2).any(|pair| pair[1] <= pair[0]) {
+        return None;
+    }
+
+    let k = usize::from(xi >= x[1] && xi <= x[2]);
+
+    let d0 = (y[1] - y[0]) / (x[1] - x[0]);
+    let d1 = (y[2] - y[1]) / (x[2] - x[1]);
+
+    let mut m = [0.0; 3];
+
+    m[0] = d0;
+    m[2] = d1;
+
+    if d0 * d1 <= 0.0 {
+        m[1] = 0.0;
+    } else {
+        let h0 = x[1] - x[0];
+        let h1 = x[2] - x[1];
+        let w1 = 2.0f64.mul_add(h1, h0);
+        let w2 = 2.0f64.mul_add(h0, h1);
+        m[1] = (w1 + w2) / (w1 / d0 + w2 / d1);
+    }
+
+    let h = x[k + 1] - x[k];
+    let t = (xi - x[k]) / h;
+    let t2 = t * t;
+    let t3 = t2 * t;
+
+    let h00 = 2.0f64.mul_add(t3, 3.0f64.mul_add(-t2, 1.0));
+    let h10 = 2.0f64.mul_add(-t2, t3.mul_add(1.0, t));
+    let h01 = (-2.0f64).mul_add(t3, 3.0 * t2);
+    let h11 = t3 - t2;
+
+    Some((h11 * h).mul_add(
+        m[k + 1],
+        h00.mul_add(y[k], h10.mul_add(h * m[k], h01 * y[k + 1])),
+    ))
+}
+
+pub fn pchip_interpolate(x: &[f64], y: &[f64], xi: f64) -> Option<f64> {
+    let n = x.len();
+    if n < 2 || y.len() != n {
+        return None;
+    }
+
+    for i in 0..n - 1 {
         if x[i + 1] <= x[i] {
             return None;
         }
     }
 
-    // Find interval containing xi
-    let mut k = 0;
-    for i in 0..3 {
-        if xi >= x[i] && xi <= x[i + 1] {
-            k = i;
-            break;
-        }
+    if xi < x[0] || xi > x[n - 1] {
+        return None;
     }
 
-    // Calculate slopes
-    let s0 = (y[1] - y[0]) / (x[1] - x[0]);
-    let s1 = (y[2] - y[1]) / (x[2] - x[1]);
-    let s2 = (y[3] - y[2]) / (x[3] - x[2]);
+    let k = (0..n - 1).find(|&i| xi >= x[i] && xi <= x[i + 1]).unwrap_or(0);
 
-    // Calculate derivatives using PCHIP method
-    let mut d = [0.0; 4];
+    let s: Vec<f64> = (0..n - 1).map(|i| (y[i + 1] - y[i]) / (x[i + 1] - x[i])).collect();
 
-    // Endpoint derivatives
-    d[0] = s0;
-    d[3] = s2;
+    let mut d = vec![0.0; n];
+    d[0] = s[0];
+    d[n - 1] = s[n - 2];
 
-    // Interior derivatives (weighted harmonic mean)
-    #[expect(clippy::needless_range_loop)]
-    for i in 1..=2 {
-        let (s_prev, s_next, h_prev, h_next) = if i == 1 {
-            (s0, s1, x[1] - x[0], x[2] - x[1])
-        } else {
-            (s1, s2, x[2] - x[1], x[3] - x[2])
-        };
-
+    for i in 1..n - 1 {
+        let s_prev = s[i - 1];
+        let s_next = s[i];
         if s_prev * s_next <= 0.0 {
             d[i] = 0.0;
         } else {
+            let h_prev = x[i] - x[i - 1];
+            let h_next = x[i + 1] - x[i];
             let w1 = 2.0f64.mul_add(h_next, h_prev);
             let w2 = 2.0f64.mul_add(h_prev, h_next);
             d[i] = (w1 + w2) / (w1 / s_prev + w2 / s_next);
         }
     }
 
-    // Monotonicity constraint
-    let slopes = [s0, s1, s2];
-    for i in 0..3 {
-        if slopes[i] == 0.0 {
+    for i in 0..n - 1 {
+        if s[i] == 0.0 {
             d[i] = 0.0;
             d[i + 1] = 0.0;
         } else {
-            let alpha = d[i] / slopes[i];
-            let beta = d[i + 1] / slopes[i];
+            let alpha = d[i] / s[i];
+            let beta = d[i + 1] / s[i];
             let tau = alpha.mul_add(alpha, beta * beta);
 
             if tau > PCHIP_MAX_TAU_SQUARED {
                 let scale = 3.0 / tau.sqrt();
-                d[i] = scale * alpha * slopes[i];
-                d[i + 1] = scale * beta * slopes[i];
+                d[i] = scale * alpha * s[i];
+                d[i + 1] = scale * beta * s[i];
             }
         }
     }
 
-    // Hermite cubic evaluation
     let h = x[k + 1] - x[k];
     let t = (xi - x[k]) / h;
     let t2 = t * t;
     let t3 = t2 * t;
 
-    // (2.0 * t3 - 3.0 * t2 + 1.0) * y[k]
-    // + (t3 - 2.0 * t2 + t) * h * d[k]
-    // + (-2.0 * t3 + 3.0 * t2) * y[k + 1]
-    // + (t3 - t2) * h * d[k + 1],
-    Some(
-        (2.0f64.mul_add(t3, -(3.0 * t2)) + 1.0)
-            .mul_add(y[k], (2.0f64.mul_add(-t2, t3) + t) * h * d[k])
-            + (-2.0f64).mul_add(t3, 3.0 * t2).mul_add(y[k + 1], (t3 - t2) * h * d[k + 1]),
-    )
+    let h00 = 2.0f64.mul_add(t3, -3.0 * t2) + 1.0;
+    let h10 = 2.0f64.mul_add(-t2, t3) + t;
+    let h01 = (-2.0f64).mul_add(t3, 3.0 * t2);
+    let h11 = t3 - t2;
+
+    Some(h00.mul_add(
+        y[k],
+        (h10 * h).mul_add(d[k], (h11 * h).mul_add(d[k + 1], h01 * y[k + 1])),
+    ))
 }
 
 pub fn quadratic_interpolate(x: &[f64; 3], y: &[f64; 3], xi: f64) -> Option<f64> {
@@ -405,6 +439,7 @@ mod tests {
         akima_interpolate as akima_interpolate_impl,
         catmull_rom_interpolate as catmull_rom_interpolate_impl,
         cubic_polynomial_interpolate as cubic_polynomial_interpolate_impl,
+        fritsch_carlson as fritsch_carlson_impl,
         linear_interpolate as linear_interpolate_impl,
         natural_cubic_spline as natural_cubic_spline_impl,
         pchip_interpolate as pchip_interpolate_impl,
@@ -525,6 +560,84 @@ mod tests {
             natural_cubic_spline_impl(&x_mismatch, &y_mismatch, 85.0),
             None
         );
+    }
+
+    #[test]
+    fn fritsch_carlson() {
+        // CRF 10 (84.872162), CRF 20 (78.517479), CRF 30 (72.812233)
+        let x = vec![72.812233, 78.517479, 84.872162]; // scores (ascending order)
+        let y = vec![30.0, 20.0, 10.0]; // CRFs
+
+        // Test exact points
+        assert!(
+            (fritsch_carlson_impl(&x, &y, 72.812233).expect("result should exist") - 30.0).abs()
+                < 1e-10
+        );
+        assert!(
+            (fritsch_carlson_impl(&x, &y, 78.517479).expect("result should exist") - 20.0).abs()
+                < 1e-10
+        );
+        assert!(
+            (fritsch_carlson_impl(&x, &y, 84.872162).expect("result should exist") - 10.0).abs()
+                < 1e-10
+        );
+
+        // Test interpolation for score 81.0
+        let result = fritsch_carlson_impl(&x, &y, 81.0);
+        assert!(result.is_some());
+        assert!(
+            result.expect("result should exist") > 10.0
+                && result.expect("result should exist") < 20.0
+        );
+
+        // CRF 15 (84.864449), CRF 25 (80.161186), CRF 35 (72.134048)
+        let x2 = vec![72.134048, 80.161186, 84.864449]; // scores (ascending order)
+        let y2 = vec![35.0, 25.0, 15.0]; // CRFs
+
+        // Test interpolation for score 82.0
+        let result = fritsch_carlson_impl(&x2, &y2, 82.0);
+        assert!(result.is_some());
+        assert!(
+            result.expect("result should exist") > 15.0
+                && result.expect("result should exist") < 25.0
+        );
+
+        // CRF 20 (83.0155), CRF 30 (77.7812), CRF 40 (67.3447)
+        let x3 = vec![67.3447, 77.7812, 83.0155]; // scores (ascending order)
+        let y3 = vec![40.0, 30.0, 20.0]; // CRFs
+
+        // Test interpolation for score 80.0
+        let result = fritsch_carlson_impl(&x3, &y3, 80.0);
+        assert!(result.is_some());
+        assert!(
+            result.expect("result should exist") > 20.0
+                && result.expect("result should exist") < 30.0
+        );
+
+        // Test with non-increasing x values (should return None)
+        let x_bad = vec![84.872162, 78.517479, 80.0]; // Not properly ordered
+        let y_bad = vec![10.0, 20.0, 25.0];
+        assert_eq!(fritsch_carlson_impl(&x_bad, &y_bad, 79.0), None);
+
+        // Test with duplicate scores (should return None)
+        let x_dup = vec![80.0, 80.0, 80.0];
+        let y_dup = vec![30.0, 20.0, 10.0];
+        assert_eq!(fritsch_carlson_impl(&x_dup, &y_dup, 80.0), None);
+
+        // Test partial duplicate (should return None)
+        let x_dup2 = vec![80.0, 80.0, 87.0];
+        let y_dup2 = vec![30.0, 20.0, 10.0];
+        assert_eq!(fritsch_carlson_impl(&x_dup2, &y_dup2, 80.0), None);
+
+        // Test with too few points (should return None)
+        let x_short = vec![87.0715, 90.0064];
+        let y_short = vec![20.0, 10.0];
+        assert_eq!(fritsch_carlson_impl(&x_short, &y_short, 88.0), None);
+
+        // Test with mismatched lengths (should return None)
+        let x_mismatch = vec![83.8005, 87.0715, 90.0064];
+        let y_mismatch = vec![30.0, 20.0];
+        assert_eq!(fritsch_carlson_impl(&x_mismatch, &y_mismatch, 85.0), None);
     }
 
     #[test]

--- a/av1an-core/src/scenes/tests.rs
+++ b/av1an-core/src/scenes/tests.rs
@@ -254,7 +254,7 @@ fn validate_zones_target_quality() {
         name:  crate::ProbingStatisticName::Mode,
         value: None,
     };
-    let desired_interpolation_method4 = "natural";
+    let desired_interpolation_method4 = "fritschcarlson";
     let desired_interpolation_method5 = "cubic";
 
     let input = format!(

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -21,6 +21,7 @@ use crate::{
         akima_interpolate,
         catmull_rom_interpolate,
         cubic_polynomial_interpolate,
+        fritsch_carlson,
         linear_interpolate,
         natural_cubic_spline,
         pchip_interpolate,
@@ -46,6 +47,7 @@ pub enum InterpolationMethod {
     Linear,
     Quadratic,
     Natural,
+    FritschCarlson,
     Pchip,
     Catmull,
     Akima,
@@ -61,6 +63,7 @@ impl FromStr for InterpolationMethod {
             "linear" => Ok(Self::Linear),
             "quadratic" => Ok(Self::Quadratic),
             "natural" => Ok(Self::Natural),
+            "fritschcarlson" => Ok(Self::FritschCarlson),
             "pchip" => Ok(Self::Pchip),
             "catmull" => Ok(Self::Catmull),
             "akima" => Ok(Self::Akima),
@@ -814,7 +817,8 @@ impl TargetQuality {
         match method4 {
             InterpolationMethod::Linear
             | InterpolationMethod::Quadratic
-            | InterpolationMethod::Natural => {},
+            | InterpolationMethod::Natural
+            | InterpolationMethod::FritschCarlson => {},
             _ => {
                 return Err(anyhow::anyhow!(
                     "Method '{}' not available for 4th round",
@@ -938,7 +942,8 @@ fn predict_quantizer(
                 },
                 3 => {
                     // 4th probe: configurable method
-                    let method = interp_method.map_or(InterpolationMethod::Natural, |(m, _)| m);
+                    let method =
+                        interp_method.map_or(InterpolationMethod::FritschCarlson, |(m, _)| m);
                     match method {
                         InterpolationMethod::Linear => linear_interpolate(
                             &[scores[0], scores[1]],
@@ -952,6 +957,9 @@ fn predict_quantizer(
                         ),
                         InterpolationMethod::Natural => {
                             natural_cubic_spline(&scores, &quantizers, target)
+                        },
+                        InterpolationMethod::FritschCarlson => {
+                            fritsch_carlson(&scores, &quantizers, target)
                         },
                         _ => None,
                     }
@@ -978,9 +986,10 @@ fn predict_quantizer(
                         InterpolationMethod::CubicPolynomial => {
                             cubic_polynomial_interpolate(s, q, target)
                         },
+                        _ => None,
                     }
                 },
-                _ => None,
+                _ => pchip_interpolate(&scores, &quantizers, target),
             };
 
             result.unwrap_or_else(|| {

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -826,6 +826,21 @@ impl TargetQuality {
                 ))
             },
         }
+        match method5 {
+            InterpolationMethod::Linear
+            | InterpolationMethod::Quadratic
+            | InterpolationMethod::Natural
+            | InterpolationMethod::Pchip
+            | InterpolationMethod::Catmull
+            | InterpolationMethod::Akima
+            | InterpolationMethod::CubicPolynomial => {},
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Method '{}' not available for 5th round",
+                    parts[1]
+                ))
+            },
+        }
 
         Ok((method4, method5))
     }

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -708,9 +708,10 @@ pub struct CliOpts {
     /// Format: --interp-method <method4>-<method5>
     ///
     /// 4th round methods (3 known points):
-    ///   linear    - Simple linear interpolation using the 2 closest points. Fast and stable, good for monotonic data.
-    ///   quadratic - Quadratic interpolation using all 3 points. Better curve fitting than linear, moderate accuracy.
-    ///   natural   - Natural cubic spline interpolation. Smooth curves with natural boundary conditions. (default)
+    ///   linear         - Simple linear interpolation using the 2 closest points. Fast and stable, good for monotonic data.
+    ///   quadratic      - Quadratic interpolation using all 3 points. Better curve fitting than linear, moderate accuracy.
+    ///   natural        - Natural cubic spline interpolation. Smooth curves with natural boundary conditions.
+    ///   fritschcarlson - Fritsch-Carlson Monotone Cubic Spline interpolation. Smooth monotone curves. (default)
     ///
     /// 5th round methods (4 known points):
     ///   linear                  - Simple linear interpolation using 2 closest points. Most stable for narrow ranges.
@@ -722,14 +723,14 @@ pub struct CliOpts {
     ///   cubic | cubicpolynomial - Cubic polynomial through all 4 points. High accuracy but can overshoot dramatically.
     ///
     /// Recommendations:
-    ///   - For most content:      natural-pchip      - Good balance of accuracy and stability (tested)
-    ///   - For difficult content: quadratic-natural  - More conservative, less prone to overshooting
-    ///   - For fine-tuning:       linear-linear      - Most predictable behavior, good for testing
+    ///   - For most content:      fritschcarlson-pchip - Good balance of accuracy and stability (tested)
+    ///   - For difficult content: quadratic-pchip      - More conservative, less prone to overshooting
+    ///   - For fine-tuning:       linear-linear        - Most predictable behavior, good for testing
     ///
     /// Examples:
-    ///   --interp-method natural-pchip      # Default: balanced accuracy and stability
-    ///   --interp-method quadratic-akima    # Experimental
-    ///   --interp-method linear-catmull     # Simple start, smooth finish
+    ///   --interp-method fritschcarlson-pchip      # Default: balanced accuracy and stability
+    ///   --interp-method quadratic-akima           # Experimental
+    ///   --interp-method linear-catmull            # Simple start, smooth finish
     #[clap(long, help_heading = "Target Quality", value_parser = TargetQuality::parse_interp_method, verbatim_doc_comment)]
     pub interp_method: Option<(InterpolationMethod, InterpolationMethod)>,
     /// The metric used for Target Quality mode


### PR DESCRIPTION
and Validate 5th-round interpolation method

Code is taken from xav, and pchip for 6th+ probes is what xav does
Fritsch-Carlson test is the exact same as natural cubic spline
From my testing, with very tight target quality, like 79.999-80.001, probes are greatly reduced